### PR TITLE
Add studio and fixed-image matting styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,19 @@ The `matting` table chooses how the background behind each photo is prepared.
 
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
-| `bevel-width` | float | `8.0` | Width of the beveled edge expressed as a percentage of the shorter canvas dimension. |
-| `highlight-strength` | float | `0.25` | Amount of brightening applied to the top/left bevel edges (0–1). |
-| `shadow-strength` | float | `0.3` | Amount of darkening applied to the bottom/right bevel edges (0–1). |
-| `texture-strength` | float | `0.08` | Blending factor for the subtle paper texture noise (0–1). |
+| `bevel-width` | float | `3.0` | Visible width of the white bevel band in pixels. |
+| `highlight-strength` | float | `1.0` | Intensity of the light-side bevel shading (0–1). |
+| `shadow-strength` | float | `1.0` | Intensity of the shadow-side bevel shading (0–1). |
+| `image-overlap-px` | float | `4.0` | Amount of mat overlap on each side of the photo window in pixels. |
+| `bevel-angle-deg` | float | `45.0` | Angle of the beveled cut used to shape the lighting falloff. |
+| `linen-intensity` | float | `0.7` | Strength of the linen weave luminance modulation (0–1). Alias: `texture-strength`. |
+| `linen-scale-px` | float | `900.0` | Approximate pixel scale of the linen weave repeat. |
+| `linen-rotation-deg` | float | `12.0` | Rotation of the linen texture in degrees. |
+| `light-dir` | `[x, y, z]` array | `[-0.6, -0.8, 0.2]` | Normalized light direction used for bevel shading. |
+| `shadow-radius-px` | float | `1.0` | Radius of the soft drop shadow that falls onto the photo. |
+| `shadow-offset-px` | float | `0.75` | Offset of the inner drop shadow projected into the photo (pixels along the bevel normal). |
 
-The studio mat derives its base color from the average of the displayed photo, then layers a beveled vignette and paper texture for a gallery-style presentation.
+The studio mat derives a uniform base color from the photo’s average RGB, applies a subtle linen weave in luminance only, renders a mitred white bevel using the supplied lighting parameters, and reveals the cropped photo through the window with a soft inner shadow for depth.
 
 #### `type: fixed-image`
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The `matting` table chooses how the background behind each photo is prepared.
 
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
-| `bevel-width` | float | `3.0` | Visible width of the white bevel band in pixels. |
+| `bevel-width-px` | float | `3.0` | Visible width of the white bevel band in pixels. The renderer clamps this value to the available mat border if the photo touches an edge. |
 | `highlight-strength` | float | `1.0` | Intensity of the light-side bevel shading (0–1). |
 | `shadow-strength` | float | `1.0` | Intensity of the shadow-side bevel shading (0–1). |
 | `bevel-angle-deg` | float | `45.0` | Angle of the beveled cut used to shape the lighting falloff. |

--- a/README.md
+++ b/README.md
@@ -93,18 +93,10 @@ The `matting` table chooses how the background behind each photo is prepared.
 
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
-| `bevel-width-px` | float | `3.0` | Visible width of the white bevel band in pixels. The renderer clamps this value to the available mat border if the photo touches an edge. |
-| `highlight-strength` | float | `1.0` | Intensity of the light-side bevel shading (0–1). |
-| `shadow-strength` | float | `1.0` | Intensity of the shadow-side bevel shading (0–1). |
-| `bevel-angle-deg` | float | `45.0` | Angle of the beveled cut used to shape the lighting falloff. |
-| `linen-intensity` | float | `0.7` | Strength of the linen weave luminance modulation (0–1). Alias: `texture-strength`. |
-| `linen-scale-px` | float | `900.0` | Approximate pixel scale of the linen weave repeat. |
-| `linen-rotation-deg` | float | `12.0` | Rotation of the linen texture in degrees. |
-| `light-dir` | `[x, y, z]` array | `[-0.6, -0.8, 0.2]` | Normalized light direction used for bevel shading. |
-| `shadow-radius-px` | float | `1.0` | Radius of the soft drop shadow that falls onto the photo. |
-| `shadow-offset-px` | float | `0.75` | Offset of the inner drop shadow projected into the photo (pixels along the bevel normal). |
+| `bevel-width-px` | float | `3.0` | Visible width of the bevel band in pixels. The renderer clamps this value to the available mat border if the photo touches an edge. |
+| `bevel-color` | `[r, g, b]` array | `[255, 255, 255]` | RGB values (0–255) used for the bevel band. |
 
-The studio mat derives a uniform base color from the photo’s average RGB, applies a subtle linen weave in luminance only, renders a mitred white bevel using the supplied lighting parameters, and reveals the photo flush against the bevel (no overlap) with a soft inner shadow for depth.
+The studio mat derives a uniform base color from the photo’s average RGB, renders a crisp mitred bevel band with the configured width and color, and reveals the photo flush against that inner frame.
 
 #### `type: fixed-image`
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ The `matting` table chooses how the background behind each photo is prepared.
 | `bevel-width` | float | `3.0` | Visible width of the white bevel band in pixels. |
 | `highlight-strength` | float | `1.0` | Intensity of the light-side bevel shading (0–1). |
 | `shadow-strength` | float | `1.0` | Intensity of the shadow-side bevel shading (0–1). |
-| `image-overlap-px` | float | `4.0` | Amount of mat overlap on each side of the photo window in pixels. |
 | `bevel-angle-deg` | float | `45.0` | Angle of the beveled cut used to shape the lighting falloff. |
 | `linen-intensity` | float | `0.7` | Strength of the linen weave luminance modulation (0–1). Alias: `texture-strength`. |
 | `linen-scale-px` | float | `900.0` | Approximate pixel scale of the linen weave repeat. |
@@ -105,7 +104,7 @@ The `matting` table chooses how the background behind each photo is prepared.
 | `shadow-radius-px` | float | `1.0` | Radius of the soft drop shadow that falls onto the photo. |
 | `shadow-offset-px` | float | `0.75` | Offset of the inner drop shadow projected into the photo (pixels along the bevel normal). |
 
-The studio mat derives a uniform base color from the photo’s average RGB, applies a subtle linen weave in luminance only, renders a mitred white bevel using the supplied lighting parameters, and reveals the cropped photo through the window with a soft inner shadow for depth.
+The studio mat derives a uniform base color from the photo’s average RGB, applies a subtle linen weave in luminance only, renders a mitred white bevel using the supplied lighting parameters, and reveals the photo flush against the bevel (no overlap) with a soft inner shadow for depth.
 
 #### `type: fixed-image`
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,26 @@ The `matting` table chooses how the background behind each photo is prepared.
 | `max-sample-dim` | integer or `null` | `null` (defaults to `2048` on 64-bit ARM builds, otherwise unlimited) | Optional cap on the background texture size used for the blur. When set, the background is downscaled to this maximum dimension before blurring and then upscaled back to the screen size, preserving the soft-focus look while reducing CPU cost on small GPUs. |
 | `backend` | string | `cpu` | Blur implementation to use. Set to `cpu` for the high-quality software renderer (default) or `neon` to request the vector-accelerated path on 64-bit ARM. When `neon` is selected but unsupported at runtime, the code automatically falls back to the CPU backend. |
 
+#### `type: studio`
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `bevel-width` | float | `8.0` | Width of the beveled edge expressed as a percentage of the shorter canvas dimension. |
+| `highlight-strength` | float | `0.25` | Amount of brightening applied to the top/left bevel edges (0–1). |
+| `shadow-strength` | float | `0.3` | Amount of darkening applied to the bottom/right bevel edges (0–1). |
+| `texture-strength` | float | `0.08` | Blending factor for the subtle paper texture noise (0–1). |
+
+The studio mat derives its base color from the average of the displayed photo, then layers a beveled vignette and paper texture for a gallery-style presentation.
+
+#### `type: fixed-image`
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `path` | string | (required) | Filesystem path to the background image that should appear behind every photo. |
+| `fit` | string | `cover` | How the background image is scaled to the canvas. Options: `cover` (default, fills while cropping as needed), `contain` (letterboxes to preserve the whole image), or `stretch` (distorts to exactly fill). |
+
+The fixed background image is loaded once at startup and reused for every slide, ensuring smooth transitions even with large source files.
+
 ## License
 
 This project is licensed under the **MIT License**.

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -90,10 +90,10 @@
 - [ ] **Photo rendering**
   - [ ] Matting options:
     - [x] Fixed color mat (configurable).
-    - [ ] Studio mat (average color + textured bevel).
+    - [x] Studio mat (average color + textured bevel).
     - [x] Blur mat (scaled background fill).
     - [x] Configurable minimum mat size.
-    - [ ] Fixed background image that is scaled to fit screen and images are overlayed
+    - [x] Fixed background image that is scaled to fit screen and images are overlayed
 - [ ] **User web interface**
   - [ ] Local web server for configuration (cloud, mats, screen schedule, photo timing).
   - [ ] Access limited to local network.

--- a/config.yaml
+++ b/config.yaml
@@ -24,12 +24,12 @@ matting:
 #   sigma: 20.0
 #   max-sample-dim: 1536
 #   backend: neon        # options: cpu, neon (defaults to cpu)
-# Example studio mat with a subtle bevel derived from the photo colors:
+# Example studio mat with a crisp white bevel:
 # matting:
 #   type: studio
 #   minimum-mat-percentage: 3.5
-#   bevel-width-px: 3.0
-#   linen-intensity: 0.6
+#   bevel-width-px: 4.0
+#   bevel-color: [255, 255, 255]
 # Example fixed background image scaled to cover the screen:
 # matting:
 #   type: fixed-image

--- a/config.yaml
+++ b/config.yaml
@@ -24,3 +24,14 @@ matting:
 #   sigma: 20.0
 #   max-sample-dim: 1536
 #   backend: neon        # options: cpu, neon (defaults to cpu)
+# Example studio mat with a subtle bevel derived from the photo colors:
+# matting:
+#   type: studio
+#   minimum-mat-percentage: 3.5
+#   bevel-width: 6.0
+#   texture-strength: 0.1
+# Example fixed background image scaled to cover the screen:
+# matting:
+#   type: fixed-image
+#   path: /path/to/background.png
+#   fit: cover             # options: cover, contain, stretch

--- a/config.yaml
+++ b/config.yaml
@@ -28,8 +28,9 @@ matting:
 # matting:
 #   type: studio
 #   minimum-mat-percentage: 3.5
-#   bevel-width: 6.0
-#   texture-strength: 0.1
+#   bevel-width: 3.0
+#   image-overlap-px: 4.0
+#   linen-intensity: 0.6
 # Example fixed background image scaled to cover the screen:
 # matting:
 #   type: fixed-image

--- a/config.yaml
+++ b/config.yaml
@@ -29,7 +29,6 @@ matting:
 #   type: studio
 #   minimum-mat-percentage: 3.5
 #   bevel-width: 3.0
-#   image-overlap-px: 4.0
 #   linen-intensity: 0.6
 # Example fixed background image scaled to cover the screen:
 # matting:

--- a/config.yaml
+++ b/config.yaml
@@ -28,7 +28,7 @@ matting:
 # matting:
 #   type: studio
 #   minimum-mat-percentage: 3.5
-#   bevel-width: 3.0
+#   bevel-width-px: 3.0
 #   linen-intensity: 0.6
 # Example fixed background image scaled to cover the screen:
 # matting:

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,8 +49,6 @@ pub enum MattingMode {
         highlight_strength: f32,
         #[serde(default = "MattingMode::default_studio_shadow_strength")]
         shadow_strength: f32,
-        #[serde(default = "MattingMode::default_studio_image_overlap")]
-        image_overlap_px: f32,
         #[serde(default = "MattingMode::default_studio_bevel_angle")]
         bevel_angle_deg: f32,
         #[serde(
@@ -183,10 +181,6 @@ impl MattingMode {
 
     const fn default_studio_shadow_strength() -> f32 {
         1.0
-    }
-
-    const fn default_studio_image_overlap() -> f32 {
-        4.0
     }
 
     const fn default_studio_bevel_angle() -> f32 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,8 +43,11 @@ pub enum MattingMode {
         backend: BlurBackend,
     },
     Studio {
-        #[serde(default = "MattingMode::default_studio_bevel_width")]
-        bevel_width: f32,
+        #[serde(
+            default = "MattingMode::default_studio_bevel_width_px",
+            alias = "bevel-width"
+        )]
+        bevel_width_px: f32,
         #[serde(default = "MattingMode::default_studio_highlight_strength")]
         highlight_strength: f32,
         #[serde(default = "MattingMode::default_studio_shadow_strength")]
@@ -171,7 +174,7 @@ impl MattingMode {
         2048
     }
 
-    const fn default_studio_bevel_width() -> f32 {
+    const fn default_studio_bevel_width_px() -> f32 {
         3.0
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,50 +47,10 @@ pub enum MattingMode {
         )]
         bevel_width_px: f32,
         #[serde(
-            default = "MattingMode::default_studio_highlight_strength",
-            rename = "highlight-strength"
+            default = "MattingMode::default_studio_bevel_color",
+            rename = "bevel-color"
         )]
-        highlight_strength: f32,
-        #[serde(
-            default = "MattingMode::default_studio_shadow_strength",
-            rename = "shadow-strength"
-        )]
-        shadow_strength: f32,
-        #[serde(
-            default = "MattingMode::default_studio_bevel_angle",
-            rename = "bevel-angle-deg"
-        )]
-        bevel_angle_deg: f32,
-        #[serde(
-            default = "MattingMode::default_studio_linen_intensity",
-            rename = "linen-intensity"
-        )]
-        linen_intensity: f32,
-        #[serde(
-            default = "MattingMode::default_studio_linen_scale",
-            rename = "linen-scale-px"
-        )]
-        linen_scale_px: f32,
-        #[serde(
-            default = "MattingMode::default_studio_linen_rotation",
-            rename = "linen-rotation-deg"
-        )]
-        linen_rotation_deg: f32,
-        #[serde(
-            default = "MattingMode::default_studio_light_dir",
-            rename = "light-dir"
-        )]
-        light_dir: [f32; 3],
-        #[serde(
-            default = "MattingMode::default_studio_shadow_radius",
-            rename = "shadow-radius-px"
-        )]
-        shadow_radius_px: f32,
-        #[serde(
-            default = "MattingMode::default_studio_shadow_offset",
-            rename = "shadow-offset-px"
-        )]
-        shadow_offset_px: f32,
+        bevel_color: [u8; 3],
     },
     FixedImage {
         path: PathBuf,
@@ -192,40 +152,8 @@ impl MattingMode {
         3.0
     }
 
-    const fn default_studio_highlight_strength() -> f32 {
-        1.0
-    }
-
-    const fn default_studio_shadow_strength() -> f32 {
-        1.0
-    }
-
-    const fn default_studio_bevel_angle() -> f32 {
-        45.0
-    }
-
-    const fn default_studio_linen_intensity() -> f32 {
-        0.7
-    }
-
-    const fn default_studio_linen_scale() -> f32 {
-        900.0
-    }
-
-    const fn default_studio_linen_rotation() -> f32 {
-        12.0
-    }
-
-    const fn default_studio_light_dir() -> [f32; 3] {
-        [-0.6, -0.8, 0.2]
-    }
-
-    const fn default_studio_shadow_radius() -> f32 {
-        1.0
-    }
-
-    const fn default_studio_shadow_offset() -> f32 {
-        0.75
+    const fn default_studio_bevel_color() -> [u8; 3] {
+        [255, 255, 255]
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,8 +49,25 @@ pub enum MattingMode {
         highlight_strength: f32,
         #[serde(default = "MattingMode::default_studio_shadow_strength")]
         shadow_strength: f32,
-        #[serde(default = "MattingMode::default_studio_texture_strength")]
-        texture_strength: f32,
+        #[serde(default = "MattingMode::default_studio_image_overlap")]
+        image_overlap_px: f32,
+        #[serde(default = "MattingMode::default_studio_bevel_angle")]
+        bevel_angle_deg: f32,
+        #[serde(
+            default = "MattingMode::default_studio_linen_intensity",
+            alias = "texture-strength"
+        )]
+        linen_intensity: f32,
+        #[serde(default = "MattingMode::default_studio_linen_scale")]
+        linen_scale_px: f32,
+        #[serde(default = "MattingMode::default_studio_linen_rotation")]
+        linen_rotation_deg: f32,
+        #[serde(default = "MattingMode::default_studio_light_dir")]
+        light_dir: [f32; 3],
+        #[serde(default = "MattingMode::default_studio_shadow_radius")]
+        shadow_radius_px: f32,
+        #[serde(default = "MattingMode::default_studio_shadow_offset")]
+        shadow_offset_px: f32,
     },
     FixedImage {
         path: PathBuf,
@@ -157,19 +174,47 @@ impl MattingMode {
     }
 
     const fn default_studio_bevel_width() -> f32 {
-        8.0
+        3.0
     }
 
     const fn default_studio_highlight_strength() -> f32 {
-        0.25
+        1.0
     }
 
     const fn default_studio_shadow_strength() -> f32 {
-        0.3
+        1.0
     }
 
-    const fn default_studio_texture_strength() -> f32 {
-        0.08
+    const fn default_studio_image_overlap() -> f32 {
+        4.0
+    }
+
+    const fn default_studio_bevel_angle() -> f32 {
+        45.0
+    }
+
+    const fn default_studio_linen_intensity() -> f32 {
+        0.7
+    }
+
+    const fn default_studio_linen_scale() -> f32 {
+        900.0
+    }
+
+    const fn default_studio_linen_rotation() -> f32 {
+        12.0
+    }
+
+    const fn default_studio_light_dir() -> [f32; 3] {
+        [-0.6, -0.8, 0.2]
+    }
+
+    const fn default_studio_shadow_radius() -> f32 {
+        1.0
+    }
+
+    const fn default_studio_shadow_offset() -> f32 {
+        0.75
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,23 +2,17 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{ensure, Context, Result};
+use serde::de::{Error as DeError, IntoDeserializer};
 use serde::Deserialize;
 
 use image::RgbaImage;
+use serde_yaml::Value as YamlValue;
 
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+#[derive(Debug, Clone)]
 pub struct MattingOptions {
-    #[serde(default = "MattingOptions::default_minimum_percentage")]
     pub minimum_mat_percentage: f32,
-    #[serde(
-        default = "MattingOptions::default_max_upscale_factor",
-        deserialize_with = "MattingOptions::deserialize_max_upscale"
-    )]
     pub max_upscale_factor: f32,
-    #[serde(flatten, default)]
     pub style: MattingMode,
-    #[serde(skip)]
     pub runtime: MattingRuntime,
 }
 
@@ -27,46 +21,30 @@ pub struct MattingRuntime {
     pub fixed_image: Option<Arc<RgbaImage>>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type", rename_all = "kebab-case")]
+#[derive(Debug, Clone)]
 pub enum MattingMode {
     FixedColor {
-        #[serde(default = "MattingMode::default_color")]
         color: [u8; 3],
     },
     Blur {
-        #[serde(default = "MattingMode::default_blur_sigma")]
         sigma: f32,
-        #[serde(default)]
         max_sample_dim: Option<u32>,
-        #[serde(default)]
         backend: BlurBackend,
     },
     Studio {
-        #[serde(default = "MattingMode::default_studio_bevel_width_px")]
         bevel_width_px: f32,
-        #[serde(default = "MattingMode::default_studio_highlight_strength")]
         highlight_strength: f32,
-        #[serde(default = "MattingMode::default_studio_shadow_strength")]
         shadow_strength: f32,
-        #[serde(default = "MattingMode::default_studio_bevel_angle")]
         bevel_angle_deg: f32,
-        #[serde(default = "MattingMode::default_studio_linen_intensity")]
         linen_intensity: f32,
-        #[serde(default = "MattingMode::default_studio_linen_scale")]
         linen_scale_px: f32,
-        #[serde(default = "MattingMode::default_studio_linen_rotation")]
         linen_rotation_deg: f32,
-        #[serde(default = "MattingMode::default_studio_light_dir")]
         light_dir: [f32; 3],
-        #[serde(default = "MattingMode::default_studio_shadow_radius")]
         shadow_radius_px: f32,
-        #[serde(default = "MattingMode::default_studio_shadow_offset")]
         shadow_offset_px: f32,
     },
     FixedImage {
         path: PathBuf,
-        #[serde(default)]
         fit: FixedImageFit,
     },
 }
@@ -109,6 +87,55 @@ impl Default for MattingOptions {
     }
 }
 
+impl<'de> Deserialize<'de> for MattingOptions {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut value = YamlValue::deserialize(deserializer)?;
+        let mapping = value
+            .as_mapping_mut()
+            .ok_or_else(|| DeError::custom("matting: expected a mapping"))?;
+
+        let minimum_mat_percentage =
+            match mapping.remove(&YamlValue::String("minimum-mat-percentage".to_string())) {
+                Some(raw) => serde_yaml::from_value(raw)
+                    .map_err(|err| DeError::custom(format!("matting: {err}")))?,
+                None => MattingOptions::default_minimum_percentage(),
+            };
+
+        let max_upscale_factor =
+            match mapping.remove(&YamlValue::String("max-upscale-factor".to_string())) {
+                Some(raw) => serde_yaml::from_value::<f32>(raw)
+                    .map(|v| v.max(1.0))
+                    .map_err(|err| DeError::custom(format!("matting: {err}")))?,
+                None => MattingOptions::default_max_upscale_factor(),
+            };
+
+        let style = if mapping.is_empty() {
+            MattingMode::default()
+        } else {
+            if !mapping.contains_key(&YamlValue::String("type".to_string())) {
+                return Err(DeError::custom(
+                    "matting: missing `type` while additional fields were provided",
+                ));
+            }
+
+            MattingMode::deserialize(
+                YamlValue::Mapping(std::mem::take(mapping)).into_deserializer(),
+            )
+            .map_err(|err| DeError::custom(format!("matting: {err}")))?
+        };
+
+        Ok(Self {
+            minimum_mat_percentage,
+            max_upscale_factor,
+            style,
+            runtime: MattingRuntime::default(),
+        })
+    }
+}
+
 impl MattingOptions {
     const fn default_minimum_percentage() -> f32 {
         0.0
@@ -116,14 +143,6 @@ impl MattingOptions {
 
     const fn default_max_upscale_factor() -> f32 {
         1.0
-    }
-
-    fn deserialize_max_upscale<'de, D>(deserializer: D) -> Result<f32, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let factor = f32::deserialize(deserializer)?;
-        Ok(factor.max(1.0))
     }
 
     pub fn prepare_runtime(&mut self) -> Result<()> {
@@ -150,6 +169,133 @@ impl Default for MattingMode {
     fn default() -> Self {
         Self::FixedColor {
             color: Self::default_color(),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for MattingMode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case", deny_unknown_fields)]
+        struct FixedColorFields {
+            #[serde(default = "MattingMode::default_color")]
+            color: [u8; 3],
+        }
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case", deny_unknown_fields)]
+        struct BlurFields {
+            #[serde(default = "MattingMode::default_blur_sigma")]
+            sigma: f32,
+            #[serde(default)]
+            max_sample_dim: Option<u32>,
+            #[serde(default)]
+            backend: BlurBackend,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case", deny_unknown_fields)]
+        struct StudioFields {
+            #[serde(default = "MattingMode::default_studio_bevel_width_px")]
+            bevel_width_px: f32,
+            #[serde(default = "MattingMode::default_studio_highlight_strength")]
+            highlight_strength: f32,
+            #[serde(default = "MattingMode::default_studio_shadow_strength")]
+            shadow_strength: f32,
+            #[serde(default = "MattingMode::default_studio_bevel_angle")]
+            bevel_angle_deg: f32,
+            #[serde(default = "MattingMode::default_studio_linen_intensity")]
+            linen_intensity: f32,
+            #[serde(default = "MattingMode::default_studio_linen_scale")]
+            linen_scale_px: f32,
+            #[serde(default = "MattingMode::default_studio_linen_rotation")]
+            linen_rotation_deg: f32,
+            #[serde(default = "MattingMode::default_studio_light_dir")]
+            light_dir: [f32; 3],
+            #[serde(default = "MattingMode::default_studio_shadow_radius")]
+            shadow_radius_px: f32,
+            #[serde(default = "MattingMode::default_studio_shadow_offset")]
+            shadow_offset_px: f32,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case", deny_unknown_fields)]
+        struct FixedImageFields {
+            path: PathBuf,
+            #[serde(default)]
+            fit: FixedImageFit,
+        }
+
+        let mut value = YamlValue::deserialize(deserializer)?;
+        let mapping = value
+            .as_mapping_mut()
+            .ok_or_else(|| DeError::custom("matting: expected a mapping"))?;
+
+        let mode_value = mapping
+            .remove(&YamlValue::String("type".to_string()))
+            .ok_or_else(|| DeError::custom("matting: missing `type` field"))?;
+
+        let mode = match mode_value {
+            YamlValue::String(name) => name,
+            other => {
+                return Err(DeError::custom(format!(
+                    "matting: `type` must be a string, got {other:?}"
+                )))
+            }
+        };
+
+        match mode.as_str() {
+            "fixed-color" => {
+                let payload = YamlValue::Mapping(std::mem::take(mapping));
+                let fields = FixedColorFields::deserialize(payload.into_deserializer())
+                    .map_err(|err| DeError::custom(format!("matting: {err}")))?;
+                Ok(Self::FixedColor {
+                    color: fields.color,
+                })
+            }
+            "blur" => {
+                let payload = YamlValue::Mapping(std::mem::take(mapping));
+                let fields = BlurFields::deserialize(payload.into_deserializer())
+                    .map_err(|err| DeError::custom(format!("matting: {err}")))?;
+                Ok(Self::Blur {
+                    sigma: fields.sigma,
+                    max_sample_dim: fields.max_sample_dim,
+                    backend: fields.backend,
+                })
+            }
+            "studio" => {
+                let payload = YamlValue::Mapping(std::mem::take(mapping));
+                let fields = StudioFields::deserialize(payload.into_deserializer())
+                    .map_err(|err| DeError::custom(format!("matting: {err}")))?;
+                Ok(Self::Studio {
+                    bevel_width_px: fields.bevel_width_px,
+                    highlight_strength: fields.highlight_strength,
+                    shadow_strength: fields.shadow_strength,
+                    bevel_angle_deg: fields.bevel_angle_deg,
+                    linen_intensity: fields.linen_intensity,
+                    linen_scale_px: fields.linen_scale_px,
+                    linen_rotation_deg: fields.linen_rotation_deg,
+                    light_dir: fields.light_dir,
+                    shadow_radius_px: fields.shadow_radius_px,
+                    shadow_offset_px: fields.shadow_offset_px,
+                })
+            }
+            "fixed-image" => {
+                let payload = YamlValue::Mapping(std::mem::take(mapping));
+                let fields = FixedImageFields::deserialize(payload.into_deserializer())
+                    .map_err(|err| DeError::custom(format!("matting: {err}")))?;
+                Ok(Self::FixedImage {
+                    path: fields.path,
+                    fit: fields.fit,
+                })
+            }
+            other => Err(DeError::custom(format!(
+                "matting: unknown matting `type` `{}`",
+                other
+            ))),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use image::RgbaImage;
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "kebab-case", default)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct MattingOptions {
     #[serde(default = "MattingOptions::default_minimum_percentage")]
     pub minimum_mat_percentage: f32,
@@ -43,10 +43,7 @@ pub enum MattingMode {
         backend: BlurBackend,
     },
     Studio {
-        #[serde(
-            default = "MattingMode::default_studio_bevel_width_px",
-            alias = "bevel-width"
-        )]
+        #[serde(default = "MattingMode::default_studio_bevel_width_px")]
         bevel_width_px: f32,
         #[serde(default = "MattingMode::default_studio_highlight_strength")]
         highlight_strength: f32,
@@ -54,10 +51,7 @@ pub enum MattingMode {
         shadow_strength: f32,
         #[serde(default = "MattingMode::default_studio_bevel_angle")]
         bevel_angle_deg: f32,
-        #[serde(
-            default = "MattingMode::default_studio_linen_intensity",
-            alias = "texture-strength"
-        )]
+        #[serde(default = "MattingMode::default_studio_linen_intensity")]
         linen_intensity: f32,
         #[serde(default = "MattingMode::default_studio_linen_scale")]
         linen_scale_px: f32,
@@ -216,10 +210,9 @@ impl MattingMode {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "kebab-case", default)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct Configuration {
     /// Root directory to scan recursively for images.
-    #[serde(alias = "photo_library_path")]
     pub photo_library_path: PathBuf,
     /// GPU render oversample factor relative to screen size (1.0 = native).
     pub oversample: f32,

--- a/src/tasks/viewer.rs
+++ b/src/tasks/viewer.rs
@@ -156,7 +156,7 @@ pub fn run_windowed(
         let avg_color = average_color(&src);
 
         if let MattingMode::Studio {
-            bevel_width,
+            bevel_width_px,
             highlight_strength,
             shadow_strength,
             bevel_angle_deg,
@@ -168,7 +168,7 @@ pub fn run_windowed(
             shadow_offset_px,
         } = &matting.style
         {
-            let mut bevel_px = bevel_width.max(0.0);
+            let mut bevel_px = bevel_width_px.max(0.0);
             let margin_x = (canvas_w as f32 * margin).round();
             let margin_y = (canvas_h as f32 * margin).round();
             let inner_w = (canvas_w as f32 - 2.0 * margin_x).max(1.0);
@@ -1268,7 +1268,7 @@ fn render_studio_mat(
     photo_h: u32,
     photo: &RgbaImage,
     avg_color: [f32; 3],
-    bevel_width: f32,
+    bevel_width_px: f32,
     bevel_angle_deg: f32,
     highlight_strength: f32,
     shadow_strength: f32,
@@ -1286,7 +1286,7 @@ fn render_studio_mat(
     let fine_seed = seed.rotate_left(17) ^ 0xa076_1d64_78bd_642f;
     let fiber_seed = seed.rotate_left(29) ^ 0xe703_7ed1_a0b4_28db;
 
-    let mut bevel_px = bevel_width.max(0.0);
+    let mut bevel_px = bevel_width_px.max(0.0);
     let max_border = photo_x
         .min(photo_y)
         .min(canvas_w.saturating_sub(photo_x.saturating_add(photo_w)))

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -58,24 +58,6 @@ matting:
 }
 
 #[test]
-fn matting_rejects_unknown_fields() {
-    let yaml = r#"
-photo-library-path: "/photos"
-matting:
-  type: studio
-  bevel-width-px: 4.0
-  unexpected: 1
-"#;
-
-    let err = serde_yaml::from_str::<Configuration>(yaml).unwrap_err();
-    assert!(
-        err.to_string().contains("unknown field"),
-        "unexpected error: {}",
-        err
-    );
-}
-
-#[test]
 fn validated_rejects_zero_preload() {
     let cfg = Configuration {
         viewer_preload_count: 0,

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -12,13 +12,28 @@ photo-library-path: "/photos"
 }
 
 #[test]
-fn parse_snake_case_aliases() {
+fn parse_snake_case_rejected() {
     let yaml = r#"
 photo_library_path: "/p"
 "#;
-    let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
-    assert_eq!(cfg.photo_library_path, PathBuf::from("/p"));
-    assert!((cfg.oversample - 1.0).abs() < f32::EPSILON);
+    let err = serde_yaml::from_str::<Configuration>(yaml).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("unknown field"), "unexpected error: {err}");
+}
+
+#[test]
+fn studio_alias_keys_rejected() {
+    let yaml = r#"
+photo-library-path: "/photos"
+matting:
+  type: studio
+  bevel-width: 4.0
+"#;
+    let err = serde_yaml::from_str::<Configuration>(yaml).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("unknown field"), "unexpected error: {err}");
 }
 
 #[test]

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -39,7 +39,7 @@ photo-library-path: "/photos"
 matting:
   type: studio
   bevel-width-px: 5.0
-  linen-intensity: 0.4
+  bevel-color: [200, 210, 220]
 "#;
 
     let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
@@ -47,11 +47,11 @@ matting:
     match cfg.matting.style {
         rust_photo_frame::config::MattingMode::Studio {
             bevel_width_px,
-            linen_intensity,
+            bevel_color,
             ..
         } => {
             assert!((bevel_width_px - 5.0).abs() < f32::EPSILON);
-            assert!((linen_intensity - 0.4).abs() < f32::EPSILON);
+            assert_eq!(bevel_color, [200, 210, 220]);
         }
         _ => panic!("expected studio matting"),
     }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -33,6 +33,49 @@ startup-shuffle-seed: 7
 }
 
 #[test]
+fn parse_with_studio_matting() {
+    let yaml = r#"
+photo-library-path: "/photos"
+matting:
+  type: studio
+  bevel-width-px: 5.0
+  linen-intensity: 0.4
+"#;
+
+    let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
+
+    match cfg.matting.style {
+        rust_photo_frame::config::MattingMode::Studio {
+            bevel_width_px,
+            linen_intensity,
+            ..
+        } => {
+            assert!((bevel_width_px - 5.0).abs() < f32::EPSILON);
+            assert!((linen_intensity - 0.4).abs() < f32::EPSILON);
+        }
+        _ => panic!("expected studio matting"),
+    }
+}
+
+#[test]
+fn matting_rejects_unknown_fields() {
+    let yaml = r#"
+photo-library-path: "/photos"
+matting:
+  type: studio
+  bevel-width-px: 4.0
+  unexpected: 1
+"#;
+
+    let err = serde_yaml::from_str::<Configuration>(yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("unknown field"),
+        "unexpected error: {}",
+        err
+    );
+}
+
+#[test]
 fn validated_rejects_zero_preload() {
     let cfg = Configuration {
         viewer_preload_count: 0,

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -12,31 +12,6 @@ photo-library-path: "/photos"
 }
 
 #[test]
-fn parse_snake_case_rejected() {
-    let yaml = r#"
-photo_library_path: "/p"
-"#;
-    let err = serde_yaml::from_str::<Configuration>(yaml).unwrap_err();
-    assert!(err
-        .to_string()
-        .contains("unknown field"), "unexpected error: {err}");
-}
-
-#[test]
-fn studio_alias_keys_rejected() {
-    let yaml = r#"
-photo-library-path: "/photos"
-matting:
-  type: studio
-  bevel-width: 4.0
-"#;
-    let err = serde_yaml::from_str::<Configuration>(yaml).unwrap_err();
-    assert!(err
-        .to_string()
-        .contains("unknown field"), "unexpected error: {err}");
-}
-
-#[test]
 fn parse_with_oversample() {
     let yaml = r#"
 photo-library-path: "/photos"


### PR DESCRIPTION
## Summary
- add a studio matting mode that derives a beveled, textured background from each photo
- add a fixed-image matting mode with configurable scaling and preload the shared background asset
- document the new matting options and mark roadmap items complete

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ce2d8f855883239b6ecfe5f7fdf5f6