### PR TITLE
Add configurable blur backends with GPU and NEON pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ The `matting` table chooses how the background behind each photo is prepared.
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | `sigma` | float | `20.0` | Gaussian blur radius applied to a scaled copy of the photo that covers the screen. |
+| `max-sample-dim` | integer or `null` | `null` (defaults to `2048` on 64-bit ARM builds, otherwise unlimited) | Optional cap on the background texture size used for the blur. When set, the background is downscaled to this maximum dimension before blurring and then upscaled back to the screen size, preserving the soft-focus look while reducing CPU cost on small GPUs. |
+| `backend` | string | `auto` | Blur implementation to use. `auto` prefers the NEON vector path on 64-bit ARM, then a WGPU compute shader, and finally the CPU-only renderer. You can force a specific branch by setting `cpu`, `neon`, or `wgpu-compute`. |
 
 ## License
 

--- a/config.yaml
+++ b/config.yaml
@@ -18,3 +18,9 @@ matting:
   color: [0, 0, 0]
   minimum-mat-percentage: 0.0
   max-upscale-factor: 1.0
+# To enable the blur mat optimized for Raspberry Pi, switch to:
+# matting:
+#   type: blur
+#   sigma: 20.0
+#   max-sample-dim: 1536
+#   backend: auto        # options: auto, cpu, neon, wgpu-compute

--- a/docs/rpi-performance.md
+++ b/docs/rpi-performance.md
@@ -1,0 +1,38 @@
+# Raspberry Pi Blur Mat Performance Notes
+
+## Platform capabilities
+
+- The viewer spawns one CPU matting worker per logical core using `std::thread::available_parallelism()`, so a quad-core Pi 4 runs four concurrent matting jobs.
+- Gaussian blur for the matting background now supports three execution paths:
+  - A portable CPU renderer (the previous default).
+  - A NEON-accelerated branch that uses SIMD intrinsics when running on 64-bit ARM cores.
+  - A WGPU compute shader that runs the blur on the GPU when a compatible adapter is available.
+- The viewer still composites the final frame with WGPU; the new compute shader path keeps the background blur on the GPU.
+
+## Proposed optimization for Pi + 4K displays
+
+- Large 4K canvases require ~8.3M pixels per blur, which is slow on Cortex-A72 cores.
+- Because the background is heavily blurred, we can downsample before blurring without reducing visual quality.
+- A new `max-sample-dim` option on the `blur` matting mode downsamples to the specified maximum dimension, scales the blur radius to compensate, and re-upscales to the canvas size.
+- The `backend` selector lets you choose between the CPU, NEON, or WGPU compute branches so you can measure each one independently.
+- Builds targeting 64-bit ARM (such as Raspberry Pi OS 64-bit) default this limit to 2048px to reduce CPU cost automatically. Other platforms remain unlimited unless configured.
+
+## Recommended configuration
+
+```yaml
+matting:
+  type: blur
+  sigma: 20.0
+  max-sample-dim: 1536
+  backend: auto
+```
+
+- `max-sample-dim: 1536` keeps the blur staging surface near 1080p, roughly quartering the pixel count compared to 4K.
+- Adjust upward if artifacts become noticeable on very large TVs; the default 2048 is a good balance for Pi 5.
+- Leave `backend` at `auto` to let the viewer pick NEON on Pi 4/5 hardware. Switch to `wgpu-compute` to benchmark the GPU path or `cpu` to compare against the original implementation.
+
+## Next steps
+
+1. Deploy builds with the new defaults to Raspberry Pi hardware and measure blur preparation times for each backend (`auto`, `wgpu-compute`, and `cpu`).
+2. Experiment with lower `sigma` values (e.g., 16) if further savings are needed.
+3. Validate WGPU compute performance on Pi 5/400 systems with active cooling to ensure thermal headroom remains acceptable.

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,26 @@ pub enum MattingMode {
     Blur {
         #[serde(default = "MattingMode::default_blur_sigma")]
         sigma: f32,
+        #[serde(default)]
+        max_sample_dim: Option<u32>,
+        #[serde(default)]
+        backend: BlurBackend,
     },
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BlurBackend {
+    Auto,
+    Cpu,
+    Neon,
+    WgpuCompute,
+}
+
+impl Default for BlurBackend {
+    fn default() -> Self {
+        Self::Auto
+    }
 }
 
 impl Default for MattingOptions {
@@ -73,6 +92,11 @@ impl MattingMode {
 
     const fn default_blur_sigma() -> f32 {
         20.0
+    }
+
+    #[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
+    pub const fn default_blur_max_sample_dim() -> u32 {
+        2048
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod events;
+pub mod processing;
 pub mod tasks {
     pub mod files;
     pub mod loader;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod events;
+mod processing;
 mod tasks {
     pub mod files;
     pub mod loader;

--- a/src/processing/blur.rs
+++ b/src/processing/blur.rs
@@ -1,0 +1,443 @@
+use bytemuck::{Pod, Zeroable};
+use image::{imageops, RgbaImage};
+use tracing::warn;
+
+use crate::config::BlurBackend;
+
+pub fn apply_blur(image: &RgbaImage, sigma: f32, backend: BlurBackend) -> RgbaImage {
+    if sigma <= 0.0 {
+        return image.clone();
+    }
+    match backend {
+        BlurBackend::Cpu => blur_cpu(image, sigma),
+        BlurBackend::Neon => neon_blur(image, sigma).unwrap_or_else(|| blur_cpu(image, sigma)),
+        BlurBackend::WgpuCompute => {
+            gpu_blur(image, sigma).unwrap_or_else(|| blur_cpu(image, sigma))
+        }
+        BlurBackend::Auto => {
+            #[cfg(target_arch = "aarch64")]
+            {
+                if let Some(img) = neon_blur(image, sigma) {
+                    return img;
+                }
+            }
+            if let Some(img) = gpu_blur(image, sigma) {
+                return img;
+            }
+            blur_cpu(image, sigma)
+        }
+    }
+}
+
+fn blur_cpu(image: &RgbaImage, sigma: f32) -> RgbaImage {
+    imageops::blur(image, sigma)
+}
+
+fn gaussian_kernel(sigma: f32) -> (Vec<f32>, u32) {
+    let sigma = sigma.max(0.01);
+    let radius = (sigma * 3.0).ceil() as i32;
+    if radius <= 0 {
+        return (vec![1.0], 0);
+    }
+    let mut weights = Vec::with_capacity((radius * 2 + 1) as usize);
+    let denom = 2.0 * sigma * sigma;
+    let mut sum = 0.0;
+    for i in -radius..=radius {
+        let x = i as f32;
+        let w = (-x * x / denom).exp();
+        weights.push(w);
+        sum += w;
+    }
+    if sum > 0.0 {
+        for w in &mut weights {
+            *w /= sum;
+        }
+    }
+    (weights, radius as u32)
+}
+
+fn rgba_to_f32(image: &RgbaImage) -> Vec<f32> {
+    image
+        .pixels()
+        .flat_map(|p| p.0.iter().map(|&c| (c as f32) / 255.0))
+        .collect()
+}
+
+fn f32_to_rgba(width: u32, height: u32, data: &[f32]) -> RgbaImage {
+    let mut out = RgbaImage::new(width, height);
+    for (i, pixel) in out.pixels_mut().enumerate() {
+        let base = i * 4;
+        let rgba = [
+            (data.get(base).copied().unwrap_or(0.0) * 255.0).clamp(0.0, 255.0) as u8,
+            (data.get(base + 1).copied().unwrap_or(0.0) * 255.0).clamp(0.0, 255.0) as u8,
+            (data.get(base + 2).copied().unwrap_or(0.0) * 255.0).clamp(0.0, 255.0) as u8,
+            (data.get(base + 3).copied().unwrap_or(1.0) * 255.0).clamp(0.0, 255.0) as u8,
+        ];
+        pixel.0 = rgba;
+    }
+    out
+}
+
+#[cfg(target_arch = "aarch64")]
+fn neon_blur(image: &RgbaImage, sigma: f32) -> Option<RgbaImage> {
+    if !std::arch::is_aarch64_feature_detected!("neon") {
+        return None;
+    }
+    let (weights, radius) = gaussian_kernel(sigma);
+    if radius == 0 {
+        return Some(image.clone());
+    }
+    let width = image.width() as usize;
+    let height = image.height() as usize;
+    let mut src = rgba_to_f32(image);
+    let mut tmp = vec![0.0f32; src.len()];
+    unsafe {
+        neon::blur_pass(
+            &src,
+            &mut tmp,
+            width,
+            height,
+            radius as usize,
+            &weights,
+            true,
+        );
+        neon::blur_pass(
+            &tmp,
+            &mut src,
+            width,
+            height,
+            radius as usize,
+            &weights,
+            false,
+        );
+    }
+    Some(f32_to_rgba(image.width(), image.height(), &src))
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn neon_blur(_image: &RgbaImage, _sigma: f32) -> Option<RgbaImage> {
+    None
+}
+
+fn gpu_blur(image: &RgbaImage, sigma: f32) -> Option<RgbaImage> {
+    let (weights, radius) = gaussian_kernel(sigma);
+    if radius == 0 {
+        return Some(image.clone());
+    }
+    let width = image.width();
+    let height = image.height();
+    let data = rgba_to_f32(image);
+    let ctx = match gpu::instance() {
+        Some(ctx) => ctx,
+        None => return None,
+    };
+    let mut guard = ctx.lock().expect("gpu blur mutex poisoned");
+    let result = guard.run(width, height, radius, &weights, &data);
+    drop(guard);
+    match result {
+        Ok(result) => Some(f32_to_rgba(width, height, &result)),
+        Err(err) => {
+            warn!("wgpu compute blur fallback: {err:?}");
+            None
+        }
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+mod neon {
+    use std::arch::aarch64::*;
+
+    #[target_feature(enable = "neon")]
+    pub unsafe fn blur_pass(
+        src: &[f32],
+        dst: &mut [f32],
+        width: usize,
+        height: usize,
+        radius: usize,
+        weights: &[f32],
+        horizontal: bool,
+    ) {
+        let src_ptr = src.as_ptr();
+        let dst_ptr = dst.as_mut_ptr();
+        let kernel = &weights[..(2 * radius + 1)];
+        for y in 0..height {
+            for x in 0..width {
+                let mut acc = vdupq_n_f32(0.0);
+                for (idx, &weight) in kernel.iter().enumerate() {
+                    let offset = idx as isize - radius as isize;
+                    let sample_index = if horizontal {
+                        let sx = clamp_i((x as isize) + offset, width as isize);
+                        ((y * width) + sx) * 4
+                    } else {
+                        let sy = clamp_i((y as isize) + offset, height as isize);
+                        ((sy * width) + x) * 4
+                    } as isize;
+                    let pix = vld1q_f32(src_ptr.offset(sample_index));
+                    let weight_vec = vdupq_n_f32(weight);
+                    acc = vmlaq_f32(acc, pix, weight_vec);
+                }
+                let out_index = ((y * width + x) * 4) as isize;
+                vst1q_f32(dst_ptr.offset(out_index), acc);
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn clamp_i(value: isize, max: isize) -> usize {
+        value.clamp(0, max.saturating_sub(1)) as usize
+    }
+}
+
+mod gpu {
+    use super::BlurUniform;
+    use anyhow::{anyhow, Context, Result};
+    use bytemuck::cast_slice;
+    use std::sync::{mpsc, Arc, Mutex, OnceLock};
+
+    use wgpu::util::DeviceExt;
+
+    static CONTEXT: OnceLock<Result<Arc<Mutex<GpuBlurContext>>>> = OnceLock::new();
+
+    pub fn instance() -> Option<Arc<Mutex<GpuBlurContext>>> {
+        match CONTEXT.get_or_init(|| GpuBlurContext::new().map(Mutex::new).map(Arc::new)) {
+            Ok(ctx) => Some(Arc::clone(ctx)),
+            Err(err) => {
+                tracing::warn!("failed to init gpu blur context: {err:?}");
+                None
+            }
+        }
+    }
+
+    pub struct GpuBlurContext {
+        device: wgpu::Device,
+        queue: wgpu::Queue,
+        pipeline: wgpu::ComputePipeline,
+        layout: wgpu::BindGroupLayout,
+    }
+
+    impl GpuBlurContext {
+        fn new() -> Result<Self> {
+            let instance = wgpu::Instance::default();
+            let adapter =
+                pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::HighPerformance,
+                    compatible_surface: None,
+                    force_fallback_adapter: false,
+                }))
+                .context("request wgpu adapter")?;
+            let limits = adapter.limits();
+            let (device, queue) =
+                pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+                    label: Some("blur-compute-device"),
+                    required_features: wgpu::Features::empty(),
+                    required_limits: limits,
+                    memory_hints: wgpu::MemoryHints::default(),
+                    trace: wgpu::Trace::default(),
+                }))
+                .context("request wgpu device")?;
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("gaussian-blur-compute"),
+                source: wgpu::ShaderSource::Wgsl(
+                    include_str!("../tasks/shaders/gaussian_blur.comp.wgsl").into(),
+                ),
+            });
+            let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("gaussian-blur-layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Storage { read_only: true },
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Storage { read_only: false },
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 3,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Storage { read_only: true },
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                ],
+            });
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("gaussian-blur-pipeline-layout"),
+                bind_group_layouts: &[&layout],
+                push_constant_ranges: &[],
+            });
+            let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some("gaussian-blur-pipeline"),
+                layout: Some(&pipeline_layout),
+                module: &shader,
+                entry_point: Some("main"),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+                cache: None,
+            });
+            Ok(Self {
+                device,
+                queue,
+                pipeline,
+                layout,
+            })
+        }
+
+        pub fn run(
+            &mut self,
+            width: u32,
+            height: u32,
+            radius: u32,
+            weights: &[f32],
+            input: &[f32],
+        ) -> Result<Vec<f32>> {
+            let pixel_count = (width as usize) * (height as usize);
+            if input.len() != pixel_count * 4 {
+                return Err(anyhow!("unexpected input length"));
+            }
+            let buffer_size = (input.len() * std::mem::size_of::<f32>()) as u64;
+            let src = self
+                .device
+                .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("blur-src"),
+                    contents: cast_slice(input),
+                    usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+                });
+            let tmp = self.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("blur-tmp"),
+                size: buffer_size as u64,
+                usage: wgpu::BufferUsages::STORAGE
+                    | wgpu::BufferUsages::COPY_SRC
+                    | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+            let dst = self.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("blur-dst"),
+                size: buffer_size as u64,
+                usage: wgpu::BufferUsages::STORAGE
+                    | wgpu::BufferUsages::COPY_SRC
+                    | wgpu::BufferUsages::COPY_DST
+                    | wgpu::BufferUsages::MAP_READ,
+                mapped_at_creation: false,
+            });
+            let weights_buf = self
+                .device
+                .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("blur-weights"),
+                    contents: cast_slice(weights),
+                    usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+                });
+            let stages = [(0u32, &src, &tmp), (1u32, &tmp, &dst)];
+            for (direction, src_buf, dst_buf) in stages.iter() {
+                let uniforms = BlurUniform {
+                    width,
+                    height,
+                    radius,
+                    direction: *direction,
+                };
+                let uniform_buf =
+                    self.device
+                        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                            label: Some("blur-uniform"),
+                            contents: cast_slice(&[uniforms]),
+                            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_SRC,
+                        });
+                let bind = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some("blur-bind"),
+                    layout: &self.layout,
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: wgpu::BindingResource::Buffer(
+                                uniform_buf.as_entire_buffer_binding(),
+                            ),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: wgpu::BindingResource::Buffer(
+                                src_buf.as_entire_buffer_binding(),
+                            ),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 2,
+                            resource: wgpu::BindingResource::Buffer(
+                                dst_buf.as_entire_buffer_binding(),
+                            ),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 3,
+                            resource: wgpu::BindingResource::Buffer(
+                                weights_buf.as_entire_buffer_binding(),
+                            ),
+                        },
+                    ],
+                });
+                let mut encoder =
+                    self.device
+                        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                            label: Some("blur-command"),
+                        });
+                {
+                    let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                        label: Some("blur-pass"),
+                        timestamp_writes: None,
+                    });
+                    pass.set_pipeline(&self.pipeline);
+                    pass.set_bind_group(0, &bind, &[]);
+                    let groups_x = (width + 15) / 16;
+                    let groups_y = (height + 15) / 16;
+                    pass.dispatch_workgroups(groups_x, groups_y, 1);
+                }
+                self.queue.submit(Some(encoder.finish()));
+            }
+            let buffer_slice = dst.slice(..);
+            let (sender, receiver) = mpsc::channel();
+            buffer_slice.map_async(wgpu::MapMode::Read, move |res| {
+                let _ = sender.send(res);
+            });
+            let _ = self.device.poll(wgpu::PollType::Wait);
+            receiver
+                .recv()
+                .context("receive map result")?
+                .context("map buffer for read")?;
+            let data = buffer_slice.get_mapped_range();
+            let out = bytemuck::cast_slice(&data).to_vec();
+            drop(data);
+            dst.unmap();
+            Ok(out)
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct BlurUniform {
+    width: u32,
+    height: u32,
+    radius: u32,
+    direction: u32,
+}

--- a/src/processing/mod.rs
+++ b/src/processing/mod.rs
@@ -1,0 +1,1 @@
+pub mod blur;

--- a/src/tasks/shaders/gaussian_blur.comp.wgsl
+++ b/src/tasks/shaders/gaussian_blur.comp.wgsl
@@ -1,0 +1,53 @@
+struct Params {
+    width: u32,
+    height: u32,
+    radius: u32,
+    direction: u32,
+};
+
+struct PixelBuffer {
+    pixels: array<vec4<f32>>,
+};
+
+struct Weights {
+    values: array<f32>,
+};
+
+@group(0) @binding(0)
+var<uniform> U: Params;
+
+@group(0) @binding(1)
+var<storage, read> Src: PixelBuffer;
+
+@group(0) @binding(2)
+var<storage, read_write> Dst: PixelBuffer;
+
+@group(0) @binding(3)
+var<storage, read> W: Weights;
+
+@compute @workgroup_size(16, 16, 1)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    if (id.x >= U.width || id.y >= U.height) {
+        return;
+    }
+
+    let idx = id.y * U.width + id.x;
+    let kernel_width = U.radius * 2u + 1u;
+    var acc: vec4<f32> = vec4<f32>(0.0);
+
+    for (var i: u32 = 0u; i < kernel_width; i = i + 1u) {
+        let offset = i32(i) - i32(U.radius);
+        var sample_x = i32(id.x);
+        var sample_y = i32(id.y);
+        if (U.direction == 0u) {
+            sample_x = clamp(i32(id.x) + offset, 0, i32(U.width) - 1);
+        } else {
+            sample_y = clamp(i32(id.y) + offset, 0, i32(U.height) - 1);
+        }
+        let sample_idx = u32(sample_y) * U.width + u32(sample_x);
+        let weight = W.values[i];
+        acc = acc + Src.pixels[sample_idx] * weight;
+    }
+
+    Dst.pixels[idx] = acc;
+}

--- a/src/tasks/viewer.rs
+++ b/src/tasks/viewer.rs
@@ -1,7 +1,8 @@
 use crate::config::{MattingMode, MattingOptions};
 use crate::events::{Displayed, PhotoLoaded, PreparedImageCpu};
+use crate::processing::blur::apply_blur;
 use crossbeam_channel::{bounded, Receiver as CbReceiver, Sender as CbSender, TrySendError};
-use image::{imageops, DynamicImage, Rgba, RgbaImage};
+use image::{imageops, Rgba, RgbaImage};
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -154,7 +155,11 @@ pub fn run_windowed(
                 let px = Rgba([color[0], color[1], color[2], 255]);
                 RgbaImage::from_pixel(canvas_w, canvas_h, px)
             }
-            MattingMode::Blur { sigma } => {
+            MattingMode::Blur {
+                sigma,
+                max_sample_dim,
+                backend,
+            } => {
                 let (bg_w, bg_h) = resize_to_cover(canvas_w, canvas_h, width, height, max_dim);
                 let mut bg = imageops::resize(&src, bg_w, bg_h, imageops::FilterType::Triangle);
                 if bg_w > canvas_w || bg_h > canvas_h {
@@ -169,8 +174,49 @@ pub fn run_windowed(
                     bg = canvas;
                 }
                 if sigma > 0.0 {
-                    let dynamic = DynamicImage::ImageRgba8(bg);
-                    imageops::blur(&dynamic, sigma)
+                    let limit = max_sample_dim
+                        .filter(|v| *v > 0)
+                        .unwrap_or_else(|| {
+                            #[cfg(target_arch = "aarch64")]
+                            {
+                                MattingMode::default_blur_max_sample_dim()
+                            }
+                            #[cfg(not(target_arch = "aarch64"))]
+                            {
+                                max_dim
+                            }
+                        })
+                        .min(max_dim)
+                        .max(1);
+
+                    let mut sample = bg;
+                    let mut sigma_px = sigma;
+                    let canvas_max = canvas_w.max(canvas_h).max(1);
+                    if canvas_max > limit {
+                        let scale = (limit as f32) / (canvas_max as f32);
+                        let sample_w =
+                            ((canvas_w as f32) * scale).round().clamp(1.0, limit as f32) as u32;
+                        let sample_h =
+                            ((canvas_h as f32) * scale).round().clamp(1.0, limit as f32) as u32;
+                        sample = imageops::resize(
+                            &sample,
+                            sample_w,
+                            sample_h,
+                            imageops::FilterType::Triangle,
+                        );
+                        sigma_px *= scale.max(0.01);
+                    }
+
+                    let mut blurred: RgbaImage = apply_blur(&sample, sigma_px, backend);
+                    if blurred.width() != canvas_w || blurred.height() != canvas_h {
+                        blurred = imageops::resize(
+                            &blurred,
+                            canvas_w,
+                            canvas_h,
+                            imageops::FilterType::CatmullRom,
+                        );
+                    }
+                    blurred
                 } else {
                     bg
                 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -1,4 +1,4 @@
-use rust_photo_frame::config::Configuration;
+use rust_photo_frame::config::{BlurBackend, Configuration, MattingMode};
 use std::path::PathBuf;
 
 #[test]
@@ -40,4 +40,21 @@ startup-shuffle-seed: 7
 "#;
     let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
     assert_eq!(cfg.startup_shuffle_seed, Some(7));
+}
+
+#[test]
+fn parse_blur_backend() {
+    let yaml = r#"
+photo-library-path: "/p"
+matting:
+  type: blur
+  backend: wgpu-compute
+"#;
+    let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
+    match cfg.matting.style {
+        MattingMode::Blur { backend, .. } => {
+            assert!(matches!(backend, BlurBackend::WgpuCompute));
+        }
+        _ => panic!("expected blur matting"),
+    }
 }


### PR DESCRIPTION
## Summary
- add a `backend` selector to blur mat configuration so Raspberry Pi builds can opt into CPU, NEON, or WGPU compute paths
- implement NEON-accelerated and WGPU compute blur pipelines plus supporting shader and dispatcher infrastructure
- update documentation, sample config, and tests to cover the new blur backends and usage guidance

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cccc43b1f08323ad1e15c3df96d975