### PR TITLE
Add configurable photo realism effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ matting:
     blur:
       minimum-mat-percentage: 4.0
       sigma: 18.0
+photo-effects:
+  paper-simulation:
+    strength: 0.03
+    texture-period-px: 18.0
+  light-falloff:
+    strength: 0.18
+    radius: 0.9
+    softness: 0.4
+  adaptive-sharpening:
+    base-sigma: 0.35
+    reference-diagonal-px: 1600.0
+    max-sigma: 0.6
 ```
 
 ### Top-level keys
@@ -116,6 +128,7 @@ matting:
 | `startup-shuffle-seed` | integer or `null` | `null` | Optional deterministic seed used for the initial photo shuffle. |
 | `playlist` | mapping | see below | Controls how aggressively new photos repeat before settling into the long-term cadence. |
 | `matting` | mapping | see below | Controls how mats are generated around each photo. |
+| `photo-effects` | mapping | disabled | Optional post-scaling adjustments applied to the photo (paper texture, vignette, softening). |
 
 ### Playlist weighting
 
@@ -262,6 +275,36 @@ The studio mat derives a uniform base color from the photo’s average RGB, rend
 | `fit` | string | `cover` | How the background image is scaled to the canvas. Options: `cover` (default, fills while cropping as needed), `contain` (letterboxes to preserve the whole image), or `stretch` (distorts to exactly fill). |
 
 The fixed background image is loaded once at startup and reused for every slide, ensuring smooth transitions even with large source files.
+
+### Photo effects configuration
+
+The optional `photo-effects` table tweaks the photo itself after it has been scaled to its display size. Every effect is opt-in;
+ omit the mapping (or set `enabled: false`) to disable an effect. Multiple effects can run together.
+
+#### `paper-simulation`
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `strength` | float | `0.04` | Multiplies each pixel by a subtle texture (0.0 disables, clamped to ≤0.05). |
+| `texture-period-px` | float | `18.0` | Size of the repeating noise cell in pixels; scaled by the render oversample factor. |
+| `seed` | integer | `0` | Optional deterministic seed to vary the procedural texture between frames. |
+
+#### `light-falloff`
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `strength` | float | `0.16` | How strongly the vignette darkens the corners (0.0 disables). |
+| `radius` | float | `0.85` | Radius (as a fraction of the smallest screen dimension) where the falloff begins. |
+| `softness` | float | `0.45` | Width of the feathered region between the inner radius and full vignette. |
+
+#### `adaptive-sharpening`
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `base-sigma` | float | `0.35` | Baseline Gaussian blur applied at the reference diagonal. |
+| `reference-diagonal-px` | float | `1600.0` | Diagonal resolution that receives the base blur. Larger photos soften proportionally. |
+| `scale-power` | float | `1.0` | Exponent applied to the resolution ratio when scaling the blur radius. |
+| `max-sigma` | float | `0.8` | Upper bound for the blur radius after scaling. |
 
 ## References
 

--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,20 @@ loader-max-concurrent-decodes: 4
 # Optional deterministic seed for the initial shuffle (set to null for random)
 startup-shuffle-seed: null
 
+photo-effects:
+  paper-simulation:
+    strength: 0.03
+    texture-period-px: 18.0
+  light-falloff:
+    strength: 0.18
+    radius: 0.9
+    softness: 0.4
+  adaptive-sharpening:
+    base-sigma: 0.35
+    scale-power: 1.0
+    reference-diagonal-px: 1600.0
+    max-sigma: 0.6
+
 playlist:
   new-multiplicity: 3
   half-life: 3 days

--- a/src/processing/mod.rs
+++ b/src/processing/mod.rs
@@ -2,3 +2,4 @@ pub mod blur;
 pub mod color;
 pub mod fixed_image;
 pub mod layout;
+pub mod photo_effects;

--- a/src/processing/photo_effects.rs
+++ b/src/processing/photo_effects.rs
@@ -1,0 +1,125 @@
+use image::{imageops, RgbaImage};
+
+use crate::config::{
+    AdaptiveSharpeningConfig, LightFalloffConfig, PaperSimulationConfig, PhotoEffectsConfig,
+};
+
+pub fn apply_photo_effects(image: &mut RgbaImage, cfg: &PhotoEffectsConfig, oversample: f32) {
+    if let Some(paper) = cfg.paper_simulation() {
+        apply_paper_simulation(image, paper, oversample);
+    }
+    if let Some(vignette) = cfg.light_falloff() {
+        apply_light_falloff(image, vignette);
+    }
+    if let Some(softening) = cfg.adaptive_sharpening() {
+        apply_adaptive_softening(image, softening);
+    }
+}
+
+fn apply_paper_simulation(image: &mut RgbaImage, cfg: &PaperSimulationConfig, oversample: f32) {
+    let strength = cfg.strength().max(0.0);
+    if strength <= f32::EPSILON {
+        return;
+    }
+    let scale = cfg.texture_period_px().max(1.0) * oversample.max(0.01);
+    let seed = cfg.seed();
+    let mut noise = SmoothNoise::new(scale, seed);
+    for (x, y, pixel) in image.enumerate_pixels_mut() {
+        let factor = 1.0 - strength + strength * noise.sample(x, y);
+        for channel in &mut pixel.0[..3] {
+            let v = (*channel as f32) * factor;
+            *channel = v.clamp(0.0, 255.0) as u8;
+        }
+    }
+}
+
+fn apply_light_falloff(image: &mut RgbaImage, cfg: &LightFalloffConfig) {
+    let strength = cfg.strength().max(0.0);
+    if strength <= f32::EPSILON {
+        return;
+    }
+    let width = image.width() as f32;
+    let height = image.height() as f32;
+    if width <= 0.0 || height <= 0.0 {
+        return;
+    }
+    let center_x = (width - 1.0) * 0.5;
+    let center_y = (height - 1.0) * 0.5;
+    let half_min = 0.5 * width.min(height).max(1.0);
+    let inner = (cfg.radius() * half_min).max(0.0);
+    let falloff = (cfg.softness() * half_min).max(1.0);
+    let outer = (inner + falloff).max(inner + 1.0);
+    for (x, y, pixel) in image.enumerate_pixels_mut() {
+        let dx = x as f32 - center_x;
+        let dy = y as f32 - center_y;
+        let dist = f32::sqrt(dx * dx + dy * dy);
+        let mut factor = 1.0;
+        if dist > inner {
+            let t = ((dist - inner) / (outer - inner)).clamp(0.0, 1.0);
+            let eased = smoothstep(t);
+            factor = 1.0 - strength * eased;
+        }
+        for channel in &mut pixel.0[..3] {
+            let v = (*channel as f32) * factor;
+            *channel = v.clamp(0.0, 255.0) as u8;
+        }
+    }
+}
+
+fn apply_adaptive_softening(image: &mut RgbaImage, cfg: &AdaptiveSharpeningConfig) {
+    let sigma = cfg.effective_sigma(image.width(), image.height());
+    if sigma <= f32::EPSILON {
+        return;
+    }
+    let blurred = imageops::blur(image, sigma);
+    *image = blurred;
+}
+
+fn smoothstep(t: f32) -> f32 {
+    let t = t.clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+struct SmoothNoise {
+    scale: f32,
+    seed: u64,
+}
+
+impl SmoothNoise {
+    fn new(scale: f32, seed: u64) -> Self {
+        Self { scale, seed }
+    }
+
+    fn sample(&mut self, x: u32, y: u32) -> f32 {
+        let fx = (x as f32) / self.scale;
+        let fy = (y as f32) / self.scale;
+        let x0 = fx.floor() as i32;
+        let y0 = fy.floor() as i32;
+        let tx = fx - x0 as f32;
+        let ty = fy - y0 as f32;
+        let tx = smoothstep(tx.clamp(0.0, 1.0));
+        let ty = smoothstep(ty.clamp(0.0, 1.0));
+        let n00 = hashed_noise(x0, y0, self.seed);
+        let n10 = hashed_noise(x0 + 1, y0, self.seed);
+        let n01 = hashed_noise(x0, y0 + 1, self.seed);
+        let n11 = hashed_noise(x0 + 1, y0 + 1, self.seed);
+        let nx0 = lerp(n00, n10, tx);
+        let nx1 = lerp(n01, n11, tx);
+        lerp(nx0, nx1, ty)
+    }
+}
+
+fn hashed_noise(x: i32, y: i32, seed: u64) -> f32 {
+    let mut v = x as u64;
+    v = v.wrapping_mul(0x9E37_79B1_85EB_CA87);
+    v ^= (y as u64).wrapping_mul(0xC2B2_AE3D_27D4_EB4F);
+    v ^= seed.wrapping_mul(0x1656_67B1_9E37_79F9);
+    v ^= v >> 33;
+    v = v.wrapping_mul(0xFF51_AFD7_ED55_8CCD);
+    v ^= v >> 33;
+    ((v as u32) as f32) / (u32::MAX as f32)
+}
+
+fn lerp(a: f32, b: f32, t: f32) -> f32 {
+    a + (b - a) * t
+}


### PR DESCRIPTION
## Summary
- add a `photo-effects` configuration block that exposes paper simulation, vignette and adaptive softening controls
- run the selected effects after photo scaling via a new processing module that reuses validated configuration values
- document the new options in the sample config and README and extend configuration tests

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d36b5c2ad0832385019f6f40af6cbb