### PR TITLE
Add CPU and NEON blur backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ The `matting` table chooses how the background behind each photo is prepared.
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | `sigma` | float | `20.0` | Gaussian blur radius applied to a scaled copy of the photo that covers the screen. |
+| `max-sample-dim` | integer or `null` | `null` (defaults to `2048` on 64-bit ARM builds, otherwise unlimited) | Optional cap on the background texture size used for the blur. When set, the background is downscaled to this maximum dimension before blurring and then upscaled back to the screen size, preserving the soft-focus look while reducing CPU cost on small GPUs. |
+| `backend` | string | `cpu` | Blur implementation to use. Set to `cpu` for the high-quality software renderer (default) or `neon` to request the vector-accelerated path on 64-bit ARM. When `neon` is selected but unsupported at runtime, the code automatically falls back to the CPU backend. |
 
 ## License
 

--- a/config.yaml
+++ b/config.yaml
@@ -18,3 +18,9 @@ matting:
   color: [0, 0, 0]
   minimum-mat-percentage: 0.0
   max-upscale-factor: 1.0
+# To enable the blur mat optimized for Raspberry Pi, switch to:
+# matting:
+#   type: blur
+#   sigma: 20.0
+#   max-sample-dim: 1536
+#   backend: neon        # options: cpu, neon (defaults to cpu)

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,24 @@ pub enum MattingMode {
     Blur {
         #[serde(default = "MattingMode::default_blur_sigma")]
         sigma: f32,
+        #[serde(default)]
+        max_sample_dim: Option<u32>,
+        #[serde(default)]
+        backend: BlurBackend,
     },
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BlurBackend {
+    Cpu,
+    Neon,
+}
+
+impl Default for BlurBackend {
+    fn default() -> Self {
+        Self::Cpu
+    }
 }
 
 impl Default for MattingOptions {
@@ -73,6 +90,11 @@ impl MattingMode {
 
     const fn default_blur_sigma() -> f32 {
         20.0
+    }
+
+    #[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
+    pub const fn default_blur_max_sample_dim() -> u32 {
+        2048
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod events;
+pub mod processing;
 pub mod tasks {
     pub mod files;
     pub mod loader;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod events;
+mod processing;
 mod tasks {
     pub mod files;
     pub mod loader;

--- a/src/processing/blur.rs
+++ b/src/processing/blur.rs
@@ -1,0 +1,159 @@
+use image::{imageops, RgbaImage};
+
+use crate::config::BlurBackend;
+
+pub fn apply_blur(image: &RgbaImage, sigma: f32, backend: BlurBackend) -> RgbaImage {
+    if sigma <= 0.0 {
+        return image.clone();
+    }
+
+    match backend {
+        BlurBackend::Cpu => blur_cpu(image, sigma),
+        BlurBackend::Neon => neon_blur(image, sigma).unwrap_or_else(|| blur_cpu(image, sigma)),
+    }
+}
+
+fn blur_cpu(image: &RgbaImage, sigma: f32) -> RgbaImage {
+    imageops::blur(image, sigma)
+}
+
+#[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
+fn gaussian_kernel(sigma: f32) -> (Vec<f32>, u32) {
+    let sigma = sigma.max(0.01);
+    let radius = (sigma * 3.0).ceil() as i32;
+    if radius <= 0 {
+        return (vec![1.0], 0);
+    }
+
+    let mut weights = Vec::with_capacity((radius * 2 + 1) as usize);
+    let denom = 2.0 * sigma * sigma;
+    let mut sum = 0.0;
+    for i in -radius..=radius {
+        let x = i as f32;
+        let w = (-x * x / denom).exp();
+        weights.push(w);
+        sum += w;
+    }
+
+    if sum > 0.0 {
+        for w in &mut weights {
+            *w /= sum;
+        }
+    }
+
+    (weights, radius as u32)
+}
+
+#[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
+fn rgba_to_f32(image: &RgbaImage) -> Vec<f32> {
+    image
+        .pixels()
+        .flat_map(|p| p.0.iter().map(|&c| (c as f32) / 255.0))
+        .collect()
+}
+
+#[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
+fn f32_to_rgba(width: u32, height: u32, data: &[f32]) -> RgbaImage {
+    let mut out = RgbaImage::new(width, height);
+    for (i, pixel) in out.pixels_mut().enumerate() {
+        let base = i * 4;
+        let rgba = [
+            (data.get(base).copied().unwrap_or(0.0) * 255.0).clamp(0.0, 255.0) as u8,
+            (data.get(base + 1).copied().unwrap_or(0.0) * 255.0).clamp(0.0, 255.0) as u8,
+            (data.get(base + 2).copied().unwrap_or(0.0) * 255.0).clamp(0.0, 255.0) as u8,
+            (data.get(base + 3).copied().unwrap_or(1.0) * 255.0).clamp(0.0, 255.0) as u8,
+        ];
+        pixel.0 = rgba;
+    }
+    out
+}
+
+#[cfg(target_arch = "aarch64")]
+fn neon_blur(image: &RgbaImage, sigma: f32) -> Option<RgbaImage> {
+    if !std::arch::is_aarch64_feature_detected!("neon") {
+        return None;
+    }
+
+    let (weights, radius) = gaussian_kernel(sigma);
+    if radius == 0 {
+        return Some(image.clone());
+    }
+
+    let width = image.width() as usize;
+    let height = image.height() as usize;
+    let mut src = rgba_to_f32(image);
+    let mut tmp = vec![0.0f32; src.len()];
+
+    unsafe {
+        neon::blur_pass(
+            &src,
+            &mut tmp,
+            width,
+            height,
+            radius as usize,
+            &weights,
+            true,
+        );
+        neon::blur_pass(
+            &tmp,
+            &mut src,
+            width,
+            height,
+            radius as usize,
+            &weights,
+            false,
+        );
+    }
+
+    Some(f32_to_rgba(image.width(), image.height(), &src))
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn neon_blur(_image: &RgbaImage, _sigma: f32) -> Option<RgbaImage> {
+    None
+}
+
+#[cfg(target_arch = "aarch64")]
+mod neon {
+    use std::arch::aarch64::*;
+
+    #[target_feature(enable = "neon")]
+    pub unsafe fn blur_pass(
+        src: &[f32],
+        dst: &mut [f32],
+        width: usize,
+        height: usize,
+        radius: usize,
+        weights: &[f32],
+        horizontal: bool,
+    ) {
+        let src_ptr = src.as_ptr();
+        let dst_ptr = dst.as_mut_ptr();
+        let kernel = &weights[..(2 * radius + 1)];
+        for y in 0..height {
+            for x in 0..width {
+                let mut acc = vdupq_n_f32(0.0);
+                for (idx, &weight) in kernel.iter().enumerate() {
+                    let offset = idx as isize - radius as isize;
+                    let sample_index = if horizontal {
+                        let sx = clamp_i((x as isize) + offset, width as isize);
+                        ((y * width) + sx) * 4
+                    } else {
+                        let sy = clamp_i((y as isize) + offset, height as isize);
+                        ((sy * width) + x) * 4
+                    } as isize;
+                    let pix = vld1q_f32(src_ptr.offset(sample_index));
+                    let weight_vec = vdupq_n_f32(weight);
+                    acc = vmlaq_f32(acc, pix, weight_vec);
+                }
+                let out_index = ((y * width + x) * 4) as isize;
+                vst1q_f32(dst_ptr.offset(out_index), acc);
+            }
+        }
+    }
+
+    #[inline(always)]
+    fn clamp_i(value: isize, max: isize) -> usize {
+        value.clamp(0, max.saturating_sub(1)) as usize
+    }
+}

--- a/src/processing/mod.rs
+++ b/src/processing/mod.rs
@@ -1,0 +1,1 @@
+pub mod blur;

--- a/src/tasks/viewer.rs
+++ b/src/tasks/viewer.rs
@@ -1,7 +1,8 @@
 use crate::config::{MattingMode, MattingOptions};
 use crate::events::{Displayed, PhotoLoaded, PreparedImageCpu};
+use crate::processing::blur::apply_blur;
 use crossbeam_channel::{bounded, Receiver as CbReceiver, Sender as CbSender, TrySendError};
-use image::{imageops, DynamicImage, Rgba, RgbaImage};
+use image::{imageops, Rgba, RgbaImage};
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -154,7 +155,11 @@ pub fn run_windowed(
                 let px = Rgba([color[0], color[1], color[2], 255]);
                 RgbaImage::from_pixel(canvas_w, canvas_h, px)
             }
-            MattingMode::Blur { sigma } => {
+            MattingMode::Blur {
+                sigma,
+                max_sample_dim,
+                backend,
+            } => {
                 let (bg_w, bg_h) = resize_to_cover(canvas_w, canvas_h, width, height, max_dim);
                 let mut bg = imageops::resize(&src, bg_w, bg_h, imageops::FilterType::Triangle);
                 if bg_w > canvas_w || bg_h > canvas_h {
@@ -169,8 +174,49 @@ pub fn run_windowed(
                     bg = canvas;
                 }
                 if sigma > 0.0 {
-                    let dynamic = DynamicImage::ImageRgba8(bg);
-                    imageops::blur(&dynamic, sigma)
+                    let limit = max_sample_dim
+                        .filter(|v| *v > 0)
+                        .unwrap_or_else(|| {
+                            #[cfg(target_arch = "aarch64")]
+                            {
+                                MattingMode::default_blur_max_sample_dim()
+                            }
+                            #[cfg(not(target_arch = "aarch64"))]
+                            {
+                                max_dim
+                            }
+                        })
+                        .min(max_dim)
+                        .max(1);
+
+                    let mut sample = bg;
+                    let mut sigma_px = sigma;
+                    let canvas_max = canvas_w.max(canvas_h).max(1);
+                    if canvas_max > limit {
+                        let scale = (limit as f32) / (canvas_max as f32);
+                        let sample_w =
+                            ((canvas_w as f32) * scale).round().clamp(1.0, limit as f32) as u32;
+                        let sample_h =
+                            ((canvas_h as f32) * scale).round().clamp(1.0, limit as f32) as u32;
+                        sample = imageops::resize(
+                            &sample,
+                            sample_w,
+                            sample_h,
+                            imageops::FilterType::Triangle,
+                        );
+                        sigma_px *= scale.max(0.01);
+                    }
+
+                    let mut blurred: RgbaImage = apply_blur(&sample, sigma_px, backend);
+                    if blurred.width() != canvas_w || blurred.height() != canvas_h {
+                        blurred = imageops::resize(
+                            &blurred,
+                            canvas_w,
+                            canvas_h,
+                            imageops::FilterType::CatmullRom,
+                        );
+                    }
+                    blurred
                 } else {
                     bg
                 }


### PR DESCRIPTION
## Summary
- add a blur processing module that provides CPU and optional NEON implementations and removes the GPU pipeline
- expose a simplified `backend` selector in the matting configuration and route the viewer through the new blur helper
- update the documentation and sample config to reflect the available backends

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ce1f8cec3c83238342d2ebe8cfe7b0