### PR TITLE
Add configurable photo affect pipeline

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -51,6 +51,24 @@ playlist:
   new-multiplicity: 3
   half-life: 3 days
 
+# Photo affect pipeline (optional shading/relighting after decode)
+photo-affects:
+  # Provide a list of affect types to enable. Leave empty to disable the stage entirely.
+  types: []
+  # Selection strategy mirrors transition + matting configuration. Only used when multiple types are listed.
+  type-selection: random
+  options:
+    print-3d:
+      relief-strength: 1.6
+      light-azimuth-degrees: 135.0
+      light-elevation-degrees: 55.0
+      ambient: 0.35
+      diffuse: 0.65
+      specular-strength: 0.25
+      specular-shininess: 24.0
+      shadow-floor: 0.15
+      highlight-gain: 0.35
+
 # Matting settings
 matting:
   types: [fixed-color, blur, studio, fixed-image]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ pub mod tasks {
     pub mod files;
     pub mod loader;
     pub mod manager;
+    pub mod photo_affect;
     pub mod viewer;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod tasks {
     pub mod files;
     pub mod loader;
     pub mod manager;
+    pub mod photo_affect;
     pub mod viewer;
 }
 
@@ -84,7 +85,8 @@ async fn main() -> Result<()> {
     let (inv_tx, inv_rx) = mpsc::channel::<InventoryEvent>(128); // Files -> Manager
     let (invalid_tx, invalid_rx) = mpsc::channel::<InvalidPhoto>(64); // Manager/Loader -> Files
     let (to_load_tx, to_load_rx) = mpsc::channel::<LoadPhoto>(4); // Manager -> Loader (allow a few in-flight requests)
-    let (loaded_tx, loaded_rx) = mpsc::channel::<PhotoLoaded>(cfg.viewer_preload_count); // Loader  -> Viewer (prefetch up to cfg.viewer_preload_count)
+    let (decoded_tx, decoded_rx) = mpsc::channel::<PhotoLoaded>(cfg.viewer_preload_count); // Loader -> PhotoAffect
+    let (processed_tx, processed_rx) = mpsc::channel::<PhotoLoaded>(cfg.viewer_preload_count); // PhotoAffect -> Viewer
     let (displayed_tx, displayed_rx) = mpsc::channel::<Displayed>(64); // Viewer  -> Manager
 
     let cancel = CancellationToken::new();
@@ -156,21 +158,38 @@ async fn main() -> Result<()> {
     tasks.spawn({
         let to_load_rx = to_load_rx;
         let invalid_tx = invalid_tx.clone();
-        let loaded_tx = loaded_tx.clone();
+        let decoded_tx = decoded_tx.clone();
         let cancel = cancel.clone();
         let max_in_flight = cfg.loader_max_concurrent_decodes;
         async move {
-            tasks::loader::run(to_load_rx, invalid_tx, loaded_tx, cancel, max_in_flight)
+            tasks::loader::run(to_load_rx, invalid_tx, decoded_tx, cancel, max_in_flight)
                 .await
                 .context("loader task failed")
         }
     });
 
+    // PhotoAffect pipeline (optional effects)
+    tasks.spawn({
+        let from_loader = decoded_rx;
+        let to_viewer = processed_tx.clone();
+        let cancel = cancel.clone();
+        let config = cfg.photo_affects.clone();
+        async move {
+            tasks::photo_affect::run(from_loader, to_viewer, cancel, config)
+                .await
+                .context("photo-affect task failed")
+        }
+    });
+
     // Run the windowed viewer on the main thread (blocking) after spawning other tasks
     // This call returns when the window closes or cancellation occurs
-    if let Err(e) =
-        tasks::viewer::run_windowed(loaded_rx, displayed_tx.clone(), cancel.clone(), cfg.clone())
-            .context("viewer failed")
+    if let Err(e) = tasks::viewer::run_windowed(
+        processed_rx,
+        displayed_tx.clone(),
+        cancel.clone(),
+        cfg.clone(),
+    )
+    .context("viewer failed")
     {
         tracing::error!("{e:?}");
     }

--- a/src/processing/affect.rs
+++ b/src/processing/affect.rs
@@ -1,0 +1,128 @@
+use image::{Pixel, RgbaImage};
+
+use crate::config::Print3dOptions;
+
+fn light_direction(options: &Print3dOptions) -> [f32; 3] {
+    let azimuth = options.light_azimuth_degrees.to_radians();
+    let elevation = options.light_elevation_degrees.to_radians();
+    let cos_elev = elevation.cos();
+    [
+        azimuth.cos() * cos_elev,
+        azimuth.sin() * cos_elev,
+        elevation.sin().max(1e-3),
+    ]
+}
+
+fn normalize(v: [f32; 3]) -> [f32; 3] {
+    let len_sq = v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
+    if len_sq <= 0.0 {
+        [0.0, 0.0, 1.0]
+    } else {
+        let inv = len_sq.sqrt().recip();
+        [v[0] * inv, v[1] * inv, v[2] * inv]
+    }
+}
+
+/// Apply a simple relief shading model inspired by
+/// "3D Simulation of Prints for Improved Soft Proofing" to mimic paper depth.
+pub fn apply_print_relief(image: &mut RgbaImage, options: &Print3dOptions) {
+    let (width, height) = image.dimensions();
+    if width == 0 || height == 0 {
+        return;
+    }
+
+    let light = normalize(light_direction(options));
+    let view = [0.0_f32, 0.0, 1.0];
+    let half_vector = normalize([light[0] + view[0], light[1] + view[1], light[2] + view[2]]);
+
+    let mut luminance = vec![0.0_f32; (width * height) as usize];
+    for (x, y, pixel) in image.enumerate_pixels() {
+        let idx = (y as usize) * (width as usize) + (x as usize);
+        let rgb = pixel.to_rgb();
+        let channels = rgb.0;
+        luminance[idx] = 0.2126 * f32::from(channels[0])
+            + 0.7152 * f32::from(channels[1])
+            + 0.0722 * f32::from(channels[2]);
+    }
+
+    let relief_strength = options.relief_strength.max(0.0);
+    let ambient = options.ambient.clamp(0.0, 1.0);
+    let diffuse_scale = options.diffuse.clamp(0.0, 1.0);
+    let specular_strength = options.specular_strength.max(0.0);
+    let shininess = options.specular_shininess.max(1.0);
+    let shadow_floor = options.shadow_floor.clamp(0.0, 1.0);
+    let highlight_gain = options.highlight_gain.max(0.0);
+
+    let width_i = width as usize;
+
+    for y in 0..height as usize {
+        for x in 0..width as usize {
+            let idx = y * width_i + x;
+            let center = luminance[idx];
+            let left = if x == 0 { center } else { luminance[idx - 1] };
+            let right = if x + 1 >= width_i {
+                center
+            } else {
+                luminance[idx + 1]
+            };
+            let up = if y == 0 {
+                center
+            } else {
+                luminance[idx - width_i]
+            };
+            let down = if y + 1 >= height as usize {
+                center
+            } else {
+                luminance[idx + width_i]
+            };
+
+            let dx = (right - left) * 0.5 * relief_strength * (1.0 / 255.0);
+            let dy = (down - up) * 0.5 * relief_strength * (1.0 / 255.0);
+
+            let normal = normalize([-dx, -dy, 1.0]);
+            let diffuse =
+                (normal[0] * light[0] + normal[1] * light[1] + normal[2] * light[2]).max(0.0);
+            let ndoth = (normal[0] * half_vector[0]
+                + normal[1] * half_vector[1]
+                + normal[2] * half_vector[2])
+                .max(0.0);
+            let specular = if specular_strength > 0.0 {
+                specular_strength * ndoth.powf(shininess)
+            } else {
+                0.0
+            };
+
+            let mut shading = ambient + diffuse_scale * diffuse;
+            shading = shading.max(shadow_floor).min(1.0);
+            shading = (shading + specular * (1.0 + highlight_gain)).min(1.0 + highlight_gain);
+
+            let pixel = image.get_pixel_mut(x as u32, y as u32);
+            for channel in &mut pixel.0[0..3] {
+                let value = f32::from(*channel) / 255.0;
+                let mapped = (value * shading).clamp(0.0, 1.0);
+                *channel = (mapped * 255.0).round().clamp(0.0, 255.0) as u8;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relief_applies_perceptible_change() {
+        let mut img = RgbaImage::from_raw(
+            3,
+            3,
+            vec![
+                10, 10, 10, 255, 40, 40, 40, 255, 80, 80, 80, 255, 10, 10, 10, 255, 128, 128, 128,
+                255, 200, 200, 200, 255, 10, 10, 10, 255, 220, 220, 220, 255, 250, 250, 250, 255,
+            ],
+        )
+        .expect("image creation");
+        let before = img.clone();
+        apply_print_relief(&mut img, &Print3dOptions::default());
+        assert_ne!(before.into_raw(), img.into_raw());
+    }
+}

--- a/src/processing/mod.rs
+++ b/src/processing/mod.rs
@@ -1,3 +1,4 @@
+pub mod affect;
 pub mod blur;
 pub mod color;
 pub mod fixed_image;

--- a/src/tasks/photo_affect.rs
+++ b/src/tasks/photo_affect.rs
@@ -1,0 +1,81 @@
+use anyhow::{Context, Result};
+use tokio::select;
+use tokio::sync::mpsc::{Receiver, Sender};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, trace, warn};
+
+use crate::config::{PhotoAffectConfig, PhotoAffectKind, PhotoAffectMode};
+use crate::events::PhotoLoaded;
+use crate::processing::affect::apply_print_relief;
+
+pub async fn run(
+    mut from_loader: Receiver<PhotoLoaded>,
+    to_viewer: Sender<PhotoLoaded>,
+    cancel: CancellationToken,
+    config: PhotoAffectConfig,
+) -> Result<()> {
+    let enabled = config.is_enabled();
+    loop {
+        select! {
+            _ = cancel.cancelled() => {
+                debug!("photo-affect task cancelled");
+                break;
+            },
+            maybe_msg = from_loader.recv() => {
+                match maybe_msg {
+                    Some(PhotoLoaded(mut prepared)) => {
+                        if enabled {
+                            if let Some(kind) = config.next_kind() {
+                                if let Some(mode) = config.options_for(kind) {
+                                    if let Err(err) = apply_affect(kind, mode, &mut prepared) {
+                                        warn!(
+                                            path = %prepared.path.display(),
+                                            ?err,
+                                            "photo affect failed; forwarding original image"
+                                        );
+                                    } else {
+                                        trace!(path = %prepared.path.display(), ?kind, "applied photo affect");
+                                    }
+                                } else {
+                                    warn!(?kind, "missing configuration for selected photo affect");
+                                }
+                            }
+                        }
+                        if to_viewer.send(PhotoLoaded(prepared)).await.is_err() {
+                            debug!("viewer channel closed");
+                            break;
+                        }
+                    }
+                    None => {
+                        trace!("loader channel closed; stopping photo-affect task");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn apply_affect(
+    kind: PhotoAffectKind,
+    mode: &PhotoAffectMode,
+    prepared: &mut crate::events::PreparedImageCpu,
+) -> Result<()> {
+    let result: Result<()> = match mode {
+        PhotoAffectMode::Print3d(options) => {
+            let Some(mut image) = image::RgbaImage::from_raw(
+                prepared.width,
+                prepared.height,
+                std::mem::take(&mut prepared.pixels),
+            ) else {
+                anyhow::bail!("invalid image buffer for print-3d affect");
+            };
+            apply_print_relief(&mut image, options);
+            prepared.pixels = image.into_raw();
+            Ok(())
+        }
+    };
+
+    result.with_context(|| format!("failed to apply {:?} photo affect", kind))
+}


### PR DESCRIPTION
## Summary
- insert a dedicated photo-affect async task between the loader and viewer and apply it conditionally
- implement a 3D print relief effect inspired by Patil/Fairchild/Johnson with configurable lighting controls
- extend the configuration surface, sample config, and documentation to describe optional affects and future expansion

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68d544a07f8483238cc6fad5b909b62e