### PR TITLE
Add optional power button override setup module

### DIFF
--- a/setup/Instructions.md
+++ b/setup/Instructions.md
@@ -69,7 +69,7 @@ This workflow prepares a Raspberry Pi OS (Bookworm, 64-bit) image that boots dir
    ```bash
    chmod +x setup/system-setup.sh setup/setup-modules/*.sh
    ```
-3. Run the system configuration wrapper. It executes each module in ascending numeric order:
+3. Run the system configuration wrapper. It executes each module in ascending numeric order and will prompt for optional features (such as the power button override) before running them:
    ```bash
    sudo ./setup/system-setup.sh
    ```

--- a/setup/setup-modules/10-power-button-override.optional.sh
+++ b/setup/setup-modules/10-power-button-override.optional.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODULE_NAME="[10-power-button-override]"
+
+echo "${MODULE_NAME} Configuring power button override..."
+
+TARGET_USER="${SUDO_USER:-$USER}"
+TARGET_HOME="$(eval echo ~"${TARGET_USER}")"
+TARGET_GROUP="$(id -gn "${TARGET_USER}")"
+
+run_as_target() {
+    local command="$1"
+    if [[ "${TARGET_USER}" == "root" ]]; then
+        bash -lc "${command}"
+    else
+        sudo -u "${TARGET_USER}" bash -lc "${command}"
+    fi
+}
+
+require_file_copy() {
+    local source="$1"
+    local destination="$2"
+    local mode="$3"
+    local owner="$4"
+    local group="$5"
+
+    if [[ -f "${source}" ]]; then
+        install -o "${owner}" -g "${group}" -m "${mode}" "${source}" "${destination}"
+        return 0
+    fi
+    return 1
+}
+
+CONFIG_DIR="${TARGET_HOME}/.config"
+AUTOSTART_DIR="${CONFIG_DIR}/autostart"
+AUTOSTART_FILE="${AUTOSTART_DIR}/pwrkey.desktop"
+LABWC_DIR="${CONFIG_DIR}/labwc"
+LABWC_RC="${LABWC_DIR}/rc.xml"
+
+install -d -o "${TARGET_USER}" -g "${TARGET_GROUP}" "${AUTOSTART_DIR}"
+
+if ! require_file_copy "/etc/xdg/autostart/pwrkey.desktop" "${AUTOSTART_FILE}" 644 "${TARGET_USER}" "${TARGET_GROUP}"; then
+    if [[ ! -f "${AUTOSTART_FILE}" ]]; then
+        cat <<'DESKTOP' > "${AUTOSTART_FILE}"
+[Desktop Entry]
+Type=Application
+Name=pwrkey
+Exec=pwrkey
+DESKTOP
+        chown "${TARGET_USER}:${TARGET_GROUP}" "${AUTOSTART_FILE}"
+        chmod 644 "${AUTOSTART_FILE}"
+    fi
+fi
+
+echo "${MODULE_NAME} Ensuring pwrkey autostart entry is hidden."
+if [[ -f "${AUTOSTART_FILE}" ]]; then
+    if grep -q '^Hidden=' "${AUTOSTART_FILE}"; then
+        sed -i 's/^Hidden=.*/Hidden=true/' "${AUTOSTART_FILE}"
+    else
+        printf '\nHidden=true\n' >> "${AUTOSTART_FILE}"
+    fi
+    chown "${TARGET_USER}:${TARGET_GROUP}" "${AUTOSTART_FILE}"
+fi
+
+install -d -o "${TARGET_USER}" -g "${TARGET_GROUP}" "${LABWC_DIR}"
+if require_file_copy "/etc/xdg/labwc/rc.xml" "${LABWC_RC}" 644 "${TARGET_USER}" "${TARGET_GROUP}"; then
+    echo "${MODULE_NAME} Overriding Labwc power button command."
+    sed -i 's|<command>pwrkey</command>|<command>/usr/bin/false</command>|g' "${LABWC_RC}"
+else
+    echo "${MODULE_NAME} [WARN] /etc/xdg/labwc/rc.xml not found. Skipping Labwc override." >&2
+fi
+
+if command -v systemctl >/dev/null 2>&1; then
+    echo "${MODULE_NAME} Masking user-level pwrkey autostart service (if present)."
+    run_as_target "systemctl --user mask app-pwrkey@autostart.service" || true
+    run_as_target "systemctl --user daemon-reload" || true
+else
+    echo "${MODULE_NAME} [WARN] systemctl not available. Skipping user service mask." >&2
+fi
+
+UDEV_RULE="/etc/udev/rules.d/99-pwr-button.rules"
+echo "${MODULE_NAME} Installing udev rule at ${UDEV_RULE}."
+cat <<'RULE' > "${UDEV_RULE}"
+SUBSYSTEM=="input", KERNEL=="event*", ATTRS{name}=="pwr_button", SYMLINK+="input/pwr_button", GROUP="input", MODE="0660"
+RULE
+chmod 644 "${UDEV_RULE}"
+
+if command -v udevadm >/dev/null 2>&1; then
+    echo "${MODULE_NAME} Reloading udev rules and triggering input subsystem."
+    udevadm control --reload-rules
+    udevadm trigger -s input
+else
+    echo "${MODULE_NAME} [WARN] udevadm not available. Please reload rules manually." >&2
+fi
+
+if [[ -e /dev/input/pwr_button ]]; then
+    ls -l /dev/input/pwr_button
+else
+    echo "${MODULE_NAME} /dev/input/pwr_button not present (will appear after compatible hardware initializes)."
+fi
+
+echo "${MODULE_NAME} Adding ${TARGET_USER} to input group."
+usermod -aG input "${TARGET_USER}"
+
+echo "${MODULE_NAME} Power button override configuration complete."

--- a/setup/system-setup.sh
+++ b/setup/system-setup.sh
@@ -23,8 +23,63 @@ if [[ ${#MODULES[@]} -eq 0 ]]; then
     exit 0
 fi
 
-echo "[INFO] Executing setup modules from ${MODULE_DIR}" 
+prompt_yes_no() {
+    local prompt="$1"
+    local default_choice="$2"
+    local suffix="[y/N]"
+
+    if [[ "${default_choice}" == "Y" ]]; then
+        suffix="[Y/n]"
+    fi
+
+    while true; do
+        local response
+        if read -r -p "${prompt} ${suffix} " response </dev/tty; then
+            if [[ -z "${response}" ]]; then
+                if [[ "${default_choice}" == "Y" ]]; then
+                    return 0
+                else
+                    return 1
+                fi
+            fi
+
+            case "${response}" in
+                [Yy]*)
+                    return 0
+                    ;;
+                [Nn]*)
+                    return 1
+                    ;;
+            esac
+        fi
+        echo "Please answer yes or no (y/n)."
+    done
+}
+
+RUN_MODULES=()
+
 for module in "${MODULES[@]}"; do
+    case "$(basename "${module}")" in
+        10-power-button-override.optional.sh)
+            if prompt_yes_no "[OPTIONAL] Enable the power button override module?" "N"; then
+                RUN_MODULES+=("${module}")
+            else
+                echo "[INFO] Skipping optional module $(basename "${module}")."
+            fi
+            ;;
+        *)
+            RUN_MODULES+=("${module}")
+            ;;
+    esac
+done
+
+if [[ ${#RUN_MODULES[@]} -eq 0 ]]; then
+    echo "[WARN] No setup modules selected. Nothing to do."
+    exit 0
+fi
+
+echo "[INFO] Executing setup modules from ${MODULE_DIR}"
+for module in "${RUN_MODULES[@]}"; do
     echo "[INFO] Running $(basename "${module}")"
     if [[ ! -x "${module}" ]]; then
         echo "[INFO] Making module executable"


### PR DESCRIPTION
## Summary
- prompt for optional setup modules when running the system setup wrapper
- add a power button override module that neutralizes the default handler and provisions a persistent udev rule
- document the optional prompt behavior in the setup instructions

## Testing
- shellcheck setup/system-setup.sh setup/setup-modules/10-power-button-override.optional.sh *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf7dc453188323917355320db4122e