### PR TITLE
Stabilize playlist rebuild iteration order

### DIFF
--- a/src/tasks/manager.rs
+++ b/src/tasks/manager.rs
@@ -150,7 +150,10 @@ impl PlaylistState {
         let mut rest: Vec<PathBuf> = Vec::new();
         let mut multiplicities: Vec<(PathBuf, usize)> = Vec::new();
 
-        for info in self.known.values() {
+        let mut infos: Vec<&PhotoInfo> = self.known.values().collect();
+        infos.sort_by(|a, b| a.path.cmp(&b.path));
+
+        for info in infos {
             let multiplicity = self.options.multiplicity_for(info.created_at, now);
             if multiplicity == 0 {
                 continue;


### PR DESCRIPTION
## Summary
- ensure playlist rebuild iterates over known photos in a deterministic order by sorting paths before weighting

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cf80d0e33c8323983ed0870c7679b9