### PR TITLE
Add matting configuration and threaded background compositing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ pollster = "0.4.0"
 rand = "0.8.5"
 serde = { version = "1.0.221", features = ["derive"] }
 serde_yaml = "0.9.34"
+crossbeam-channel = "0.5.13"
 tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 tokio-util = "0.7.16"
 tracing = "0.1.41"

--- a/README.md
+++ b/README.md
@@ -43,16 +43,49 @@ dwell-ms: 2000 # Time an image remains fully visible (ms)
 viewer-preload-count: 3 # Images the viewer preloads; also sets viewer channel capacity
 loader-max-concurrent-decodes: 4 # Concurrent decodes in the loader
 oversample: 1.0 # GPU render oversample vs. screen size
+startup-shuffle-seed: null # Optional deterministic seed for initial shuffle
+
+matting:
+  minimum-mat-percentage: 0.0 # % of each screen edge reserved for mat border
+  max-upscale-factor: 1.0 # Limit for enlarging images when applying mats
+  type: fixed-color
+  color: [0, 0, 0]
 ```
 
-Keys
+### Top-level keys
 
-- photo-library-path: Root directory for images to display.
-- fade-ms: Cross-fade transition duration in milliseconds.
-- dwell-ms: Dwell time before starting a transition, in milliseconds.
-- viewer-preload-count: Number of images the viewer holds ready; determines backpressure depth to the loader.
-- loader-max-concurrent-decodes: Max concurrent CPU decodes; tune for CPU/GPU balance.
-- oversample: Scales render target up to reduce aliasing; 1.0 is native.
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `photo-library-path` | string | `""` | Root directory that will be scanned recursively for photos. |
+| `fade-ms` | integer | `400` | Cross-fade transition duration in milliseconds. |
+| `dwell-ms` | integer | `2000` | Time an image remains fully visible before the next fade begins. |
+| `viewer-preload-count` | integer | `3` | Number of prepared images the viewer keeps queued; controls GPU upload backlog. |
+| `loader-max-concurrent-decodes` | integer | `4` | Maximum number of CPU decodes that can run in parallel. |
+| `oversample` | float | `1.0` | Render target scale relative to the screen; values >1.0 reduce aliasing but cost GPU time. |
+| `startup-shuffle-seed` | integer or `null` | `null` | Optional deterministic seed used for the initial photo shuffle. |
+| `matting` | mapping | see below | Controls how mats are generated around each photo. |
+
+### Matting configuration
+
+The `matting` table chooses how the background behind each photo is prepared.
+
+| Key | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `minimum-mat-percentage` | float | `0.0` | Fraction (0–45%) of each screen edge reserved for the mat border. |
+| `max-upscale-factor` | float | `1.0` | Maximum enlargement factor when fitting inside the mat; `1.0` disables upscaling. |
+| `type` | string | `fixed-color` | Mat style to render. The value selects one of the variants below. |
+
+#### `type: fixed-color`
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `color` | `[r, g, b]` array | `[0, 0, 0]` | The RGB values (0–255) used to fill the mat background. |
+
+#### `type: blur`
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `sigma` | float | `20.0` | Gaussian blur radius applied to a scaled copy of the photo that covers the screen. |
 
 ## License
 

--- a/config.yaml
+++ b/config.yaml
@@ -17,3 +17,4 @@ matting:
   type: fixed-color
   color: [0, 0, 0]
   minimum-mat-percentage: 0.0
+  max-upscale-factor: 1.0

--- a/config.yaml
+++ b/config.yaml
@@ -11,3 +11,9 @@ viewer-preload-count: 3
 oversample: 1.0
 # Concurrent image decodes in loader
 loader-max-concurrent-decodes: 4
+
+# Matting settings
+matting:
+  type: fixed-color
+  color: [0, 0, 0]
+  minimum-mat-percentage: 0.0

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,11 @@ use serde::Deserialize;
 pub struct MattingOptions {
     #[serde(default = "MattingOptions::default_minimum_percentage")]
     pub minimum_mat_percentage: f32,
+    #[serde(
+        default = "MattingOptions::default_max_upscale_factor",
+        deserialize_with = "MattingOptions::deserialize_max_upscale"
+    )]
+    pub max_upscale_factor: f32,
     #[serde(flatten, default)]
     pub style: MattingMode,
 }
@@ -29,6 +34,7 @@ impl Default for MattingOptions {
     fn default() -> Self {
         Self {
             minimum_mat_percentage: Self::default_minimum_percentage(),
+            max_upscale_factor: Self::default_max_upscale_factor(),
             style: MattingMode::default(),
         }
     }
@@ -37,6 +43,18 @@ impl Default for MattingOptions {
 impl MattingOptions {
     const fn default_minimum_percentage() -> f32 {
         0.0
+    }
+
+    const fn default_max_upscale_factor() -> f32 {
+        1.0
+    }
+
+    fn deserialize_max_upscale<'de, D>(deserializer: D) -> Result<f32, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let factor = f32::deserialize(deserializer)?;
+        Ok(factor.max(1.0))
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,61 @@ use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "kebab-case", default)]
+pub struct MattingOptions {
+    #[serde(default = "MattingOptions::default_minimum_percentage")]
+    pub minimum_mat_percentage: f32,
+    #[serde(flatten, default)]
+    pub style: MattingMode,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum MattingMode {
+    FixedColor {
+        #[serde(default = "MattingMode::default_color")]
+        color: [u8; 3],
+    },
+    Blur {
+        #[serde(default = "MattingMode::default_blur_sigma")]
+        sigma: f32,
+    },
+}
+
+impl Default for MattingOptions {
+    fn default() -> Self {
+        Self {
+            minimum_mat_percentage: Self::default_minimum_percentage(),
+            style: MattingMode::default(),
+        }
+    }
+}
+
+impl MattingOptions {
+    const fn default_minimum_percentage() -> f32 {
+        0.0
+    }
+}
+
+impl Default for MattingMode {
+    fn default() -> Self {
+        Self::FixedColor {
+            color: Self::default_color(),
+        }
+    }
+}
+
+impl MattingMode {
+    const fn default_color() -> [u8; 3] {
+        [0, 0, 0]
+    }
+
+    const fn default_blur_sigma() -> f32 {
+        20.0
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case", default)]
 pub struct Configuration {
     /// Root directory to scan recursively for images.
     #[serde(alias = "photo_library_path")]
@@ -21,6 +76,8 @@ pub struct Configuration {
     pub loader_max_concurrent_decodes: usize,
     /// Optional deterministic seed for initial photo shuffle.
     pub startup_shuffle_seed: Option<u64>,
+    /// Matting configuration for displayed photos.
+    pub matting: MattingOptions,
 }
 
 impl Configuration {
@@ -40,6 +97,7 @@ impl Default for Configuration {
             viewer_preload_count: 3,
             loader_max_concurrent_decodes: 4,
             startup_shuffle_seed: None,
+            matting: MattingOptions::default(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,9 @@ async fn main() -> Result<()> {
 
     // Run the windowed viewer on the main thread (blocking) after spawning other tasks
     // This call returns when the window closes or cancellation occurs
-    if let Err(e) = tasks::viewer::run_windowed(loaded_rx, displayed_tx.clone(), cancel.clone(), cfg.clone()) {
+    if let Err(e) =
+        tasks::viewer::run_windowed(loaded_rx, displayed_tx.clone(), cancel.clone(), cfg.clone())
+    {
         tracing::error!("viewer error: {e:?}");
     }
     // Ensure other tasks are asked to stop

--- a/src/tasks/viewer.rs
+++ b/src/tasks/viewer.rs
@@ -315,17 +315,19 @@ pub fn run_windowed(
             self.fade_start = None;
             self.displayed_at = None;
             self.mat_inflight = 0;
+            use winit::window::Fullscreen;
             let window = Arc::new(
                 event_loop
-                    .create_window(Window::default_attributes().with_title("Photo Frame"))
+                    .create_window(
+                        Window::default_attributes()
+                            .with_title("Photo Frame")
+                            .with_fullscreen(Some(Fullscreen::Borderless(None)))
+                            .with_decorations(false),
+                    )
                     .unwrap(),
             );
-            // Enter borderless fullscreen and hide cursor for a clean demo
-            use winit::window::Fullscreen;
             if let Some(m) = window.current_monitor() {
                 window.set_fullscreen(Some(Fullscreen::Borderless(Some(m))));
-            } else {
-                window.set_fullscreen(Some(Fullscreen::Borderless(None)));
             }
             window.set_cursor_visible(false);
 
@@ -616,7 +618,12 @@ pub fn run_windowed(
                     gpu.config.height = new_size.height.max(1);
                     gpu.surface.configure(&gpu.device, &gpu.config);
                 }
-                WindowEvent::ScaleFactorChanged { .. } => {}
+                WindowEvent::ScaleFactorChanged { .. } => {
+                    let size = window.inner_size();
+                    gpu.config.width = size.width.max(1);
+                    gpu.config.height = size.height.max(1);
+                    gpu.surface.configure(&gpu.device, &gpu.config);
+                }
                 WindowEvent::RedrawRequested => {
                     let frame = match gpu.surface.get_current_texture() {
                         Ok(frame) => frame,

--- a/src/tasks/viewer.rs
+++ b/src/tasks/viewer.rs
@@ -177,8 +177,9 @@ pub fn run_windowed(
             }
         };
 
+        let max_upscale = matting.max_upscale_factor.max(1.0);
         let (final_w, final_h) =
-            resize_to_fit_with_margin(canvas_w, canvas_h, width, height, margin);
+            resize_to_fit_with_margin(canvas_w, canvas_h, width, height, margin, max_upscale);
         let main_img = if final_w == width && final_h == height {
             src
         } else {
@@ -934,6 +935,7 @@ fn resize_to_fit_with_margin(
     src_w: u32,
     src_h: u32,
     margin_frac: f32,
+    max_upscale: f32,
 ) -> (u32, u32) {
     let iw = src_w.max(1) as f32;
     let ih = src_h.max(1) as f32;
@@ -942,7 +944,8 @@ fn resize_to_fit_with_margin(
     let margin_frac = margin_frac.clamp(0.0, 0.45);
     let avail_w = (cw * (1.0 - 2.0 * margin_frac)).max(1.0);
     let avail_h = (ch * (1.0 - 2.0 * margin_frac)).max(1.0);
-    let scale = (avail_w / iw).min(avail_h / ih).min(1.0);
+    let max_upscale = max_upscale.max(1.0);
+    let scale = (avail_w / iw).min(avail_h / ih).min(max_upscale);
     let w = (iw * scale).round().clamp(1.0, cw);
     let h = (ih * scale).round().clamp(1.0, ch);
     (w as u32, h as u32)


### PR DESCRIPTION
## Summary
- add matting configuration options to support fixed-color and blur mats with a configurable minimum border
- introduce a threaded CPU matting pipeline and update the viewer to composite prepared backgrounds with margin-aware rendering
- document the new matting keys in the sample configuration and pull in the channel dependency required for the pipeline

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ca24d36b0483239588090b753e9401