### PR TITLE
Fix WGSL reserved keyword usage in viewer shader

### DIFF
--- a/src/tasks/shaders/viewer_quad.wgsl
+++ b/src/tasks/shaders/viewer_quad.wgsl
@@ -97,8 +97,8 @@ fn fs_main(in: VSOut) -> @location(0) vec4<f32> {
         let leading = clamp(progress - softness, 0.0, progress);
         let trailing = clamp(progress + softness, progress, 1.0);
         let end = max(trailing, leading + 1e-3);
-        let smooth = smoothstep(leading, end, normalized);
-        mask = 1.0 - smooth;
+        let smooth_mask = smoothstep(leading, end, normalized);
+        mask = 1.0 - smooth_mask;
       }
       color = current * (1.0 - mask) + next * mask;
     }


### PR DESCRIPTION
## Summary
- rename the temporary wipe mask value in `viewer_quad.wgsl` so that it no longer uses the WGSL reserved keyword `smooth`
- keep the transition mask logic identical while avoiding runtime shader compilation errors

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d35ba7d6748323a9d080b9cb0c42eb