### PR TITLE
Add e-ink style transition

### DIFF
--- a/assets/sample-config.yaml
+++ b/assets/sample-config.yaml
@@ -9,6 +9,14 @@ photo-library-path: /absolute/path/to/your/photo/library
 transition:
   type: fade
   duration-ms: 400
+  # Example: enable the e-ink slow refresh effect.
+  # type: fixed
+  # options:
+  #   e-ink:
+  #     duration-ms: 1600
+  #     flash-count: 3
+  #     reveal-portion: 0.55
+  #     stripe-count: 24
 # Dwell time (ms) the current image remains fully displayed before the next transition
 dwell-ms: 2000
 

--- a/src/tasks/shaders/viewer_quad.wgsl
+++ b/src/tasks/shaders/viewer_quad.wgsl
@@ -111,12 +111,43 @@ fn fs_main(in: VSOut) -> @location(0) vec4<f32> {
       let mask = step(0.5, next.a);
       color = current * (1.0 - mask) + next * mask;
     }
+    case 4u: {
+      let flashes = max(U.params0.x, 0.0);
+      let reveal_start = clamp(U.params0.y, 0.05, 0.95);
+      let stripes = max(U.params0.z, 1.0);
+      let seed = U.params1.xy;
+      let prep_ratio = progress / max(reveal_start, 1e-3);
+      if (progress < reveal_start) {
+        let segments = flashes * 2.0 + 1.0;
+        let staged = clamp(floor(prep_ratio * segments), 0.0, segments);
+        let stage_u = u32(staged);
+        var flash_color = current;
+        if (stage_u > 0u) {
+          let toggle = (stage_u & 1u) == 1u;
+          let tone = select(1.0, 0.0, toggle);
+          flash_color = vec4<f32>(vec3<f32>(tone), 1.0);
+        }
+        let stage_pos = fract(prep_ratio * segments);
+        let flash_mix = smoothstep(0.15, 0.85, stage_pos);
+        color = mix(current, flash_color, clamp(flash_mix, 0.0, 1.0));
+      } else {
+        let reveal_ratio = (progress - reveal_start) / max(1.0 - reveal_start, 1e-3);
+        let stripe_idx = floor(in.screen_uv.y * stripes);
+        let stripe_phase = stripe_idx / stripes;
+        let noise_vec = vec2<f32>(stripe_idx, floor(in.screen_uv.x * stripes)) + seed;
+        let noise = fract(sin(dot(noise_vec, vec2<f32>(12.9898, 78.233))) * 43758.5453);
+        let gate = clamp(reveal_ratio * 1.15 - stripe_phase * 0.85 + noise * 0.25, 0.0, 1.0);
+        let mask = smoothstep(0.25, 0.75, gate);
+        let ghost = mix(current, vec4<f32>(1.0, 1.0, 1.0, 1.0), 0.55);
+        color = mix(ghost, next, mask);
+      }
+    }
     default: {
       color = current;
     }
   }
   var alpha = max(max(current.a, next.a), color.a);
-  if (U.kind == 1u && U.params0.x > 0.5) {
+  if ((U.kind == 1u && U.params0.x > 0.5) || U.kind == 4u) {
     alpha = 1.0;
   }
   return vec4<f32>(color.rgb, clamp(alpha, 0.0, 1.0));


### PR DESCRIPTION
## Summary
- extend the transition configuration with a new `e-ink` option and defaults
- implement GPU-side logic to render a slow-refresh inspired transition with flashes and noisy stripes
- expose configuration knobs and document sample usage in the bundled config

## Testing
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68d36aa5c9088323ab68ee56c6e98a12