### PR TITLE
Preserve wpa_supplicant permissions during onboarding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,21 +5,25 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.99"
+axum = { version = "0.7.7", features = ["macros", "form"] }
 bytemuck = { version = "1.23.2", features = ["derive"] }
 clap = { version = "4.5.47", features = ["derive"] }
+crossbeam-channel = "0.5.13"
 exif = { version = "0.6.1", package = "kamadak-exif" }
+html-escape = "0.2.13"
+humantime = "2.1.0"
+humantime-serde = "1.1.1"
+if-addrs = "0.13.3"
 image = { version = "0.25.8", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 jpeg-decoder = "0.3.2"
 fast_image_resize = { version = "5.3.0", default-features = false, features = ["only_u8x4"] }
 notify = "8.2.0"
 pollster = "0.4.0"
+qrcode = "0.14.1"
 rand = "0.8.5"
 serde = { version = "1.0.221", features = ["derive"] }
 serde_yaml = "0.9.34"
-humantime-serde = "1.1.1"
-humantime = "2.1.0"
-crossbeam-channel = "0.5.13"
-tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "signal", "sync", "time"] }
+tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "fs", "process"] }
 tokio-util = "0.7.16"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["fmt", "env-filter"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod events;
 mod processing;
+mod wifi_setup;
 mod tasks {
     pub mod files;
     pub mod loader;
@@ -77,6 +78,11 @@ async fn main() -> Result<()> {
 
     if let Some(iterations) = playlist_dry_run {
         run_playlist_dry_run(&cfg, iterations, now_override, playlist_seed)?;
+        return Ok(());
+    }
+
+    if !wifi_setup::ensure_wifi_connected().await? {
+        tracing::info!("wifi setup handled; exiting main loop");
         return Ok(());
     }
 

--- a/src/wifi_setup/mod.rs
+++ b/src/wifi_setup/mod.rs
@@ -1,0 +1,588 @@
+use anyhow::{anyhow, Context, Result};
+use html_escape::encode_text;
+use if_addrs::get_if_addrs;
+use rand::{distributions::Alphanumeric, Rng};
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio::process::Command;
+use tokio::sync::{mpsc, oneshot, watch};
+use tokio::time::{sleep, Duration, Instant};
+use tracing::{debug, info, warn};
+
+mod ui;
+
+#[derive(Clone, Debug)]
+pub struct SetupScreenInfo {
+    pub hotspot_ssid: String,
+    pub hotspot_password: String,
+    pub access_urls: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+pub enum WifiSetupStatus {
+    StartingHotspot,
+    WaitingForCredentials,
+    ApplyingCredentials { ssid: String },
+    ConnectionFailed { ssid: String, message: String },
+    Connected { ssid: String },
+}
+
+#[derive(Clone, Debug)]
+struct JoinRequest {
+    ssid: String,
+    password: String,
+}
+
+struct AppState {
+    join_tx: mpsc::Sender<JoinRequest>,
+    status: watch::Sender<WifiSetupStatus>,
+    info: SetupScreenInfo,
+}
+
+pub async fn ensure_wifi_connected() -> Result<bool> {
+    if current_ssid().await?.is_some() {
+        info!("wifi already connected; continuing normal startup");
+        return Ok(true);
+    }
+
+    info!("no wifi connection detected; entering setup mode");
+    run_setup_flow().await?;
+    Ok(false)
+}
+
+async fn current_ssid() -> Result<Option<String>> {
+    let output = Command::new("iwgetid")
+        .arg("-r")
+        .output()
+        .await
+        .context("failed to run iwgetid")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        debug!("iwgetid returned non-zero: {}", stderr.trim());
+        return Ok(None);
+    }
+    let ssid = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if ssid.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(ssid))
+    }
+}
+
+async fn run_setup_flow() -> Result<()> {
+    let hotspot_ssid = format!(
+        "Frame-Setup-{}",
+        rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(4)
+            .map(char::from)
+            .collect::<String>()
+    );
+    let hotspot_password = rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(10)
+        .map(char::from)
+        .collect::<String>();
+
+    if let Err(err) = enable_hotspot(&hotspot_ssid, &hotspot_password).await {
+        warn!("failed to enable hotspot automatically: {err:?}");
+    }
+
+    let listener = TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], 8080)))
+        .await
+        .context("failed to bind wifi setup listener")?;
+
+    let access_urls = discover_access_urls(8080);
+    info!(?access_urls, "wifi setup server running");
+
+    let screen_info = SetupScreenInfo {
+        hotspot_ssid: hotspot_ssid.clone(),
+        hotspot_password: hotspot_password.clone(),
+        access_urls: access_urls.clone(),
+    };
+
+    let (status_tx, status_rx) = watch::channel(WifiSetupStatus::StartingHotspot);
+    let (join_tx, join_rx) = mpsc::channel::<JoinRequest>(8);
+    let (outcome_tx, outcome_rx) = oneshot::channel();
+
+    let app_state = Arc::new(AppState {
+        join_tx: join_tx.clone(),
+        status: status_tx.clone(),
+        info: screen_info.clone(),
+    });
+
+    let server_task = tokio::spawn({
+        let state = app_state.clone();
+        async move {
+            if let Err(err) = run_http_server(listener, state).await {
+                warn!("wifi setup server stopped unexpectedly: {err:?}");
+            }
+        }
+    });
+
+    let controller_task = tokio::spawn(async move {
+        run_controller(
+            join_rx,
+            status_tx,
+            hotspot_ssid.clone(),
+            hotspot_password.clone(),
+            outcome_tx,
+        )
+        .await;
+    });
+
+    let (ui_status_tx, ui_status_rx) = std::sync::mpsc::channel();
+    let (ui_ctrl_tx, ui_ctrl_rx) = std::sync::mpsc::channel();
+
+    let mut status_rx_for_ui = status_rx.clone();
+    tokio::spawn(async move {
+        loop {
+            let value = status_rx_for_ui.borrow().clone();
+            if ui_status_tx.send(value.clone()).is_err() {
+                break;
+            }
+            if status_rx_for_ui.changed().await.is_err() {
+                break;
+            }
+        }
+    });
+
+    let ui_thread = std::thread::spawn(move || {
+        if let Err(err) = ui::run(screen_info, ui_status_rx, ui_ctrl_rx) {
+            warn!("wifi setup UI exited with error: {err:?}");
+        }
+    });
+
+    let outcome = outcome_rx
+        .await
+        .unwrap_or(WifiSetupStatus::ConnectionFailed {
+            ssid: String::new(),
+            message: "setup interrupted".to_string(),
+        });
+
+    if let WifiSetupStatus::Connected { ssid } = &outcome {
+        info!(ssid, "wifi connected; preparing to restart application");
+        sleep(Duration::from_secs(3)).await;
+        let _ = disable_hotspot().await;
+        let _ = ui_ctrl_tx.send(ui::UiControl::Exit);
+    } else {
+        warn!("wifi setup controller exited unexpectedly; leaving UI running");
+    }
+
+    let _ = ui_ctrl_tx.send(ui::UiControl::Exit);
+    let _ = ui_thread.join();
+
+    server_task.abort();
+    let _ = controller_task.await;
+
+    if let WifiSetupStatus::Connected { ssid: _ } = outcome {
+        if let Err(err) = restart_network_services().await {
+            warn!("failed to restart network services: {err:?}");
+        }
+        if let Err(err) = restart_application_service().await {
+            warn!("failed to request app restart: {err:?}");
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_controller(
+    mut join_rx: mpsc::Receiver<JoinRequest>,
+    status_tx: watch::Sender<WifiSetupStatus>,
+    hotspot_ssid: String,
+    hotspot_password: String,
+    outcome_tx: oneshot::Sender<WifiSetupStatus>,
+) {
+    let _ = status_tx.send(WifiSetupStatus::WaitingForCredentials);
+
+    while let Some(req) = join_rx.recv().await {
+        let JoinRequest { ssid, password } = req;
+        let _ = status_tx.send(WifiSetupStatus::ApplyingCredentials { ssid: ssid.clone() });
+
+        match apply_credentials(&ssid, &password).await {
+            Ok(()) => {
+                info!(target = %ssid, "credentials applied; waiting for wifi connection");
+                if wait_for_connection(&ssid, Duration::from_secs(45)).await {
+                    let _ = status_tx.send(WifiSetupStatus::Connected { ssid: ssid.clone() });
+                    let _ = outcome_tx.send(WifiSetupStatus::Connected { ssid });
+                    return;
+                }
+                let _ = status_tx.send(WifiSetupStatus::ConnectionFailed {
+                    ssid: ssid.clone(),
+                    message: "Timed out waiting for connection".to_string(),
+                });
+            }
+            Err(err) => {
+                let _ = status_tx.send(WifiSetupStatus::ConnectionFailed {
+                    ssid: ssid.clone(),
+                    message: err.to_string(),
+                });
+            }
+        }
+
+        if let Err(err) = enable_hotspot(&hotspot_ssid, &hotspot_password).await {
+            warn!("failed to ensure hotspot remains active: {err:?}");
+        }
+        let _ = status_tx.send(WifiSetupStatus::WaitingForCredentials);
+    }
+
+    let _ = outcome_tx.send(WifiSetupStatus::ConnectionFailed {
+        ssid: String::new(),
+        message: "Setup channel closed".to_string(),
+    });
+}
+
+async fn wait_for_connection(target_ssid: &str, max_wait: Duration) -> bool {
+    let deadline = Instant::now() + max_wait;
+    loop {
+        match current_ssid().await {
+            Ok(Some(current)) if current == target_ssid => return true,
+            Ok(Some(current)) => debug!(
+                current,
+                "connected to unexpected network; continuing to wait"
+            ),
+            Ok(None) => {}
+            Err(err) => warn!("failed to check wifi status: {err:?}"),
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        sleep(Duration::from_secs(5)).await;
+    }
+}
+
+async fn run_http_server(listener: TcpListener, state: Arc<AppState>) -> Result<()> {
+    use axum::extract::State;
+    use axum::response::Html;
+    use axum::routing::get;
+    use axum::{Form, Router};
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct JoinForm {
+        ssid: String,
+        password: String,
+    }
+
+    async fn get_index(State(state): State<Arc<AppState>>) -> Html<String> {
+        let status = state.status.borrow().clone();
+        Html(render_setup_page(&state.info, &status))
+    }
+
+    async fn post_join(
+        State(state): State<Arc<AppState>>,
+        Form(form): Form<JoinForm>,
+    ) -> Html<String> {
+        let req = JoinRequest {
+            ssid: form.ssid.trim().to_string(),
+            password: form.password.trim().to_string(),
+        };
+        if req.ssid.is_empty() {
+            let status = WifiSetupStatus::ConnectionFailed {
+                ssid: String::new(),
+                message: "SSID is required".to_string(),
+            };
+            let _ = state.status.send(status.clone());
+            return Html(render_setup_page(&state.info, &status));
+        }
+        if state.join_tx.try_send(req).is_err() {
+            warn!("dropping join request; controller busy");
+        }
+        let status = state.status.borrow().clone();
+        Html(render_setup_page(&state.info, &status))
+    }
+
+    let app = Router::new()
+        .route("/", get(get_index).post(post_join))
+        .with_state(state);
+
+    axum::serve(listener, app)
+        .await
+        .context("wifi setup server terminated")
+}
+
+fn render_setup_page(info: &SetupScreenInfo, status: &WifiSetupStatus) -> String {
+    let mut status_msg = match status {
+        WifiSetupStatus::StartingHotspot => "Preparing hotspot...".to_string(),
+        WifiSetupStatus::WaitingForCredentials => "Ready for Wi-Fi details.".to_string(),
+        WifiSetupStatus::ApplyingCredentials { ssid } => {
+            format!("Connecting to '{ssid}'...")
+        }
+        WifiSetupStatus::ConnectionFailed { ssid, message } => {
+            if ssid.is_empty() {
+                format!("Setup error: {message}")
+            } else {
+                format!("Failed to connect to '{ssid}': {message}")
+            }
+        }
+        WifiSetupStatus::Connected { ssid } => {
+            format!("Connected to '{ssid}'. Restarting frame...")
+        }
+    };
+    if status_msg.is_empty() {
+        status_msg = "Ready.".to_string();
+    }
+
+    let access_list = if info.access_urls.is_empty() {
+        "<li>http://192.168.4.1:8080</li>".to_string()
+    } else {
+        info.access_urls
+            .iter()
+            .map(|url| format!("<li>{}</li>", url))
+            .collect::<Vec<_>>()
+            .join("")
+    };
+
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Frame Wi-Fi Setup</title>
+<style>
+body {{ font-family: sans-serif; margin: 2rem; background: #f5f5f5; color: #222; }}
+main {{ max-width: 30rem; margin: 0 auto; background: white; padding: 2rem; border-radius: 1rem; box-shadow: 0 0.5rem 2rem rgba(0,0,0,0.1); }}
+form {{ display: flex; flex-direction: column; gap: 1rem; }}
+label {{ display: flex; flex-direction: column; font-weight: 600; }}
+input {{ padding: 0.75rem; border-radius: 0.5rem; border: 1px solid #ccc; font-size: 1rem; }}
+button {{ padding: 0.75rem; font-size: 1rem; border-radius: 0.5rem; border: none; background: #0069c0; color: white; cursor: pointer; }}
+.status {{ margin-bottom: 1rem; font-weight: 600; }}
+</style>
+</head>
+<body>
+<main>
+<h1>Wi-Fi Setup</h1>
+<p>1. Connect to hotspot <strong>{ssid}</strong> with password <strong>{password}</strong>.</p>
+<p>2. Visit one of these URLs once connected:</p>
+<ul>{access_list}</ul>
+<p>3. Enter your Wi-Fi network below.</p>
+<p class="status">{status_msg}</p>
+<form method="post" action="/">
+<label>Wi-Fi Network
+<input name="ssid" placeholder="Network name" required /></label>
+<label>Password
+<input name="password" placeholder="Password" type="password" /></label>
+<button type="submit">Join</button>
+</form>
+</main>
+</body>
+</html>"#,
+        ssid = encode_text(&info.hotspot_ssid),
+        password = encode_text(&info.hotspot_password),
+        access_list = access_list,
+        status_msg = encode_text(&status_msg),
+    )
+}
+
+fn discover_access_urls(port: u16) -> Vec<String> {
+    match get_if_addrs() {
+        Ok(ifaces) => ifaces
+            .into_iter()
+            .filter(|iface| !iface.is_loopback())
+            .filter_map(|iface| match iface.addr.ip() {
+                std::net::IpAddr::V4(v4) => Some(format!("http://{}:{}", v4, port)),
+                _ => None,
+            })
+            .collect(),
+        Err(err) => {
+            warn!("failed to enumerate interfaces: {err:?}");
+            Vec::new()
+        }
+    }
+}
+
+async fn enable_hotspot(ssid: &str, password: &str) -> Result<()> {
+    let status = Command::new("nmcli")
+        .args([
+            "device",
+            "wifi",
+            "hotspot",
+            "ifname",
+            "wlan0",
+            "con-name",
+            "frame-setup",
+            "ssid",
+            ssid,
+            "band",
+            "bg",
+            "password",
+            password,
+        ])
+        .status()
+        .await?;
+    if !status.success() {
+        return Err(anyhow!("nmcli hotspot command failed"));
+    }
+    Ok(())
+}
+
+async fn disable_hotspot() -> Result<()> {
+    let status = Command::new("nmcli")
+        .args(["connection", "down", "frame-setup"])
+        .status()
+        .await?;
+    if !status.success() {
+        warn!("failed to disable hotspot connection");
+    }
+    Ok(())
+}
+
+async fn apply_credentials(ssid: &str, password: &str) -> Result<()> {
+    let path = std::env::var("WPA_SUPPLICANT_CONF")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/etc/wpa_supplicant/wpa_supplicant.conf"));
+    let existing = tokio::fs::read_to_string(&path).await.unwrap_or_default();
+    let marker = format!("ssid=\"{ssid}\"");
+    let mut updated_lines = Vec::new();
+    let mut inside_network = false;
+    let mut inside_target = false;
+    let mut psk_written = false;
+
+    for line in existing.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("network={") {
+            inside_network = true;
+            inside_target = false;
+            psk_written = false;
+        } else if inside_network && trimmed == "}" {
+            if inside_target && !psk_written {
+                updated_lines.push(format!("    psk=\"{}\"", password));
+            }
+            inside_network = false;
+            inside_target = false;
+            psk_written = false;
+        }
+
+        if inside_network && trimmed == marker {
+            inside_target = true;
+        }
+
+        if inside_target && trimmed.starts_with("psk=") {
+            updated_lines.push(format!("    psk=\"{}\"", password));
+            psk_written = true;
+            continue;
+        }
+
+        updated_lines.push(line.to_string());
+    }
+
+    if !existing.contains(&marker) {
+        if !updated_lines
+            .last()
+            .map(|l| l.trim().is_empty())
+            .unwrap_or(true)
+        {
+            updated_lines.push(String::new());
+        }
+        updated_lines.push("network={".to_string());
+        updated_lines.push(format!("    ssid=\"{}\"", ssid));
+        updated_lines.push(format!("    psk=\"{}\"", password));
+        updated_lines.push("}".to_string());
+    }
+
+    let mut updated = updated_lines.join("\n");
+    if !updated.ends_with('\n') {
+        updated.push('\n');
+    }
+
+    let tmp = path.with_extension("tmp");
+    write_config_with_preserved_permissions(&path, &tmp, &updated).await?;
+    tokio::fs::rename(&tmp, &path)
+        .await
+        .with_context(|| format!("failed to replace {}", path.display()))?;
+
+    let status = Command::new("wpa_cli")
+        .args(["-i", "wlan0", "reconfigure"])
+        .status()
+        .await
+        .context("failed to reconfigure wpa_supplicant")?;
+    if !status.success() {
+        warn!("wpa_cli reconfigure returned non-zero");
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn write_config_with_preserved_permissions(
+    original: &Path,
+    tmp: &Path,
+    contents: &str,
+) -> Result<()> {
+    use std::io::ErrorKind;
+    use std::os::unix::fs::PermissionsExt;
+
+    let desired_mode = match tokio::fs::metadata(original).await {
+        Ok(metadata) => metadata.permissions().mode(),
+        Err(error) if error.kind() == ErrorKind::NotFound => 0o600,
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to read permissions for {}", original.display()));
+        }
+    };
+
+    tokio::fs::write(tmp, contents)
+        .await
+        .with_context(|| format!("failed to write {}", tmp.display()))?;
+    tokio::fs::set_permissions(tmp, std::fs::Permissions::from_mode(desired_mode))
+        .await
+        .with_context(|| format!("failed to set permissions on {}", tmp.display()))?;
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+async fn write_config_with_preserved_permissions(
+    _original: &Path,
+    tmp: &Path,
+    contents: &str,
+) -> Result<()> {
+    tokio::fs::write(tmp, contents)
+        .await
+        .with_context(|| format!("failed to write {}", tmp.display()))
+}
+
+async fn restart_network_services() -> Result<()> {
+    let status = Command::new("systemctl")
+        .args(["restart", "dhcpcd.service"])
+        .status()
+        .await
+        .context("failed to restart dhcpcd")?;
+    if !status.success() {
+        warn!("systemctl restart dhcpcd.service failed");
+    }
+    Ok(())
+}
+
+async fn restart_application_service() -> Result<()> {
+    let status = Command::new("systemctl")
+        .args(["restart", "rust-photo-frame.service"])
+        .status()
+        .await
+        .context("failed to restart rust-photo-frame service")?;
+    if !status.success() {
+        warn!("systemctl restart rust-photo-frame.service failed");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_page_contains_urls() {
+        let info = SetupScreenInfo {
+            hotspot_ssid: "Frame-Setup".to_string(),
+            hotspot_password: "password".to_string(),
+            access_urls: vec!["http://192.168.4.1:8080".to_string()],
+        };
+        let html = render_setup_page(&info, &WifiSetupStatus::WaitingForCredentials);
+        assert!(html.contains("Frame-Setup"));
+        assert!(html.contains("http://192.168.4.1:8080"));
+    }
+}

--- a/src/wifi_setup/qr_shader.wgsl
+++ b/src/wifi_setup/qr_shader.wgsl
@@ -1,0 +1,22 @@
+struct VsIn {
+    @location(0) position: vec2<f32>,
+    @location(1) color: vec3<f32>,
+};
+
+struct VsOut {
+    @builtin(position) position: vec4<f32>,
+    @location(0) color: vec3<f32>,
+};
+
+@vertex
+fn vs_main(input: VsIn) -> VsOut {
+    var out: VsOut;
+    out.position = vec4<f32>(input.position, 0.0, 1.0);
+    out.color = input.color;
+    return out;
+}
+
+@fragment
+fn fs_main(input: VsOut) -> @location(0) vec4<f32> {
+    return vec4<f32>(input.color, 1.0);
+}

--- a/src/wifi_setup/ui.rs
+++ b/src/wifi_setup/ui.rs
@@ -1,0 +1,599 @@
+use super::{SetupScreenInfo, WifiSetupStatus};
+use anyhow::{Context, Result};
+use qrcode::QrCode;
+use std::sync::{mpsc::Receiver, Arc};
+use tracing::{info, warn};
+use wgpu::util::DeviceExt;
+use wgpu_glyph::{ab_glyph::FontArc, GlyphBrush, GlyphBrushBuilder, Section, Text};
+use winit::dpi::PhysicalSize;
+use winit::event::WindowEvent;
+use winit::event_loop::{ActiveEventLoop, EventLoop};
+use winit::window::{Fullscreen, Window, WindowAttributes};
+
+pub enum UiControl {
+    Exit,
+}
+
+pub fn run(
+    info: SetupScreenInfo,
+    status_rx: Receiver<WifiSetupStatus>,
+    ctrl_rx: Receiver<UiControl>,
+) -> Result<()> {
+    let event_loop = EventLoop::new().context("failed to create event loop")?;
+    let mut app = WifiSetupApp::new(info, status_rx, ctrl_rx);
+    event_loop
+        .run_app(&mut app)
+        .context("wifi setup UI loop failed")
+}
+
+struct WifiSetupApp {
+    info: SetupScreenInfo,
+    status_rx: Receiver<WifiSetupStatus>,
+    ctrl_rx: Receiver<UiControl>,
+    state: Option<UiState>,
+    latest_status: WifiSetupStatus,
+}
+
+impl WifiSetupApp {
+    fn new(
+        info: SetupScreenInfo,
+        status_rx: Receiver<WifiSetupStatus>,
+        ctrl_rx: Receiver<UiControl>,
+    ) -> Self {
+        Self {
+            info,
+            status_rx,
+            ctrl_rx,
+            state: None,
+            latest_status: WifiSetupStatus::StartingHotspot,
+        }
+    }
+}
+
+impl winit::application::ApplicationHandler for WifiSetupApp {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.state.is_some() {
+            return;
+        }
+        match UiState::new(event_loop, self.info.clone()) {
+            Ok(mut state) => {
+                info!("wifi setup UI ready");
+                state.update_status(self.latest_status.clone());
+                state.window.request_redraw();
+                self.state = Some(state);
+            }
+            Err(err) => {
+                warn!("failed to initialize wifi setup UI: {err:?}");
+                event_loop.exit();
+            }
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        while let Ok(ctrl) = self.ctrl_rx.try_recv() {
+            if matches!(ctrl, UiControl::Exit) {
+                event_loop.exit();
+                return;
+            }
+        }
+        let mut updated = false;
+        while let Ok(status) = self.status_rx.try_recv() {
+            self.latest_status = status.clone();
+            if let Some(state) = self.state.as_mut() {
+                state.update_status(status);
+                updated = true;
+            }
+        }
+        if let Some(state) = self.state.as_ref() {
+            if updated {
+                state.window.request_redraw();
+            }
+        }
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        window_id: winit::window::WindowId,
+        event: WindowEvent,
+    ) {
+        let Some(state) = self.state.as_mut() else {
+            return;
+        };
+        if state.window.id() != window_id {
+            return;
+        }
+        match event {
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::RedrawRequested => {
+                if let Err(err) = state.render() {
+                    match err {
+                        RenderError::Surface(wgpu::SurfaceError::Lost)
+                        | RenderError::Surface(wgpu::SurfaceError::Outdated) => {
+                            state.resize(state.window.inner_size());
+                        }
+                        RenderError::Surface(wgpu::SurfaceError::OutOfMemory) => {
+                            warn!("surface out of memory; exiting setup UI");
+                            event_loop.exit();
+                        }
+                        RenderError::Surface(other) => {
+                            warn!("surface error: {other:?}");
+                        }
+                        RenderError::Glyph(gerr) => {
+                            warn!("glyph error during render: {gerr:?}");
+                        }
+                    }
+                }
+            }
+            WindowEvent::Resized(size) => {
+                state.resize(size);
+                state.window.request_redraw();
+            }
+            WindowEvent::ScaleFactorChanged {
+                mut inner_size_writer,
+                ..
+            } => {
+                let size = state.window.inner_size();
+                let _ = inner_size_writer.request_inner_size(size);
+                state.resize(size);
+                state.window.request_redraw();
+            }
+            _ => {}
+        }
+    }
+}
+
+struct UiState {
+    window: Arc<Window>,
+    renderer: Renderer,
+    info: SetupScreenInfo,
+    status: WifiSetupStatus,
+    lines: Vec<DisplayLine>,
+}
+
+impl UiState {
+    fn new(event_loop: &ActiveEventLoop, info: SetupScreenInfo) -> Result<Self> {
+        let attrs = WindowAttributes::default()
+            .with_title("Frame Wi-Fi Setup")
+            .with_fullscreen(Some(Fullscreen::Borderless(None)));
+        let window = Arc::new(
+            event_loop
+                .create_window(attrs)
+                .context("failed to create wifi setup window")?,
+        );
+        let renderer = Renderer::new(window.clone(), &info)?;
+        let mut state = Self {
+            window,
+            renderer,
+            info,
+            status: WifiSetupStatus::StartingHotspot,
+            lines: Vec::new(),
+        };
+        state.update_status(WifiSetupStatus::StartingHotspot);
+        Ok(state)
+    }
+
+    fn update_status(&mut self, status: WifiSetupStatus) {
+        self.status = status.clone();
+        self.lines = compose_lines(&self.info, &self.status);
+    }
+
+    fn resize(&mut self, size: PhysicalSize<u32>) {
+        self.renderer.resize(size);
+    }
+
+    fn render(&mut self) -> Result<(), RenderError> {
+        self.renderer.render(&self.lines)
+    }
+}
+
+#[derive(Clone)]
+struct DisplayLine {
+    text: String,
+    scale: f32,
+    color: [f32; 4],
+}
+
+impl DisplayLine {
+    fn new<T: Into<String>>(text: T, scale: f32, color: [f32; 4]) -> Self {
+        Self {
+            text: text.into(),
+            scale,
+            color,
+        }
+    }
+}
+
+fn compose_lines(info: &SetupScreenInfo, status: &WifiSetupStatus) -> Vec<DisplayLine> {
+    let mut lines = Vec::new();
+    lines.push(DisplayLine::new(
+        "Frame Wi-Fi Setup",
+        44.0,
+        [0.05, 0.05, 0.05, 1.0],
+    ));
+    lines.push(DisplayLine::new("", 18.0, [0.05, 0.05, 0.05, 1.0]));
+    lines.push(DisplayLine::new(
+        format!("Hotspot: {}", info.hotspot_ssid),
+        28.0,
+        [0.1, 0.1, 0.1, 1.0],
+    ));
+    lines.push(DisplayLine::new(
+        format!("Password: {}", info.hotspot_password),
+        28.0,
+        [0.1, 0.1, 0.1, 1.0],
+    ));
+    lines.push(DisplayLine::new("", 18.0, [0.05, 0.05, 0.05, 1.0]));
+
+    if info.access_urls.is_empty() {
+        lines.push(DisplayLine::new(
+            "Open http://192.168.4.1:8080",
+            26.0,
+            [0.12, 0.12, 0.12, 1.0],
+        ));
+    } else {
+        lines.push(DisplayLine::new(
+            "Visit one of these URLs:",
+            26.0,
+            [0.12, 0.12, 0.12, 1.0],
+        ));
+        for url in &info.access_urls {
+            lines.push(DisplayLine::new(url.clone(), 26.0, [0.1, 0.1, 0.1, 1.0]));
+        }
+    }
+    lines.push(DisplayLine::new("", 18.0, [0.05, 0.05, 0.05, 1.0]));
+
+    let (status_text, color) = match status {
+        WifiSetupStatus::StartingHotspot => {
+            ("Preparing hotspot...".to_string(), [0.1, 0.3, 0.6, 1.0])
+        }
+        WifiSetupStatus::WaitingForCredentials => {
+            ("Ready for Wi-Fi details.".to_string(), [0.1, 0.3, 0.6, 1.0])
+        }
+        WifiSetupStatus::ApplyingCredentials { ssid } => {
+            (format!("Connecting to '{ssid}'..."), [0.1, 0.35, 0.7, 1.0])
+        }
+        WifiSetupStatus::ConnectionFailed { ssid, message } => {
+            let msg = if ssid.is_empty() {
+                format!("Setup error: {message}")
+            } else {
+                format!("Failed to connect to '{ssid}': {message}")
+            };
+            (msg, [0.75, 0.2, 0.2, 1.0])
+        }
+        WifiSetupStatus::Connected { ssid } => (
+            format!("Connected to '{ssid}'. Restarting..."),
+            [0.15, 0.55, 0.25, 1.0],
+        ),
+    };
+    lines.push(DisplayLine::new(status_text, 30.0, color));
+    lines
+}
+
+struct Renderer {
+    surface: wgpu::Surface<'static>,
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    config: wgpu::SurfaceConfiguration,
+    pipeline: wgpu::RenderPipeline,
+    glyph_brush: GlyphBrush<()>,
+    staging_belt: wgpu::util::StagingBelt,
+    qr_mesh: QrMesh,
+    vertex_buffer: Option<wgpu::Buffer>,
+    vertex_count: u32,
+}
+
+impl Renderer {
+    fn new(window: Arc<Window>, info: &SetupScreenInfo) -> Result<Self> {
+        let instance = wgpu::Instance::default();
+        let surface = instance
+            .create_surface(window.clone())
+            .context("failed to create surface")?;
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            compatible_surface: Some(&surface),
+            force_fallback_adapter: false,
+        }))
+        .context("failed to request adapter")?;
+        let limits = wgpu::Limits::downlevel_defaults();
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some("wifi-setup-device"),
+            required_features: wgpu::Features::empty(),
+            required_limits: limits,
+            memory_hints: wgpu::MemoryHints::default(),
+            trace: wgpu::Trace::default(),
+        }))
+        .context("failed to request device")?;
+        let capabilities = surface.get_capabilities(&adapter);
+        let format = capabilities
+            .formats
+            .iter()
+            .copied()
+            .find(|f| f.is_srgb())
+            .unwrap_or(capabilities.formats[0]);
+        let size = window.inner_size();
+        let config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format,
+            width: size.width.max(1),
+            height: size.height.max(1),
+            present_mode: wgpu::PresentMode::AutoVsync,
+            alpha_mode: capabilities.alpha_modes[0],
+            view_formats: vec![],
+            desired_maximum_frame_latency: 2,
+        };
+        surface.configure(&device, &config);
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("wifi-setup-shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("qr_shader.wgsl").into()),
+        });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("wifi-setup-pipeline-layout"),
+            bind_group_layouts: &[],
+            push_constant_ranges: &[],
+        });
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("wifi-setup-qr-pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[Vertex::layout()],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: config.format,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        let font =
+            FontArc::try_from_slice(include_bytes!("../../assets/fonts/Inconsolata-Regular.ttf"))
+                .context("failed to load UI font")?;
+        let glyph_brush = GlyphBrushBuilder::using_font(font).build(&device, config.format);
+        let qr_url = info
+            .access_urls
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "http://192.168.4.1:8080".to_string());
+        let qr_mesh = QrMesh::new(&qr_url)?;
+
+        let mut renderer = Self {
+            surface,
+            device,
+            queue,
+            config,
+            pipeline,
+            glyph_brush,
+            staging_belt: wgpu::util::StagingBelt::new(1024),
+            qr_mesh,
+            vertex_buffer: None,
+            vertex_count: 0,
+        };
+        renderer.rebuild_vertices(size);
+        Ok(renderer)
+    }
+
+    fn rebuild_vertices(&mut self, size: PhysicalSize<u32>) {
+        let vertices = self.qr_mesh.build_vertices(size.width, size.height);
+        if vertices.is_empty() {
+            self.vertex_buffer = None;
+            self.vertex_count = 0;
+            return;
+        }
+        self.vertex_count = vertices.len() as u32;
+        self.vertex_buffer = Some(self.device.create_buffer_init(
+            &wgpu::util::BufferInitDescriptor {
+                label: Some("wifi-setup-qr-verts"),
+                contents: bytemuck::cast_slice(&vertices),
+                usage: wgpu::BufferUsages::VERTEX,
+            },
+        ));
+    }
+
+    fn resize(&mut self, size: PhysicalSize<u32>) {
+        if size.width == 0 || size.height == 0 {
+            return;
+        }
+        self.config.width = size.width;
+        self.config.height = size.height;
+        self.surface.configure(&self.device, &self.config);
+        self.rebuild_vertices(size);
+    }
+
+    fn render(&mut self, lines: &[DisplayLine]) -> Result<(), RenderError> {
+        let frame = self
+            .surface
+            .get_current_texture()
+            .map_err(RenderError::Surface)?;
+        let view = frame
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("wifi-setup-encoder"),
+            });
+        {
+            let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("wifi-setup-pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    depth_slice: None,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color {
+                            r: 0.98,
+                            g: 0.98,
+                            b: 0.98,
+                            a: 1.0,
+                        }),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            if let Some(buffer) = &self.vertex_buffer {
+                rpass.set_pipeline(&self.pipeline);
+                rpass.set_vertex_buffer(0, buffer.slice(..));
+                rpass.draw(0..self.vertex_count, 0..1);
+            }
+        }
+        self.queue_text(lines);
+        self.glyph_brush
+            .draw_queued(
+                &self.device,
+                &mut self.staging_belt,
+                &mut encoder,
+                &view,
+                self.config.width,
+                self.config.height,
+            )
+            .map_err(RenderError::Glyph)?;
+        self.staging_belt.finish();
+        self.queue.submit(Some(encoder.finish()));
+        frame.present();
+        self.staging_belt.recall();
+        Ok(())
+    }
+
+    fn queue_text(&mut self, lines: &[DisplayLine]) {
+        let text_x =
+            (self.config.width as f32 * 0.55).clamp(40.0, self.config.width as f32 - 200.0);
+        let mut cursor_y =
+            (self.config.height as f32 * 0.18).clamp(40.0, self.config.height as f32 - 200.0);
+        for line in lines {
+            self.glyph_brush.queue(Section {
+                screen_position: (text_x, cursor_y),
+                bounds: (self.config.width as f32 * 0.4, self.config.height as f32),
+                text: vec![Text::new(&line.text)
+                    .with_scale(line.scale)
+                    .with_color(line.color)],
+                ..Section::default()
+            });
+            cursor_y += line.scale + 10.0;
+        }
+    }
+}
+
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(C)]
+struct Vertex {
+    position: [f32; 2],
+    color: [f32; 3],
+}
+
+const VERTEX_ATTRIBUTES: [wgpu::VertexAttribute; 2] =
+    wgpu::vertex_attr_array![0 => Float32x2, 1 => Float32x3];
+
+impl Vertex {
+    fn layout() -> wgpu::VertexBufferLayout<'static> {
+        wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<Vertex>() as u64,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &VERTEX_ATTRIBUTES,
+        }
+    }
+}
+
+struct QrMesh {
+    width: usize,
+    modules: Vec<bool>,
+}
+
+impl QrMesh {
+    fn new(url: &str) -> Result<Self> {
+        let code = QrCode::new(url.as_bytes()).context("failed to generate QR code")?;
+        let width = code.width();
+        let modules = code
+            .to_colors()
+            .into_iter()
+            .map(|color| matches!(color, qrcode::types::Color::Dark))
+            .collect::<Vec<_>>();
+        Ok(Self { width, modules })
+    }
+
+    fn build_vertices(&self, width: u32, height: u32) -> Vec<Vertex> {
+        if self.modules.is_empty() || self.width == 0 {
+            return Vec::new();
+        }
+        let width_f = width.max(1) as f32;
+        let height_f = height.max(1) as f32;
+        let max_qr_width = (width_f * 0.45).max(120.0);
+        let max_qr_height = (height_f * 0.8).max(120.0);
+        let module_size = (max_qr_width.min(max_qr_height) / self.width as f32).max(2.0);
+        let total_size = module_size * self.width as f32;
+        let mut start_x = (width_f * 0.1).max(20.0);
+        if start_x + total_size > width_f * 0.5 {
+            start_x = (width_f * 0.5 - total_size).max(20.0);
+        }
+        let mut start_y = ((height_f - total_size) / 2.0).max(20.0);
+        if start_y + total_size > height_f - 20.0 {
+            start_y = (height_f - total_size - 20.0).max(20.0);
+        }
+        let mut vertices = Vec::with_capacity(self.modules.len() * 6);
+        for y in 0..self.width {
+            for x in 0..self.width {
+                if !self.modules[y * self.width + x] {
+                    continue;
+                }
+                let px = start_x + x as f32 * module_size;
+                let py = start_y + y as f32 * module_size;
+                let x1 = px + module_size;
+                let y1 = py + module_size;
+                let tl = to_ndc(px, py, width_f, height_f);
+                let bl = to_ndc(px, y1, width_f, height_f);
+                let tr = to_ndc(x1, py, width_f, height_f);
+                let br = to_ndc(x1, y1, width_f, height_f);
+                let color = [0.05, 0.05, 0.05];
+                vertices.push(Vertex {
+                    position: tl,
+                    color,
+                });
+                vertices.push(Vertex {
+                    position: bl,
+                    color,
+                });
+                vertices.push(Vertex {
+                    position: br,
+                    color,
+                });
+                vertices.push(Vertex {
+                    position: tl,
+                    color,
+                });
+                vertices.push(Vertex {
+                    position: br,
+                    color,
+                });
+                vertices.push(Vertex {
+                    position: tr,
+                    color,
+                });
+            }
+        }
+        vertices
+    }
+}
+
+fn to_ndc(x: f32, y: f32, width: f32, height: f32) -> [f32; 2] {
+    [(x / width) * 2.0 - 1.0, 1.0 - (y / height) * 2.0]
+}
+
+enum RenderError {
+    Surface(wgpu::SurfaceError),
+    Glyph(String),
+}


### PR DESCRIPTION
## Summary
- capture the existing mode of `/etc/wpa_supplicant/wpa_supplicant.conf` when rewriting credentials
- ensure the temporary replacement file inherits those permissions (falling back to `0600` when missing)
- add a helper to centralize the Unix- and non-Unix-safe write paths

## Testing
- cargo fmt
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d5a248d0e483238a7a9f6d0cb3ae7e