### PR TITLE
Fix playlist rotation when sending photos

### DIFF
--- a/src/tasks/manager.rs
+++ b/src/tasks/manager.rs
@@ -40,17 +40,19 @@ pub async fn run(
                 let to_loader = to_loader.clone();
                 async move {
                     if let Some(p) = next {
-                        to_loader.send(LoadPhoto(p)).await.map(|_| ()).map_err(|_| ())
+                        to_loader.send(LoadPhoto(p.clone())).await.map(|_| p).map_err(|_| ())
                     } else {
                         Err(())
                     }
                 }
             }, if !playlist.is_empty() => {
                 match res {
-                    Ok(()) => {
-                        // Successfully queued: rotate front -> back to keep it in play.
-                        if let Some(f) = playlist.pop_front() {
-                            playlist.push_back(f);
+                    Ok(sent) => {
+                        // Successfully queued: rotate the item we actually sent.
+                        if let Some(pos) = playlist.iter().position(|q| q == &sent) {
+                            if let Some(item) = playlist.remove(pos) {
+                                playlist.push_back(item);
+                            }
                         }
                     }
                     Err(_) => {

--- a/tests/manager_integration.rs
+++ b/tests/manager_integration.rs
@@ -48,3 +48,63 @@ async fn manager_ignores_spurious_remove_and_sends_load_on_add() {
     cancel.cancel();
     let _ = handle.await;
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn manager_rotates_actual_sent_item() {
+    let (inv_tx, inv_rx) = mpsc::channel::<InventoryEvent>(16);
+    let (_displayed_tx, displayed_rx) = mpsc::channel::<Displayed>(16);
+    let (to_load_tx, mut to_load_rx) = mpsc::channel::<LoadPhoto>(1);
+    let cancel = CancellationToken::new();
+
+    let handle = tokio::spawn(manager::run(
+        inv_rx,
+        displayed_rx,
+        to_load_tx,
+        cancel.clone(),
+    ));
+
+    let initial_a = PathBuf::from("/photos/a.jpg");
+    let initial_b = PathBuf::from("/photos/b.jpg");
+    let newcomer = PathBuf::from("/photos/new.jpg");
+
+    inv_tx
+        .send(InventoryEvent::PhotoAdded(initial_a.clone()))
+        .await
+        .unwrap();
+    assert_eq!(receive_with_timeout(&mut to_load_rx).await, initial_a);
+
+    inv_tx
+        .send(InventoryEvent::PhotoAdded(initial_b.clone()))
+        .await
+        .unwrap();
+
+    // Allow the manager to enqueue the second photo and start waiting to resend the first.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    inv_tx
+        .send(InventoryEvent::PhotoAdded(newcomer.clone()))
+        .await
+        .unwrap();
+
+    let mut order = Vec::new();
+    for _ in 0..3 {
+        order.push(receive_with_timeout(&mut to_load_rx).await);
+    }
+
+    assert!(
+        order.contains(&newcomer),
+        "new photo should be enqueued promptly, got {:?}",
+        order
+    );
+
+    cancel.cancel();
+    let _ = handle.await;
+}
+
+async fn receive_with_timeout(rx: &mut mpsc::Receiver<LoadPhoto>) -> PathBuf {
+    let LoadPhoto(path) = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+        .await
+        .expect("timed out waiting for LoadPhoto")
+        .expect("loader channel closed unexpectedly");
+    path
+}


### PR DESCRIPTION
## Summary
- ensure the manager rotates the same photo that was sent to the loader so newly added images stay at the front of the playlist
- add an integration test that simulates a backed up loader queue and asserts the new photo is delivered promptly

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ce26310fbc8323bd582e9078a64e56