### PR TITLE
Implement configurable slideshow transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,21 @@ Place a YAML file and pass its path as the CLI argument. Example:
 photo-library-path: /path/to/photos
 
 # Render/transition settings
-fade-ms: 400 # Cross-fade duration (ms)
+transition:
+  type: fade # fade, wipe, push, or random
+  duration-ms: 400 # Transition duration (ms)
+  fade:
+    through-black: false # Optional fade-to-black midpoint
+  wipe:
+    angle-deg: 0.0 # Angle of the wipe front
+    softness-px: 32.0 # Soft-edge width
+    reverse: false # Flip wipe direction
+  push:
+    direction: left # Slide direction for push transitions
+  random:
+    fade-weight: 1.0 # Relative chance of picking fade
+    wipe-weight: 1.0 # Relative chance of picking wipe
+    push-weight: 1.0 # Relative chance of picking push
 dwell-ms: 2000 # Time an image remains fully visible (ms)
 viewer-preload-count: 3 # Images the viewer preloads; also sets viewer channel capacity
 loader-max-concurrent-decodes: 4 # Concurrent decodes in the loader
@@ -67,14 +81,32 @@ matting:
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | `photo-library-path` | string | `""` | Root directory that will be scanned recursively for photos. |
-| `fade-ms` | integer | `400` | Cross-fade transition duration in milliseconds. |
-| `dwell-ms` | integer | `2000` | Time an image remains fully visible before the next fade begins. |
+| `transition` | mapping | see below | Controls which transition mode is active and its parameters. |
+| `dwell-ms` | integer | `2000` | Time an image remains fully visible before the next transition begins. |
 | `viewer-preload-count` | integer | `3` | Number of prepared images the viewer keeps queued; controls GPU upload backlog. |
 | `loader-max-concurrent-decodes` | integer | `4` | Maximum number of CPU decodes that can run in parallel. |
 | `oversample` | float | `1.0` | Render target scale relative to the screen; values >1.0 reduce aliasing but cost GPU time. |
 | `startup-shuffle-seed` | integer or `null` | `null` | Optional deterministic seed used for the initial photo shuffle. |
 | `playlist` | mapping | see below | Controls how aggressively new photos repeat before settling into the long-term cadence. |
 | `matting` | mapping | see below | Controls how mats are generated around each photo. |
+| `transition` | mapping | see below | Chooses the transition mode between photos and its tuning parameters. |
+
+### Transition configuration
+
+The `transition` block mirrors the matting configuration style: set `transition.type` to one of the supported modes, then tune that mode's sub-table. When `transition.type` is `random`, the viewer shuffles between the configured modes according to the weights in `transition.random`.
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `type` | string | `fade` | Active transition. Use `fade`, `wipe`, `push`, or `random`. |
+| `duration-ms` | integer | `400` | Duration of the transition animation. Must be greater than zero. |
+| `fade.through-black` | boolean | `false` | When enabled the fade darkens to black before revealing the next image. |
+| `wipe.angle-deg` | float | `0.0` | Angle (in degrees) of the wipe front measured clockwise from the positive X axis. |
+| `wipe.softness-px` | float | `32.0` | Width of the feathered edge along the wipe front, in pixels. Set to `0` for a hard edge. |
+| `wipe.reverse` | boolean | `false` | When `true`, the wipe travels in the opposite direction. |
+| `push.direction` | string | `left` | Direction the outgoing photo travels. Use `left`, `right`, `up`, or `down`. |
+| `random.fade-weight` | float | `1.0` | Relative probability of choosing the fade effect when `transition.type` is `random`. |
+| `random.wipe-weight` | float | `1.0` | Relative probability of choosing the wipe effect when `transition.type` is `random`. |
+| `random.push-weight` | float | `1.0` | Relative probability of choosing the push effect when `transition.type` is `random`. |
 
 ### Playlist weighting
 

--- a/assets/sample-config.yaml
+++ b/assets/sample-config.yaml
@@ -5,9 +5,23 @@
 photo-library-path: /absolute/path/to/your/photo/library
 
 # Render/transition settings
-# Cross-fade duration in milliseconds
-fade-ms: 400
-# Dwell time (ms) the current image remains fully displayed before fading
+# Transition configuration (select fade, wipe, push, or random)
+transition:
+  type: random
+  duration-ms: 400
+  fade:
+    through-black: false
+  wipe:
+    angle-deg: 0.0
+    softness-px: 32.0
+    reverse: false
+  push:
+    direction: left
+  random:
+    fade-weight: 1.0
+    wipe-weight: 1.0
+    push-weight: 1.0
+# Dwell time (ms) the current image remains fully displayed before transitioning
 dwell-ms: 2000
 
 # Viewer buffering and pipeline backpressure

--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,23 @@
 photo-library-path: /Users/vincent/rust-photo-frame/photo-library-test
 
 # Render/transition settings
-# Cross-fade duration in milliseconds
-fade-ms: 400
-# Dwell time (ms) the current image remains fully displayed before fading
+# Transition configuration (type plus per-mode knobs)
+transition:
+  type: random # fade, wipe, push, or random
+  duration-ms: 400
+  fade:
+    through-black: false
+  wipe:
+    angle-deg: 0.0
+    softness-px: 32.0
+    reverse: false
+  push:
+    direction: left # left, right, up, down
+  random:
+    fade-weight: 1.0
+    wipe-weight: 1.0
+    push-weight: 1.0
+# Dwell time (ms) the current image remains fully displayed before transitioning
 dwell-ms: 2000
 # Number of images to preload in the viewer (aligns with channel capacity)
 viewer-preload-count: 3

--- a/src/tasks/shaders/viewer_quad.wgsl
+++ b/src/tasks/shaders/viewer_quad.wgsl
@@ -1,15 +1,15 @@
 struct Uniforms {
-  screen_w: f32,
-  screen_h: f32,
-  dest_x: f32,
-  dest_y: f32,
-  dest_w: f32,
-  dest_h: f32,
-  alpha: f32,
-  _pad0: f32,
-  _pad1: f32,
-  _pad2: f32,
+  screen: vec4<f32>,
+  dest: vec4<f32>,
+  factors: vec4<f32>,
+  wipe_main: vec4<f32>,
+  wipe_aux: vec4<f32>,
 };
+
+const MODE_HOLD: u32 = 0u;
+const MODE_FADE: u32 = 1u;
+const MODE_WIPE: u32 = 2u;
+const MODE_PUSH: u32 = 3u;
 
 @group(0) @binding(0)
 var<uniform> U: Uniforms;
@@ -37,11 +37,11 @@ fn vs_main(@builtin(vertex_index) vid: u32) -> VSOut {
   );
 
   let p = positions[vid];
-  let px = U.dest_x + p.x * U.dest_w;
-  let py = U.dest_y + p.y * U.dest_h;
+  let px = U.dest.x + p.x * U.dest.z;
+  let py = U.dest.y + p.y * U.dest.w;
   // Convert from pixels to NDC (-1..1)
-  let ndc_x = (px / U.screen_w) * 2.0 - 1.0;
-  let ndc_y = 1.0 - (py / U.screen_h) * 2.0;
+  let ndc_x = (px / U.screen.x) * 2.0 - 1.0;
+  let ndc_y = 1.0 - (py / U.screen.y) * 2.0;
 
   var out: VSOut;
   out.pos = vec4<f32>(ndc_x, ndc_y, 0.0, 1.0);
@@ -53,5 +53,22 @@ fn vs_main(@builtin(vertex_index) vid: u32) -> VSOut {
 @fragment
 fn fs_main(in: VSOut) -> @location(0) vec4<f32> {
   let c = textureSample(t_tex, t_samp, in.uv);
-  return vec4<f32>(c.rgb, U.alpha);
+  let mode = u32(U.factors.z + 0.5);
+  let is_next = U.factors.w > 0.5;
+  var alpha = clamp(U.factors.x, 0.0, 1.0);
+  if (mode == MODE_WIPE && is_next) {
+    let dir = normalize(vec2<f32>(U.wipe_main.x, U.wipe_main.y));
+    let local = vec2<f32>(in.uv.x * U.dest.z, in.uv.y * U.dest.w);
+    let proj = dot(local, dir);
+    let start = U.wipe_main.z;
+    let range = max(U.wipe_main.w, 1e-5);
+    let threshold = start + clamp(U.factors.y, 0.0, 1.0) * range;
+    let softness = max(U.wipe_aux.x, 0.0);
+    if (softness <= 0.0) {
+      alpha = select(0.0, 1.0, proj >= threshold);
+    } else {
+      alpha = smoothstep(threshold - softness, threshold + softness, proj);
+    }
+  }
+  return vec4<f32>(c.rgb, clamp(alpha, 0.0, 1.0));
 }


### PR DESCRIPTION
## Summary
- add a transition configuration surface with fade, wipe, push, and random modes
- refactor the viewer and WGSL shader to drive the new transition types without the initial black flash
- document the transition options, update sample configs, and cover parsing with new config tests
- remove the stray XML sample config and its documentation reference so YAML remains the single source

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d210a571ec832397a55c44ffa67323