### PR TITLE
Rename sequential config keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The `transition` block controls how the viewer blends between photos. List one o
 | Key | Required? | Default | Accepted values | Effect |
 | --- | --- | --- | --- | --- |
 | `types` | Yes | `['fade']` | Array containing one or more of `fade`, `wipe`, `push`, `e-ink` | Determines which transition families are in play. Duplicates are ignored; at least one entry must be supplied. |
-| `type-selection` | Optional (only valid when `types` has multiple entries) | `random` | `random` or `round-robin` | Picks whether the app draws a new type randomly each slide or cycles through the list in order. Ignored when only one type is listed. |
+| `type-selection` | Optional (only valid when `types` has multiple entries) | `random` | `random` or `sequential` | Picks whether the app draws a new type randomly each slide or cycles through the list in order. Ignored when only one type is listed. |
 | `options` | Required when `types` has multiple entries (optional otherwise) | Defaults per transition family | Mapping keyed by transition kind | Provides per-type overrides for duration and mode-specific fields. When only one type is listed you can specify the same fields inline instead of creating the map. |
 
 > **Note:** Reserve the word `random` for `type-selection`; adding it to `types` triggers a validation error.
@@ -243,14 +243,14 @@ When the list contains only one entry the viewer always uses that direction, so 
 ```yaml
 transition:
   types: [fade, wipe, push]
-  type-selection: round-robin
+  type-selection: sequential
   options:
     fade:
       duration-ms: 500
     wipe:
       duration-ms: 600
       angle-list-degrees: [45.0, 225.0]
-      angle-selection: round-robin
+      angle-selection: sequential
       angle-jitter-degrees: 30.0
     push:
       duration-ms: 650
@@ -263,12 +263,12 @@ Each transition exposes a focused set of fields:
   - **`through-black`** (boolean, default `false`): When `true`, fades to black completely before revealing the next image. Keeps cuts discreet at the cost of a slightly longer blackout.
 - **`wipe`**
   - **`angle-list-degrees`** (array of floats, default `[0.0]`): Collection of wipe directions in degrees (`0°` sweeps left→right, `90°` sweeps top→bottom). At least one finite value is required.
-  - **`angle-selection`** (`random` or `round-robin`, default `random`): Governs how the app chooses from the angle list—either independently each slide or cycling in order.
+  - **`angle-selection`** (`random` or `sequential`, default `random`): Governs how the app chooses from the angle list—either independently each slide or cycling in order.
   - **`angle-jitter-degrees`** (float ≥ 0, default `0.0`): Adds random jitter within ±the supplied degrees, preventing identical wipes.
   - **`softness`** (float, default `0.05`, clamped to `0.0–0.5`): Feathers the wipe edge; higher values create a softer blend.
 - **`push`**
   - **`angle-list-degrees`** (array of floats, default `[0.0]`): Direction the new image pushes in from; the same rules as wipes apply.
-  - **`angle-selection`** (`random` or `round-robin`, default `random`): Selection strategy for the angle list.
+  - **`angle-selection`** (`random` or `sequential`, default `random`): Selection strategy for the angle list.
   - **`angle-jitter-degrees`** (float ≥ 0, default `0.0`): Randomizes the push direction by ±the provided degrees.
 - **`e-ink`**
   - **`flash-count`** (integer, default `3`, capped at `6`): Number of alternating black/flash-color pulses before the reveal.
@@ -285,7 +285,7 @@ The `matting` table chooses how the background behind each photo is prepared. Ea
 | Key | Required? | Default | Accepted values | Effect |
 | --- | --- | --- | --- | --- |
 | `types` | Yes | `['fixed-color']` | Array containing one or more of `fixed-color`, `blur`, `studio`, `fixed-image` | Chooses which mat styles are eligible. Duplicates are ignored; at least one entry must be supplied. |
-| `type-selection` | Optional (only valid when `types` has multiple entries) | `random` | `random` or `round-robin` | Switches between drawing mats randomly or cycling through them in order. Ignored when only one type is listed. |
+| `type-selection` | Optional (only valid when `types` has multiple entries) | `random` | `random` or `sequential` | Switches between drawing mats randomly or cycling through them in order. Ignored when only one type is listed. |
 | `options` | Required when `types` has multiple entries (optional otherwise) | Defaults per mat type | Mapping keyed by mat type | Provides per-style settings. When only one type is listed, you may set the same fields inline instead of using the map. |
 
 > **Note:** Reserve the word `random` for `type-selection`; adding it to `types` triggers a validation error.
@@ -331,7 +331,7 @@ Every entry inside `matting.options` accepts the shared settings below:
 #### `blur`
 
 - **`sigma`** (float, default `20.0`): Gaussian blur radius applied to a scaled copy of the photo that covers the screen. Larger values yield softer backgrounds; zero disables the blur but keeps the scaled image.
-- **`max-sample-dim`** (integer or `null`, default `null`; falls back to `2048` on 64-bit ARM, otherwise the canvas size): Optional cap on the intermediate blur resolution. Lower caps downsample before blurring, cutting CPU/GPU cost while preserving the dreamy backdrop.
+- **`max-sample-dimension`** (integer or `null`, default `null`; falls back to `2048` on 64-bit ARM, otherwise the canvas size): Optional cap on the intermediate blur resolution. Lower caps downsample before blurring, cutting CPU/GPU cost while preserving the dreamy backdrop.
 - **`backend`** (`cpu` or `neon`, default `cpu`): Blur implementation to use. `neon` opts into the vector-accelerated path on 64-bit ARM; if unsupported at runtime the app gracefully falls back to the CPU renderer.
 
 #### `studio`

--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ photo-library-path: /absolute/path/to/your/photo/library
 transition:
   # List one or more transition kinds to rotate between.
   types: [fade, wipe, push, e-ink]
-  # Choose how to iterate through the transition types: random or round-robin.
+  # Choose how to iterate through the transition types: random or sequential.
   type-selection: random
   options:
     fade:
@@ -17,7 +17,7 @@ transition:
     wipe:
       duration-ms: 600
       angle-list-degrees: [45.0, 225.0]
-      angle-selection: round-robin
+      angle-selection: sequential
       angle-jitter-degrees: 12.0
       softness: 0.08
     push:
@@ -54,7 +54,7 @@ playlist:
 # Matting settings
 matting:
   types: [fixed-color, blur, studio, fixed-image]
-  # Choose how to iterate through the matting types: random or round-robin.
+  # Choose how to iterate through the matting types: random or sequential.
   type-selection: random
   options:
     fixed-color:
@@ -64,7 +64,7 @@ matting:
     blur:
       minimum-mat-percentage: 3.5
       sigma: 20.0
-      max-sample-dim: 1536
+      max-sample-dimension: 1536
       backend: neon # options: cpu, neon (auto-falls back to cpu if unsupported)
     studio:
       minimum-mat-percentage: 8.0

--- a/src/tasks/viewer.rs
+++ b/src/tasks/viewer.rs
@@ -284,7 +284,7 @@ pub fn run_windowed(
             }
             MattingMode::Blur {
                 sigma,
-                max_sample_dim,
+                max_sample_dimension,
                 backend,
             } => {
                 let (bg_w, bg_h) = resize_to_cover(canvas_w, canvas_h, width, height, max_dim);
@@ -301,12 +301,12 @@ pub fn run_windowed(
                     bg = canvas;
                 }
                 if *sigma > 0.0 {
-                    let limit = max_sample_dim
+                    let limit = max_sample_dimension
                         .filter(|v| *v > 0)
                         .unwrap_or({
                             #[cfg(target_arch = "aarch64")]
                             {
-                                MattingMode::default_blur_max_sample_dim()
+                                MattingMode::default_blur_max_sample_dimension()
                             }
                             #[cfg(not(target_arch = "aarch64"))]
                             {

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -171,12 +171,12 @@ matting:
 }
 
 #[test]
-fn parse_round_robin_matting_configuration() {
+fn parse_sequential_matting_configuration() {
     let yaml = r#"
 photo-library-path: "/photos"
 matting:
   types: [fixed-color, blur]
-  type-selection: round-robin
+  type-selection: sequential
   options:
     fixed-color:
       color: [10, 20, 30]
@@ -187,10 +187,10 @@ matting:
 
     let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
     match cfg.matting.selection() {
-        MattingSelection::RoundRobin { kinds, .. } => {
+        MattingSelection::Sequential { kinds, .. } => {
             assert_eq!(kinds, vec![MattingKind::FixedColor, MattingKind::Blur]);
         }
-        other => panic!("expected round-robin matting selection, got {other:?}"),
+        other => panic!("expected sequential matting selection, got {other:?}"),
     }
 
     let mut rng = StdRng::seed_from_u64(1);
@@ -308,7 +308,7 @@ transition:
     push:
       duration-ms: 640
       angle-list-degrees: [0.0, 180.0]
-      angle-selection: round-robin
+      angle-selection: sequential
 "#;
 
     let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
@@ -346,7 +346,7 @@ transition:
             assert_eq!(cfg.angles.angles_deg, vec![0.0, 180.0]);
             assert_eq!(
                 cfg.angles.selection,
-                rust_photo_frame::config::AngleSelection::RoundRobin
+                rust_photo_frame::config::AngleSelection::Sequential
             );
         }
         _ => panic!("expected push transition"),
@@ -354,17 +354,17 @@ transition:
 }
 
 #[test]
-fn parse_round_robin_transition_configuration() {
+fn parse_sequential_transition_configuration() {
     let yaml = r#"
 photo-library-path: "/photos"
 transition:
   types: [push, wipe]
-  type-selection: round-robin
+  type-selection: sequential
   options:
     push:
       duration-ms: 640
       angle-list-degrees: [0.0, 180.0]
-      angle-selection: round-robin
+      angle-selection: sequential
     wipe:
       duration-ms: 520
       angle-list-degrees: [90.0]
@@ -372,10 +372,10 @@ transition:
 
     let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
     match cfg.transition.selection() {
-        TransitionSelection::RoundRobin { kinds, .. } => {
+        TransitionSelection::Sequential { kinds, .. } => {
             assert_eq!(kinds, vec![TransitionKind::Push, TransitionKind::Wipe]);
         }
-        other => panic!("expected round-robin transition selection, got {other:?}"),
+        other => panic!("expected sequential transition selection, got {other:?}"),
     }
 
     let mut rng = StdRng::seed_from_u64(42);
@@ -494,7 +494,7 @@ transition:
   types: [push]
   duration-ms: 725
   angle-list-degrees: [90.0, 270.0]
-  angle-selection: round-robin
+  angle-selection: sequential
 "#;
 
     let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
@@ -509,7 +509,7 @@ transition:
             assert_eq!(push.angles.angles_deg, vec![90.0, 270.0]);
             assert_eq!(
                 push.angles.selection,
-                rust_photo_frame::config::AngleSelection::RoundRobin
+                rust_photo_frame::config::AngleSelection::Sequential
             );
         }
         _ => panic!("expected push transition"),


### PR DESCRIPTION
## Summary
- rename the blur matting cap from `max-sample-dim` to `max-sample-dimension` across parsing and rendering
- rename the selection strategy from `round-robin` to `sequential` in configuration structures, runtime state, and tests
- refresh the sample config and README to describe the new option names

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68d54dda4ba8832387b79f344b7b4ace