### PR TITLE
Add round-robin type selection for matting and transitions

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,8 @@ photo-library-path: /absolute/path/to/your/photo/library
 transition:
   # List one or more transition kinds to rotate between.
   types: [fade, wipe, push, e-ink]
+  # Choose how to iterate through the transition types: random or round-robin.
+  type-selection: random
   options:
     fade:
       duration-ms: 450
@@ -52,6 +54,8 @@ playlist:
 # Matting settings
 matting:
   types: [fixed-color, blur, studio, fixed-image]
+  # Choose how to iterate through the matting types: random or round-robin.
+  type-selection: random
   options:
     fixed-color:
       color: [0, 0, 0]

--- a/tests/manager_integration.rs
+++ b/tests/manager_integration.rs
@@ -21,7 +21,7 @@ async fn manager_ignores_spurious_remove_and_sends_load_on_add() {
         cancel.clone(),
         PlaylistOptions::default(),
         None,
-        None,
+        Some(42),
     ));
 
     // Spurious remove for path never added
@@ -72,7 +72,7 @@ async fn manager_rotates_actual_sent_item() {
         cancel.clone(),
         PlaylistOptions::default(),
         None,
-        None,
+        Some(42),
     ));
 
     let initial_a = PathBuf::from("/photos/a.jpg");


### PR DESCRIPTION
## Summary
- add a reusable type-selection enum and round-robin runtime so matting and transition types can rotate deterministically
- extend configuration parsing and option selection to honor random and round-robin strategies while preserving existing validation
- document the new knob in the sample config and add regression tests for round-robin behavior and deterministic manager seeding

## Testing
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68d4c0ecb7108323adb173c722bb702d