### PR TITLE
Update dependencies to latest releases and migrate to rand 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,21 +4,21 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.99"
+anyhow = "1.0.100"
 bytemuck = { version = "1.23.2", features = ["derive"] }
-clap = { version = "4.5.47", features = ["derive"] }
+clap = { version = "4.5.48", features = ["derive"] }
 exif = { version = "0.6.1", package = "kamadak-exif" }
 image = { version = "0.25.8", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 jpeg-decoder = "0.3.2"
 fast_image_resize = { version = "5.3.0", default-features = false, features = ["only_u8x4"] }
 notify = "8.2.0"
 pollster = "0.4.0"
-rand = "0.8.5"
-serde = { version = "1.0.221", features = ["derive"] }
+rand = "0.9.2"
+serde = { version = "1.0.227", features = ["derive"] }
 serde_yaml = "0.9.34"
 humantime-serde = "1.1.1"
-humantime = "2.1.0"
-crossbeam-channel = "0.5.13"
+humantime = "2.3.0"
+crossbeam-channel = "0.5.15"
 tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "signal", "sync", "time"] }
 tokio-util = "0.7.16"
 tracing = "0.1.41"
@@ -29,5 +29,5 @@ winit = "0.30.12"
 wgpu_glyph = "0.26.0"
 
 [dev-dependencies]
-tempfile = "3.22.0"
-base64 = "0.22.0"
+tempfile = "3.23.0"
+base64 = "0.22.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1917,7 +1917,7 @@ impl AnglePicker {
         } else {
             match self.selection {
                 AngleSelection::Random => {
-                    let index = rng.gen_range(0..self.angles_deg.len());
+                    let index = rng.random_range(0..self.angles_deg.len());
                     self.angles_deg[index]
                 }
                 AngleSelection::Sequential => {
@@ -1928,7 +1928,7 @@ impl AnglePicker {
             }
         };
         if self.jitter_deg.abs() > f32::EPSILON {
-            let jitter = rng.gen_range(-self.jitter_deg..=self.jitter_deg);
+            let jitter = rng.random_range(-self.jitter_deg..=self.jitter_deg);
             base_angle + jitter
         } else {
             base_angle

--- a/src/tasks/files.rs
+++ b/src/tasks/files.rs
@@ -167,7 +167,7 @@ pub fn discover_startup_photos(cfg: &Configuration) -> Result<Vec<PhotoInfo>> {
 
     let mut rng = match cfg.startup_shuffle_seed {
         Some(seed) => rand::rngs::StdRng::seed_from_u64(seed),
-        None => rand::rngs::StdRng::from_entropy(),
+        None => rand::rngs::StdRng::from_os_rng(),
     };
     initial.shuffle(&mut rng);
 

--- a/src/tasks/manager.rs
+++ b/src/tasks/manager.rs
@@ -31,7 +31,7 @@ pub async fn run(
 ) -> Result<()> {
     let rng = match seed_override {
         Some(seed) => StdRng::seed_from_u64(seed),
-        None => StdRng::from_entropy(),
+        None => StdRng::from_os_rng(),
     };
     let mut playlist = PlaylistState::with_rng(options, rng, now_override);
 
@@ -256,7 +256,7 @@ where
 {
     let rng = match seed {
         Some(seed) => StdRng::seed_from_u64(seed),
-        None => StdRng::from_entropy(),
+        None => StdRng::from_os_rng(),
     };
     let mut playlist = PlaylistState::with_rng(options, rng, Some(now));
 

--- a/src/tasks/photo_affect.rs
+++ b/src/tasks/photo_affect.rs
@@ -51,7 +51,7 @@ async fn run_with_affects(
     cancel: CancellationToken,
     config: PhotoAffectConfig,
 ) -> Result<()> {
-    let mut rng = StdRng::from_entropy();
+    let mut rng = StdRng::from_os_rng();
 
     loop {
         select! {

--- a/src/tasks/viewer.rs
+++ b/src/tasks/viewer.rs
@@ -8,7 +8,7 @@ use crate::processing::color::average_color;
 use crate::processing::layout::{center_offset, resize_to_cover};
 use crossbeam_channel::{bounded, Receiver as CbReceiver, Sender as CbSender, TrySendError};
 use image::{imageops, Rgba, RgbaImage};
-use rand::{thread_rng, Rng};
+use rand::Rng;
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -432,7 +432,7 @@ pub fn run_windowed(
                     flash_color: cfg
                         .flash_color
                         .map(|channel| (channel as f32 / 255.0).clamp(0.0, 1.0)),
-                    noise_seed: [rng.gen(), rng.gen()],
+                    noise_seed: [rng.random(), rng.random()],
                 },
             };
             Self {
@@ -1028,7 +1028,7 @@ pub fn run_windowed(
                     self.deferred_images.push_front(img);
                     break;
                 };
-                let mut rng = thread_rng();
+                let mut rng = rand::rng();
                 let matting = self.matting.choose_option(&mut rng);
                 let params = MatParams {
                     screen_w: gpu.config.width.max(1),
@@ -1161,7 +1161,7 @@ pub fn run_windowed(
         ready_results: VecDeque::new(),
         deferred_images: VecDeque::new(),
         clear_color,
-        rng: thread_rng(),
+        rng: rand::rng(),
     };
     event_loop.run_app(&mut app)?;
     Ok(())


### PR DESCRIPTION
## Summary
- bump anyhow, clap, rand, serde, humantime, crossbeam-channel, tempfile, and base64 to their latest patch releases
- replace deprecated rand 0.8 APIs with the rand 0.9 equivalents across configuration, playlist management, file discovery, and viewer logic

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d5ab2c0d788323805523bb135bcc38