### PR TITLE
Add deterministic startup shuffle and orientation test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ wgpu_glyph = "0.26.0"
 
 [dev-dependencies]
 tempfile = "3.22.0"
+base64 = "0.22.0"

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -23,7 +23,7 @@
 
 - [ ] **GPU viewer shows decoded photo**
   - [ ] Upload `PreparedImageCpu` to a wgpu texture and render a full-screen quad.
-  - [ ] Unit test verifies EXIF orientation is applied during load.
+  - [x] Unit test verifies EXIF orientation is applied during load.
   - [ ] Integration test confirms the viewer emits `Displayed` after drawing.
 - [ ] **macOS demo**
   - [ ] Build & run on macOS, confirming a window renders the first photo.
@@ -46,7 +46,7 @@
 - [ ] **Rust project features**
   - [ ] Circular buffer weighting (half-life replication for new photos).
   - [ ] Graceful removal of deleted photos from list.
-  - [ ] Randomized list at boot with configurable seed.
+  - [x] Randomized list at boot with configurable seed.
   - [ ] Event system:
     - [ ] Short button press → toggle screen.
     - [ ] Long button press → shutdown.

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 #[serde(rename_all = "kebab-case", default)]
 pub struct Configuration {
     /// Root directory to scan recursively for images.
+    #[serde(alias = "photo_library_path")]
     pub photo_library_path: PathBuf,
     /// GPU render oversample factor relative to screen size (1.0 = native).
     pub oversample: f32,
@@ -18,6 +19,8 @@ pub struct Configuration {
     pub viewer_preload_count: usize,
     /// Maximum number of concurrent image decodes in the loader.
     pub loader_max_concurrent_decodes: usize,
+    /// Optional deterministic seed for initial photo shuffle.
+    pub startup_shuffle_seed: Option<u64>,
 }
 
 impl Configuration {
@@ -36,6 +39,7 @@ impl Default for Configuration {
             dwell_ms: 2000,
             viewer_preload_count: 3,
             loader_max_concurrent_decodes: 4,
+            startup_shuffle_seed: None,
         }
     }
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -31,3 +31,13 @@ oversample: 1.5
     assert_eq!(cfg.photo_library_path, PathBuf::from("/photos"));
     assert!((cfg.oversample - 1.5).abs() < f32::EPSILON);
 }
+
+#[test]
+fn parse_with_startup_shuffle_seed() {
+    let yaml = r#"
+photo-library-path: "/p"
+startup-shuffle-seed: 7
+"#;
+    let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
+    assert_eq!(cfg.startup_shuffle_seed, Some(7));
+}


### PR DESCRIPTION
## Summary
- allow optionally seeding the initial photo shuffle via new `startup_shuffle_seed` config
- refactor viewer loading texture setup and add EXIF orientation loader test
- cover config and file watcher flows with new deterministic shuffle integration tests

## Testing
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c788a2fb5c8323ba45a139b8024dd8