### PR TITLE
Restore matting defaults and inline overrides

### DIFF
--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -84,7 +84,11 @@ matting:
 
     let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
 
-    match cfg.matting.style {
+    let mat = cfg
+        .matting
+        .primary_option()
+        .expect("expected primary matting option");
+    match mat.style {
         rust_photo_frame::config::MattingMode::Studio {
             texture_strength, ..
         } => {
@@ -106,7 +110,11 @@ matting:
 
     let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
 
-    match cfg.matting.style {
+    let mat = cfg
+        .matting
+        .primary_option()
+        .expect("expected primary matting option");
+    match mat.style {
         rust_photo_frame::config::MattingMode::Studio {
             warp_period_px,
             weft_period_px,


### PR DESCRIPTION
## Summary
- add support for studio matting defaults for texture strength and weave periods in MattingOptions builders
- allow MattingConfig to parse inline matting fields when selecting a fixed matting type, while still validating random selections
- update config tests to inspect the resolved primary matting option and cover inline overrides

## Testing
- cargo fmt
- cargo clippy
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68d208422dc083239898513c0e793d60