### PR TITLE
Add GPIO button task with display control

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde_yaml = "0.9.34"
 humantime-serde = "1.1.1"
 humantime = "2.1.0"
 crossbeam-channel = "0.5.13"
-tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "signal", "sync", "time"] }
+tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "process", "signal", "sync", "time"] }
 tokio-util = "0.7.16"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["fmt", "env-filter"] }
@@ -25,6 +25,8 @@ walkdir = "2.5.0"
 wgpu = { version = "26.0.1", features = ["wgsl"] }
 winit = "0.30.12"
 wgpu_glyph = "0.26.0"
+evdev = { version = "0.12.2", features = ["tokio"] }
+thiserror = "1.0.69"
 
 [dev-dependencies]
 tempfile = "3.22.0"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ button:
   grab-device: true
   output-name: null
   use-wlr-randr: true
-  use-vcgencmd-fallback: true
   shutdown-command: systemctl poweroff
 ```
 
@@ -153,7 +152,6 @@ The `button` table configures the optional momentary button connected to the Ras
 | `grab-device` | boolean | `true` | Attempt to grab the input device exclusively so other handlers do not react to the key. |
 | `output-name` | string or `null` | `null` | Preferred Wayland output name. When `null`, the task auto-detects the first connected output reported by `wlr-randr`. |
 | `use-wlr-randr` | boolean | `true` | Enable display control via `wlr-randr`. |
-| `use-vcgencmd-fallback` | boolean | `true` | Allow falling back to `/usr/bin/vcgencmd display_power` when `wlr-randr` is unavailable or fails. |
 | `shutdown-command` | string | `"systemctl poweroff"` | Command executed for long presses. It is invoked via `sh -c`, so shell features are available. |
 
 Short presses (< `short-max-ms`) toggle the display state. Presses between the short and long thresholds fall in the "dead zone" and are ignored. When a press reaches the long threshold the configured shutdown command runs immediately; the eventual key release is drained from the event stream so the task stays in sync.
@@ -177,8 +175,6 @@ To integrate the Pi 5 power-button header on Raspberry Pi OS (Bookworm) in a Way
    sudo apt update
    sudo apt install -y wlr-randr
    ```
-
-   The app automatically falls back to `/usr/bin/vcgencmd display_power` when enabled.
 
 3. Ensure the user that runs the photo frame belongs to the `input` group so it can read `/dev/input/event*` devices:
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ matting:
   max-upscale-factor: 1.0 # Limit for enlarging images when applying mats
   type: fixed-color
   color: [0, 0, 0]
+
+button:
+  enabled: true
+  device-path: null
+  key-code: KEY_POWER
+  short-max-ms: 2000
+  long-threshold-ms: 8000
+  grab-device: true
+  output-name: null
+  use-wlr-randr: true
+  use-vcgencmd-fallback: true
+  shutdown-command: systemctl poweroff
 ```
 
 ### Top-level keys
@@ -70,6 +82,7 @@ matting:
 | `startup-shuffle-seed` | integer or `null` | `null` | Optional deterministic seed used for the initial photo shuffle. |
 | `playlist` | mapping | see below | Controls how aggressively new photos repeat before settling into the long-term cadence. |
 | `matting` | mapping | see below | Controls how mats are generated around each photo. |
+| `button` | mapping | see below | Configures GPIO button handling, display control, and shutdown behavior. |
 
 ### Playlist weighting
 
@@ -125,6 +138,62 @@ The `matting` table chooses how the background behind each photo is prepared.
 | `sigma` | float | `20.0` | Gaussian blur radius applied to a scaled copy of the photo that covers the screen. |
 | `max-sample-dim` | integer or `null` | `null` (defaults to `2048` on 64-bit ARM builds, otherwise unlimited) | Optional cap on the background texture size used for the blur. When set, the background is downscaled to this maximum dimension before blurring and then upscaled back to the screen size, preserving the soft-focus look while reducing CPU cost on small GPUs. |
 | `backend` | string | `cpu` | Blur implementation to use. Set to `cpu` for the high-quality software renderer (default) or `neon` to request the vector-accelerated path on 64-bit ARM. When `neon` is selected but unsupported at runtime, the code automatically falls back to the CPU backend. |
+
+### GPIO button configuration
+
+The `button` table configures the optional momentary button connected to GPIO3. By default the application listens for the `KEY_POWER` event produced by the kernel's `gpio-keys` device and classifies presses based on duration:
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `enabled` | boolean | `true` | Enables the asynchronous button task. Set to `false` to disable button handling entirely. |
+| `device-path` | string or `null` | `null` | Optional explicit path to the input device (e.g. `/dev/input/event0`). When `null`, the task searches for a device whose name contains both "gpio" and "key". |
+| `key-code` | string | `"KEY_POWER"` | Evdev key code to monitor. The default matches the code emitted by the `gpio-shutdown` overlay. |
+| `short-max-ms` | integer | `2000` | Maximum press duration (in milliseconds) treated as a short press. Short presses toggle the display power state. |
+| `long-threshold-ms` | integer | `8000` | Duration (ms) after which the button triggers an immediate shutdown, even if the key is still held. |
+| `grab-device` | boolean | `true` | Attempt to grab the input device exclusively so other handlers do not react to the key. |
+| `output-name` | string or `null` | `null` | Preferred Wayland output name. When `null`, the task auto-detects the first connected output reported by `wlr-randr`. |
+| `use-wlr-randr` | boolean | `true` | Enable display control via `wlr-randr`. |
+| `use-vcgencmd-fallback` | boolean | `true` | Allow falling back to `/usr/bin/vcgencmd display_power` when `wlr-randr` is unavailable or fails. |
+| `shutdown-command` | string | `"systemctl poweroff"` | Command executed for long presses. It is invoked via `sh -c`, so shell features are available. |
+
+Short presses (< `short-max-ms`) toggle the display state. Presses between the short and long thresholds fall in the "dead zone" and are ignored. When a press reaches the long threshold the configured shutdown command runs immediately; the eventual key release is drained from the event stream so the task stays in sync.
+
+#### Raspberry Pi system setup
+
+To integrate the GPIO button on Raspberry Pi OS (Bookworm) in a Wayland session, perform the following one-time system configuration steps as `root`:
+
+1. Enable the [`gpio-shutdown`](https://www.raspberrypi.com/documentation/computers/config_txt.html#dtoverlay) overlay so the SoC wakes on GPIO3 and reports a debounced `KEY_POWER` event:
+
+   ```ini
+   # /boot/firmware/config.txt
+   dtoverlay=gpio-shutdown,gpio=3,active_low=1,debounce=100
+   ```
+
+2. Prevent `systemd-logind` from handling the power key so the application can manage it:
+
+   ```ini
+   # /etc/systemd/logind.conf
+   HandlePowerKey=ignore
+   ```
+
+   Then restart logind: `sudo systemctl restart systemd-logind`.
+
+3. Install the display control tools:
+
+   ```bash
+   sudo apt update
+   sudo apt install -y wlr-randr
+   ```
+
+   The app automatically falls back to `/usr/bin/vcgencmd display_power` when enabled.
+
+4. Ensure the user that runs the photo frame belongs to the `input` group so it can read `/dev/input/event*` devices:
+
+   ```bash
+   sudo usermod -aG input $USER
+   ```
+
+   Log out and back in (or restart the service) after changing group membership.
 
 ## License
 

--- a/config.yaml
+++ b/config.yaml
@@ -28,3 +28,15 @@ matting:
 #   sigma: 20.0
 #   max-sample-dim: 1536
 #   backend: neon        # options: cpu, neon (defaults to cpu)
+
+button:
+  enabled: true
+  device-path: null
+  key-code: KEY_POWER
+  short-max-ms: 2000
+  long-threshold-ms: 8000
+  grab-device: true
+  output-name: null
+  use-wlr-randr: true
+  use-vcgencmd-fallback: true
+  shutdown-command: systemctl poweroff

--- a/config.yaml
+++ b/config.yaml
@@ -39,5 +39,4 @@ button:
   grab-device: true
   output-name: null
   use-wlr-randr: true
-  use-vcgencmd-fallback: true
   shutdown-command: systemctl poweroff

--- a/config.yaml
+++ b/config.yaml
@@ -31,6 +31,7 @@ matting:
 
 button:
   enabled: true
+  # Leave as null to auto-detect the Pi 5 `pwr_button` device
   device-path: null
   key-code: KEY_POWER
   short-max-ms: 2000

--- a/src/button.rs
+++ b/src/button.rs
@@ -1,0 +1,548 @@
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use evdev::{Device, EventStream, InputEventKind, Key};
+use thiserror::Error;
+use tokio::process::Command;
+use tokio::time::{self, Instant};
+
+use crate::config::ButtonConfig;
+
+const INITIAL_RETRY_DELAY: Duration = Duration::from_secs(1);
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Error)]
+pub enum ButtonTaskError {
+    #[error("unknown key code: {0}")]
+    UnknownKey(String),
+}
+
+pub async fn spawn_button_task(
+    cfg: ButtonConfig,
+    mut shutdown_signal: tokio::sync::oneshot::Receiver<()>,
+) -> Result<()> {
+    if !cfg.enabled {
+        tracing::info!("GPIO button task disabled via configuration");
+        return Ok(());
+    }
+
+    let target_key = parse_key(&cfg.key_code)?;
+
+    let open_fut = open_button_device(&cfg);
+    tokio::pin!(open_fut);
+
+    let mut device = tokio::select! {
+        result = &mut open_fut => result.context("open gpio-keys device")?,
+        _ = &mut shutdown_signal => {
+            tracing::info!("Shutdown requested before GPIO button device was ready");
+            return Ok(());
+        }
+    };
+
+    if cfg.grab_device {
+        if let Err(err) = device.grab() {
+            tracing::warn!("Failed to grab input device: {err}");
+        }
+    }
+
+    let mut stream = device.into_event_stream().context("event stream")?;
+    let mut output = cfg.output_name.clone();
+    if output.is_none() && cfg.use_wlr_randr {
+        output = detect_output().await;
+    }
+    let mut last_known_state: Option<bool> = None;
+
+    loop {
+        tokio::select! {
+            _ = &mut shutdown_signal => {
+                tracing::info!("Button task shutting down");
+                break;
+            }
+            event = stream.next_event() => {
+                let event = match event {
+                    Ok(event) => event,
+                    Err(err) => {
+                        tracing::warn!("Input stream error: {err}");
+                        continue;
+                    }
+                };
+
+                if let InputEventKind::Key(key) = event.kind() {
+                    if key == target_key && event.value() == 1 {
+                        handle_key_down(
+                            &cfg,
+                            &mut stream,
+                            &mut output,
+                            &mut last_known_state,
+                            target_key,
+                        )
+                        .await;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_key_down(
+    cfg: &ButtonConfig,
+    stream: &mut EventStream,
+    output: &mut Option<String>,
+    last_known_state: &mut Option<bool>,
+    target_key: Key,
+) {
+    let start = Instant::now();
+    let long_press = time::sleep(Duration::from_millis(cfg.long_threshold_ms));
+    tokio::pin!(long_press);
+
+    tokio::select! {
+        _ = &mut long_press => {
+            tracing::info!(
+                "Long press >= {}ms → shutdown",
+                cfg.long_threshold_ms
+            );
+            if let Err(err) = run_shutdown(cfg).await {
+                tracing::warn!("Failed to execute shutdown command: {err:?}");
+            }
+            if let Err(err) = wait_for_key_up(stream, target_key).await {
+                tracing::warn!("Failed to drain key release after shutdown trigger: {err:?}");
+            }
+        }
+        event = stream.next_event() => {
+            match event {
+                Ok(event) => {
+                    if let InputEventKind::Key(key) = event.kind() {
+                        if key == target_key && event.value() == 0 {
+                            let elapsed_ms = start.elapsed().as_millis() as u64;
+                            if elapsed_ms < cfg.short_max_ms {
+                                tracing::info!("Short press {}ms → toggle screen", elapsed_ms);
+                                if let Err(err) = toggle_screen(output, last_known_state, cfg).await {
+                                    tracing::warn!("Failed to toggle display: {err:?}");
+                                }
+                            } else {
+                                tracing::info!("Dead-zone press {}ms (ignored)", elapsed_ms);
+                            }
+                        }
+                    }
+                }
+                Err(err) => tracing::warn!("Error awaiting key release: {err}"),
+            }
+        }
+    }
+}
+
+async fn wait_for_key_up(stream: &mut EventStream, target_key: Key) -> Result<()> {
+    loop {
+        let event = stream.next_event().await?;
+        if let InputEventKind::Key(key) = event.kind() {
+            if key == target_key && event.value() == 0 {
+                return Ok(());
+            }
+        }
+    }
+}
+
+fn parse_key(code: &str) -> Result<Key> {
+    Key::from_str(code).map_err(|_| ButtonTaskError::UnknownKey(code.to_string()).into())
+}
+
+async fn open_button_device(cfg: &ButtonConfig) -> Result<Device> {
+    let mut delay = INITIAL_RETRY_DELAY;
+    loop {
+        match try_open_device(cfg) {
+            Ok(device) => return Ok(device),
+            Err(err) => {
+                tracing::warn!(
+                    "GPIO button device unavailable: {err:?}; retrying in {}s",
+                    delay.as_secs()
+                );
+                time::sleep(delay).await;
+                delay = (delay * 2).min(MAX_RETRY_DELAY);
+            }
+        }
+    }
+}
+
+fn try_open_device(cfg: &ButtonConfig) -> Result<Device> {
+    if let Some(path) = cfg.device_path.as_ref() {
+        return Device::open(path).with_context(|| format!("open {}", path.display()));
+    }
+
+    for (path, device) in evdev::enumerate() {
+        if device_matches(&device) {
+            tracing::info!("Using input device {}", path.display());
+            return Device::open(&path).with_context(|| format!("open {}", path.display()));
+        }
+    }
+
+    Err(anyhow!("no gpio-keys input device found"))
+}
+
+fn device_matches(device: &Device) -> bool {
+    let name = device.name().unwrap_or("").to_ascii_lowercase();
+    name.contains("gpio") && name.contains("key")
+}
+
+async fn toggle_screen(
+    output: &mut Option<String>,
+    last_known_state: &mut Option<bool>,
+    cfg: &ButtonConfig,
+) -> Result<()> {
+    if !cfg.use_wlr_randr && !cfg.use_vcgencmd_fallback {
+        tracing::info!("Display toggle requested but no control mechanisms are enabled");
+        return Ok(());
+    }
+
+    if cfg.use_wlr_randr && output.is_none() {
+        if let Some(name) = cfg.output_name.clone() {
+            *output = Some(name);
+        } else {
+            *output = detect_output().await;
+        }
+    }
+
+    let output_name = output.as_deref();
+    let fallback_state = last_known_state.as_ref().copied().unwrap_or(true);
+    let current_state = match screen_is_on(output_name, cfg).await {
+        Ok(state) => {
+            *last_known_state = Some(state);
+            state
+        }
+        Err(err) => {
+            tracing::warn!("Failed to query display state: {err:?}");
+            fallback_state
+        }
+    };
+
+    if current_state {
+        if let Err(err) = turn_off(output_name, cfg).await {
+            return Err(err);
+        }
+        *last_known_state = Some(false);
+    } else {
+        if let Err(err) = turn_on(output_name, cfg).await {
+            return Err(err);
+        }
+        *last_known_state = Some(true);
+    }
+
+    Ok(())
+}
+
+async fn detect_output() -> Option<String> {
+    match query_wlr_outputs().await {
+        Ok(outputs) => outputs
+            .into_iter()
+            .find(|info| info.connected.unwrap_or(true))
+            .map(|info| info.name),
+        Err(err) => {
+            tracing::warn!("Failed to detect display output: {err:?}");
+            None
+        }
+    }
+}
+
+async fn screen_is_on(output_name: Option<&str>, cfg: &ButtonConfig) -> Result<bool> {
+    if cfg.use_wlr_randr {
+        if let Some(name) = output_name {
+            if let Some(state) = query_wlr_output_state(name).await? {
+                return Ok(state);
+            }
+        } else if let Some(name) = detect_output().await {
+            if let Some(state) = query_wlr_output_state(&name).await? {
+                return Ok(state);
+            }
+        }
+    }
+
+    if cfg.use_vcgencmd_fallback {
+        if let Some(state) = query_vcgencmd_state().await? {
+            return Ok(state);
+        }
+    }
+
+    Ok(true)
+}
+
+async fn turn_off(output_name: Option<&str>, cfg: &ButtonConfig) -> Result<()> {
+    let mut last_error: Option<anyhow::Error> = None;
+
+    if cfg.use_wlr_randr {
+        if let Some(name) = output_name {
+            match run_wlr_randr(&["--output", name, "--off"]).await {
+                Ok(()) => return Ok(()),
+                Err(err) => {
+                    tracing::warn!("wlr-randr failed to power off {name}: {err:?}");
+                    last_error = Some(err);
+                }
+            }
+        } else {
+            tracing::warn!("No output name available for wlr-randr --off command");
+        }
+    }
+
+    if cfg.use_vcgencmd_fallback {
+        match run_vcgencmd(false).await {
+            Ok(()) => return Ok(()),
+            Err(err) => {
+                tracing::warn!("vcgencmd display_power 0 failed: {err:?}");
+                last_error = Some(err);
+            }
+        }
+    }
+
+    if let Some(err) = last_error {
+        Err(err)
+    } else {
+        Err(anyhow!("No display control mechanisms succeeded"))
+    }
+}
+
+async fn turn_on(output_name: Option<&str>, cfg: &ButtonConfig) -> Result<()> {
+    let mut last_error: Option<anyhow::Error> = None;
+
+    if cfg.use_wlr_randr {
+        if let Some(name) = output_name {
+            match run_wlr_randr(&["--output", name, "--on"]).await {
+                Ok(()) => return Ok(()),
+                Err(err) => {
+                    tracing::warn!("wlr-randr failed to power on {name}: {err:?}");
+                    last_error = Some(err);
+                }
+            }
+        } else {
+            tracing::warn!("No output name available for wlr-randr --on command");
+        }
+    }
+
+    if cfg.use_vcgencmd_fallback {
+        match run_vcgencmd(true).await {
+            Ok(()) => return Ok(()),
+            Err(err) => {
+                tracing::warn!("vcgencmd display_power 1 failed: {err:?}");
+                last_error = Some(err);
+            }
+        }
+    }
+
+    if let Some(err) = last_error {
+        Err(err)
+    } else {
+        Err(anyhow!("No display control mechanisms succeeded"))
+    }
+}
+
+async fn run_wlr_randr(args: &[&str]) -> Result<()> {
+    let output = Command::new("wlr-randr")
+        .args(args)
+        .output()
+        .await
+        .context("spawn wlr-randr")?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(anyhow!("wlr-randr exited with status {}", output.status))
+    }
+}
+
+async fn run_vcgencmd(power_on: bool) -> Result<()> {
+    let value = if power_on { "1" } else { "0" };
+    let output = Command::new("/usr/bin/vcgencmd")
+        .arg("display_power")
+        .arg(value)
+        .output()
+        .await
+        .context("spawn vcgencmd")?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "vcgencmd display_power {value} exited with status {}",
+            output.status
+        ))
+    }
+}
+
+async fn run_shutdown(cfg: &ButtonConfig) -> Result<()> {
+    let status = Command::new("sh")
+        .arg("-c")
+        .arg(cfg.shutdown_command.as_str())
+        .status()
+        .await
+        .context("spawn shutdown command")?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(anyhow!("shutdown command exited with status {status}"))
+    }
+}
+
+#[derive(Debug)]
+struct WlrOutputInfo {
+    name: String,
+    connected: Option<bool>,
+    enabled: Option<bool>,
+    has_current_mode: bool,
+}
+
+async fn query_wlr_outputs() -> Result<Vec<WlrOutputInfo>> {
+    let output = Command::new("wlr-randr")
+        .output()
+        .await
+        .context("spawn wlr-randr")?;
+
+    if !output.status.success() {
+        return Err(anyhow!("wlr-randr exited with status {}", output.status));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_wlr_outputs(&stdout))
+}
+
+fn parse_wlr_outputs(stdout: &str) -> Vec<WlrOutputInfo> {
+    let mut outputs = Vec::new();
+    let mut current: Option<WlrOutputInfo> = None;
+
+    for line in stdout.lines() {
+        if let Some(info) = parse_header_line(line) {
+            if let Some(prev) = current.take() {
+                outputs.push(prev);
+            }
+            current = Some(info);
+            continue;
+        }
+
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        if let Some(info) = current.as_mut() {
+            parse_detail_line(info, line.trim());
+        }
+    }
+
+    if let Some(info) = current {
+        outputs.push(info);
+    }
+
+    outputs
+}
+
+fn parse_header_line(line: &str) -> Option<WlrOutputInfo> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Some(rest) = trimmed.strip_prefix("Output") {
+        let name = rest.trim_start_matches(':').trim();
+        if !name.is_empty() {
+            return Some(WlrOutputInfo {
+                name: name.to_string(),
+                connected: None,
+                enabled: None,
+                has_current_mode: false,
+            });
+        }
+    }
+
+    if !line.starts_with(' ') {
+        let mut parts = trimmed.split_whitespace();
+        if let Some(name) = parts.next() {
+            let mut info = WlrOutputInfo {
+                name: name.trim_matches('"').to_string(),
+                connected: None,
+                enabled: None,
+                has_current_mode: false,
+            };
+
+            for token in parts {
+                let lower = token.to_ascii_lowercase();
+                if lower.contains("connected") {
+                    info.connected = Some(true);
+                } else if lower.contains("disconnected") {
+                    info.connected = Some(false);
+                }
+            }
+
+            return Some(info);
+        }
+    }
+
+    None
+}
+
+fn parse_detail_line(info: &mut WlrOutputInfo, line: &str) {
+    let lower = line.to_ascii_lowercase();
+
+    if lower.starts_with("enabled:") {
+        if let Some(value) = line.split(':').nth(1) {
+            let value = value.trim().to_ascii_lowercase();
+            if value.starts_with('y') || value == "on" || value == "true" {
+                info.enabled = Some(true);
+            } else if value.starts_with('n') || value == "off" || value == "false" {
+                info.enabled = Some(false);
+            }
+        }
+    } else if lower.starts_with("current mode") {
+        info.has_current_mode = true;
+    } else if lower.contains("connected") {
+        if lower.contains("disconnected") {
+            info.connected = Some(false);
+        } else {
+            info.connected = Some(true);
+        }
+    }
+}
+
+async fn query_wlr_output_state(name: &str) -> Result<Option<bool>> {
+    let outputs = query_wlr_outputs().await?;
+    for info in outputs {
+        if info.name == name {
+            if let Some(enabled) = info.enabled {
+                return Ok(Some(enabled));
+            }
+            if let Some(connected) = info.connected {
+                if !connected {
+                    return Ok(Some(false));
+                }
+            }
+            if info.has_current_mode {
+                return Ok(Some(true));
+            }
+            return Ok(None);
+        }
+    }
+    Ok(None)
+}
+
+async fn query_vcgencmd_state() -> Result<Option<bool>> {
+    let output = Command::new("/usr/bin/vcgencmd")
+        .arg("display_power")
+        .output()
+        .await
+        .context("spawn vcgencmd")?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if let Some(rest) = line.split('=').nth(1) {
+            match rest.trim() {
+                "1" => return Ok(Some(true)),
+                "0" => return Ok(Some(false)),
+                _ => {}
+            }
+        }
+    }
+
+    Ok(None)
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,7 +110,6 @@ pub struct ButtonConfig {
     pub grab_device: bool,
     pub output_name: Option<String>,
     pub use_wlr_randr: bool,
-    pub use_vcgencmd_fallback: bool,
     pub shutdown_command: String,
 }
 
@@ -125,7 +124,6 @@ impl Default for ButtonConfig {
             grab_device: true,
             output_name: None,
             use_wlr_randr: true,
-            use_vcgencmd_fallback: true,
             shutdown_command: "systemctl poweroff".to_string(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod button;
 pub mod config;
 pub mod events;
 pub mod processing;


### PR DESCRIPTION
## Summary
- add an async GPIO button task that monitors KEY_POWER presses and triggers screen toggles or shutdowns based on duration
- integrate display power helpers with wlr-randr and vcgencmd fallbacks configurable through a new button section in the config
- document the Raspberry Pi system setup required for GPIO3 wake handling and describe the new configuration options

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cf43d903a08323b689025e8408cbd8