### PR TITLE
Implement half-life weighted playlist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ pollster = "0.4.0"
 rand = "0.8.5"
 serde = { version = "1.0.221", features = ["derive"] }
 serde_yaml = "0.9.34"
+humantime-serde = "1.1.1"
 crossbeam-channel = "0.5.13"
 tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "signal", "sync", "time"] }
 tokio-util = "0.7.16"

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -76,7 +76,8 @@
   - [ ] Automate Tailscale install + login during setup.
   - [ ] Add wifi configuration utility (form → wpa_supplicant update).
 - [ ] **Rust project features**
-  - [ ] Circular buffer weighting (half-life replication for new photos).
+  - [x] Circular buffer weighting (half-life replication for new photos).
+    - [x] Exponential half-life weighting keeps recent additions repeating while ensuring every photo appears each cycle.
   - [x] Graceful removal of deleted photos from list.
   - [x] Randomized list at boot with configurable seed.
   - [ ] Event system:

--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,10 @@ oversample: 1.0
 # Concurrent image decodes in loader
 loader-max-concurrent-decodes: 4
 
+playlist:
+  new-multiplicity: 3
+  half-life: 3 days
+
 # Matting settings
 matting:
   type: fixed-color

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,9 +1,16 @@
 use std::path::PathBuf;
+use std::time::SystemTime;
 
 #[derive(Debug)]
 pub enum InventoryEvent {
-    PhotoAdded(PathBuf),
+    PhotoAdded(PhotoInfo),
     PhotoRemoved(PathBuf),
+}
+
+#[derive(Debug, Clone)]
+pub struct PhotoInfo {
+    pub path: PathBuf,
+    pub created_at: SystemTime,
 }
 
 #[derive(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,8 +108,9 @@ async fn main() -> Result<()> {
         let displayed_rx = displayed_rx;
         let to_load_tx = to_load_tx.clone();
         let cancel = cancel.clone();
+        let playlist = cfg.playlist.clone();
         async move {
-            tasks::manager::run(inv_rx, displayed_rx, to_load_tx, cancel)
+            tasks::manager::run(inv_rx, displayed_rx, to_load_tx, cancel, playlist)
                 .await
                 .context("manager task failed")
         }

--- a/src/tasks/manager.rs
+++ b/src/tasks/manager.rs
@@ -1,7 +1,10 @@
-use crate::events::{Displayed, InventoryEvent, LoadPhoto};
+use crate::config::PlaylistOptions;
+use crate::events::{Displayed, InventoryEvent, LoadPhoto, PhotoInfo};
 use anyhow::Result;
-use std::collections::{HashSet, VecDeque};
-use std::path::PathBuf;
+use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 use tokio::select;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::time::{sleep, Duration};
@@ -11,22 +14,24 @@ use tracing::{debug, warn};
 /// Orchestrates the playlist and paces the show via the async send to `loader`.
 ///
 /// Rules:
-/// - Maintain a deduplicated `VecDeque<PathBuf>` playlist.
-/// - On any `PhotoAdded`, push_front so new shots surface quickly.
-/// - On `PhotoRemoved`, delete if present.
+/// - Maintain a weighted `VecDeque<PathBuf>` playlist, duplicating photos by multiplicity.
+/// - On `PhotoAdded`, record metadata and prioritize the new image at the front of the next cycle.
+/// - On `PhotoRemoved`, drop all scheduled occurrences and forget future weighting.
 /// - Timing is paced by the async `.send()` to the loader.
-/// - On successful send, rotate: pop_front -> push_back (keep cycling).
+/// - On successful send, consume that scheduled occurrence; rebuild the queue when exhausted or dirty.
 /// - Displayed notifications are informational; no re-queue on display.
 pub async fn run(
     mut inv_rx: Receiver<InventoryEvent>,
     mut displayed_rx: Receiver<Displayed>,
     to_loader: Sender<LoadPhoto>,
     cancel: CancellationToken,
+    options: PlaylistOptions,
 ) -> Result<()> {
-    let mut playlist: VecDeque<PathBuf> = VecDeque::new();
-    let mut seen: HashSet<PathBuf> = HashSet::new();
+    let mut playlist = PlaylistState::new(options);
 
     loop {
+        playlist.ensure_ready();
+
         // Prefer to make progress by sending when we have something.
         // Remain responsive to inventory + displayed events via `select!`.
         // Also include a small idle tick so startup (empty playlist) doesn't stall forever.
@@ -36,7 +41,7 @@ pub async fn run(
             // Drive slideshow by awaiting the send to the loader.
             // Rotate the playlist on successful send; viewer/loader handle pacing.
             res = {
-                let next = playlist.front().cloned();
+                let next = playlist.peek().cloned();
                 let to_loader = to_loader.clone();
                 async move {
                     if let Some(p) = next {
@@ -48,12 +53,7 @@ pub async fn run(
             }, if !playlist.is_empty() => {
                 match res {
                     Ok(sent) => {
-                        // Successfully queued: rotate the item we actually sent.
-                        if let Some(pos) = playlist.iter().position(|q| q == &sent) {
-                            if let Some(item) = playlist.remove(pos) {
-                                playlist.push_back(item);
-                            }
-                        }
+                        playlist.mark_sent(&sent);
                     }
                     Err(_) => {
                         warn!("loader channel closed");
@@ -66,21 +66,11 @@ pub async fn run(
             // Inventory updates (from files task)
             maybe_ev = inv_rx.recv() => {
                 match maybe_ev {
-                    Some(InventoryEvent::PhotoAdded(p)) => {
-                        if seen.insert(p.clone()) {
-                            // New to us: put it up front so it shows soon.
-                            playlist.push_front(p);
-                        } else {
-                            // Already known; ignore.
-                        }
+                    Some(InventoryEvent::PhotoAdded(info)) => {
+                        playlist.record_add(info);
                     }
                     Some(InventoryEvent::PhotoRemoved(p)) => {
-                        if seen.remove(&p) {
-                            // Remove from deque if present.
-                            if let Some(pos) = playlist.iter().position(|q| q == &p) {
-                                playlist.remove(pos);
-                            }
-                        }
+                        playlist.record_remove(&p);
                     }
                     None => {
                         // Inventory producer ended. We can continue with what we have.
@@ -108,4 +98,119 @@ pub async fn run(
     }
 
     Ok(())
+}
+
+struct PlaylistState {
+    queue: VecDeque<PathBuf>,
+    known: HashMap<PathBuf, PhotoInfo>,
+    prioritized: Vec<PathBuf>,
+    rng: StdRng,
+    options: PlaylistOptions,
+    dirty: bool,
+}
+
+impl PlaylistState {
+    fn new(options: PlaylistOptions) -> Self {
+        Self {
+            queue: VecDeque::new(),
+            known: HashMap::new(),
+            prioritized: Vec::new(),
+            rng: StdRng::from_entropy(),
+            options,
+            dirty: true,
+        }
+    }
+
+    fn ensure_ready(&mut self) {
+        if self.dirty || self.queue.is_empty() {
+            self.rebuild();
+        }
+    }
+
+    fn rebuild(&mut self) {
+        if self.known.is_empty() {
+            self.queue.clear();
+            self.dirty = false;
+            self.prioritized.clear();
+            return;
+        }
+
+        let now = SystemTime::now();
+        let prioritized = std::mem::take(&mut self.prioritized);
+        let prioritized_set: HashSet<PathBuf> = prioritized.iter().cloned().collect();
+        let mut front: Vec<PathBuf> = Vec::new();
+        let mut rest: Vec<PathBuf> = Vec::new();
+
+        for info in self.known.values() {
+            let multiplicity = self.options.multiplicity_for(info.created_at, now);
+            if multiplicity == 0 {
+                continue;
+            }
+            if prioritized_set.contains(&info.path) {
+                front.push(info.path.clone());
+                for _ in 1..multiplicity {
+                    rest.push(info.path.clone());
+                }
+            } else {
+                for _ in 0..multiplicity {
+                    rest.push(info.path.clone());
+                }
+            }
+        }
+
+        rest.shuffle(&mut self.rng);
+
+        let mut queue = VecDeque::new();
+        for path in prioritized {
+            if let Some(idx) = front.iter().position(|p| p == &path) {
+                queue.push_back(front.remove(idx));
+            }
+        }
+        for path in front {
+            queue.push_back(path);
+        }
+        for path in rest {
+            queue.push_back(path);
+        }
+
+        self.queue = queue;
+        self.dirty = false;
+    }
+
+    fn peek(&self) -> Option<&PathBuf> {
+        self.queue.front()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    fn mark_sent(&mut self, sent: &Path) {
+        if let Some(front) = self.queue.front() {
+            if front == sent {
+                self.queue.pop_front();
+                return;
+            }
+        }
+        if let Some(pos) = self.queue.iter().position(|p| p == sent) {
+            self.queue.remove(pos);
+        }
+    }
+
+    fn record_add(&mut self, info: PhotoInfo) {
+        let path = info.path.clone();
+        let was_new = self.known.insert(info.path.clone(), info).is_none();
+        if was_new && !self.prioritized.iter().any(|p| p == &path) {
+            self.prioritized.push(path);
+        }
+        self.dirty = true;
+    }
+
+    fn record_remove(&mut self, path: &Path) {
+        if self.known.remove(path).is_some() {
+            self.prioritized.retain(|p| p != path);
+            self.queue.retain(|p| p != path);
+            self.dirty = true;
+        }
+    }
 }

--- a/tests/files_integration.rs
+++ b/tests/files_integration.rs
@@ -35,12 +35,12 @@ async fn startup_recursive_scan_emits_photo_added() {
     // Collect two PhotoAdded events (for a.jpg, nested/b.jpeg)
     let mut added: Vec<PathBuf> = Vec::new();
     while added.len() < 2 {
-        if let Some(InventoryEvent::PhotoAdded(p)) =
+        if let Some(InventoryEvent::PhotoAdded(info)) =
             tokio::time::timeout(std::time::Duration::from_secs(5), inv_rx.recv())
                 .await
                 .expect("timeout waiting for inventory event")
         {
-            added.push(p);
+            added.push(info.path);
         }
     }
 
@@ -83,12 +83,12 @@ async fn invalid_photo_is_deleted_and_emits_removed() {
     // Wait for startup scan to pick up the file
     let mut saw_added = false;
     while !saw_added {
-        if let Some(InventoryEvent::PhotoAdded(p)) =
+        if let Some(InventoryEvent::PhotoAdded(info)) =
             tokio::time::timeout(std::time::Duration::from_secs(5), inv_rx.recv())
                 .await
                 .expect("timeout waiting for inventory event")
         {
-            if p == bad {
+            if info.path == bad {
                 saw_added = true;
             }
         }
@@ -163,12 +163,12 @@ async fn startup_shuffle_is_deterministic_with_seed() {
 
     let mut actual: Vec<PathBuf> = Vec::new();
     while actual.len() < 2 {
-        if let Some(InventoryEvent::PhotoAdded(p)) =
+        if let Some(InventoryEvent::PhotoAdded(info)) =
             tokio::time::timeout(std::time::Duration::from_secs(5), inv_rx.recv())
                 .await
                 .expect("timeout waiting for inventory event")
         {
-            actual.push(p);
+            actual.push(info.path);
         }
     }
 

--- a/tests/manager_integration.rs
+++ b/tests/manager_integration.rs
@@ -1,6 +1,9 @@
-use rust_photo_frame::events::{Displayed, InventoryEvent, LoadPhoto};
+use rust_photo_frame::config::PlaylistOptions;
+use rust_photo_frame::events::{Displayed, InventoryEvent, LoadPhoto, PhotoInfo};
 use rust_photo_frame::tasks::manager;
+use std::collections::HashSet;
 use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -16,6 +19,7 @@ async fn manager_ignores_spurious_remove_and_sends_load_on_add() {
         displayed_rx,
         to_load_tx,
         cancel.clone(),
+        PlaylistOptions::default(),
     ));
 
     // Spurious remove for path never added
@@ -35,7 +39,10 @@ async fn manager_ignores_spurious_remove_and_sends_load_on_add() {
     // Now add a real file and expect a load
     let real = PathBuf::from("/real/a.jpg");
     inv_tx
-        .send(InventoryEvent::PhotoAdded(real.clone()))
+        .send(InventoryEvent::PhotoAdded(photo_info(
+            real.clone(),
+            SystemTime::now(),
+        )))
         .await
         .unwrap();
 
@@ -61,6 +68,7 @@ async fn manager_rotates_actual_sent_item() {
         displayed_rx,
         to_load_tx,
         cancel.clone(),
+        PlaylistOptions::default(),
     ));
 
     let initial_a = PathBuf::from("/photos/a.jpg");
@@ -68,13 +76,19 @@ async fn manager_rotates_actual_sent_item() {
     let newcomer = PathBuf::from("/photos/new.jpg");
 
     inv_tx
-        .send(InventoryEvent::PhotoAdded(initial_a.clone()))
+        .send(InventoryEvent::PhotoAdded(photo_info(
+            initial_a.clone(),
+            SystemTime::now() - Duration::from_secs(86_400),
+        )))
         .await
         .unwrap();
     assert_eq!(receive_with_timeout(&mut to_load_rx).await, initial_a);
 
     inv_tx
-        .send(InventoryEvent::PhotoAdded(initial_b.clone()))
+        .send(InventoryEvent::PhotoAdded(photo_info(
+            initial_b.clone(),
+            SystemTime::now() - Duration::from_secs(172_800),
+        )))
         .await
         .unwrap();
 
@@ -82,19 +96,35 @@ async fn manager_rotates_actual_sent_item() {
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     inv_tx
-        .send(InventoryEvent::PhotoAdded(newcomer.clone()))
+        .send(InventoryEvent::PhotoAdded(photo_info(
+            newcomer.clone(),
+            SystemTime::now(),
+        )))
         .await
         .unwrap();
 
-    let mut order = Vec::new();
-    for _ in 0..3 {
-        order.push(receive_with_timeout(&mut to_load_rx).await);
+    let mut seen_newcomer = false;
+    let mut seen_older = HashSet::new();
+    for _ in 0..6 {
+        let next = receive_with_timeout(&mut to_load_rx).await;
+        if next == newcomer {
+            seen_newcomer = true;
+        } else {
+            seen_older.insert(next);
+        }
+        if seen_newcomer && seen_older.len() == 2 {
+            break;
+        }
     }
 
     assert!(
-        order.contains(&newcomer),
-        "new photo should be enqueued promptly, got {:?}",
-        order
+        seen_newcomer,
+        "new photo should appear early in the rotation"
+    );
+    assert_eq!(
+        seen_older.len(),
+        2,
+        "all older photos should remain in the cycle"
     );
 
     cancel.cancel();
@@ -107,4 +137,8 @@ async fn receive_with_timeout(rx: &mut mpsc::Receiver<LoadPhoto>) -> PathBuf {
         .expect("timed out waiting for LoadPhoto")
         .expect("loader channel closed unexpectedly");
     path
+}
+
+fn photo_info(path: PathBuf, created_at: SystemTime) -> PhotoInfo {
+    PhotoInfo { path, created_at }
 }


### PR DESCRIPTION
## Summary
- add playlist weighting options with half-life decay and human-friendly durations
- include photo creation timestamps in inventory events and rebuild the playlist with weighted multiplicities
- document the playlist math and update roadmap/config samples

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ce2e9875d08323b92a661827d33ced