### PR TITLE
Prompt for installation user in setup wrapper

### DIFF
--- a/setup/modules/30-wifi-watcher.sh
+++ b/setup/modules/30-wifi-watcher.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+FRAME_USER_REQUESTED="${FRAME_USER:-}"
+
+choose_frame_user() {
+    local requested_user="$1"
+    local repo_owner
+    repo_owner="$(stat -c %U "${REPO_ROOT}")"
+
+    local -a candidates=()
+    local -A seen=()
+
+    if [[ -n "${requested_user}" ]]; then
+        candidates+=("${requested_user}")
+    fi
+    if [[ -n "${SUDO_USER:-}" ]]; then
+        candidates+=("${SUDO_USER}")
+    fi
+    if [[ -n "${repo_owner}" ]]; then
+        candidates+=("${repo_owner}")
+    fi
+    candidates+=("frame" "root")
+
+    local candidate
+    for candidate in "${candidates[@]}"; do
+        if [[ -z "${candidate}" ]]; then
+            continue
+        fi
+        if [[ -n "${seen[${candidate}]:-}" ]]; then
+            continue
+        fi
+        seen["${candidate}"]=1
+        if id -u "${candidate}" >/dev/null 2>&1; then
+            echo "${candidate}"
+            return 0
+        fi
+    done
+
+    echo "root"
+}
+
+FRAME_USER="$(choose_frame_user "${FRAME_USER_REQUESTED}")"
+
+if [[ -n "${FRAME_USER_REQUESTED}" && "${FRAME_USER}" != "${FRAME_USER_REQUESTED}" ]]; then
+    echo "[30-wifi-watcher] Requested user '${FRAME_USER_REQUESTED}' was not found; using '${FRAME_USER}' instead."
+fi
+
+FRAME_HOME="$(getent passwd "${FRAME_USER}" | cut -d: -f6)"
+if [[ -z "${FRAME_HOME}" ]]; then
+    echo "[30-wifi-watcher] Unable to determine home directory for user '${FRAME_USER}'." >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+if [[ -f "${FRAME_HOME}/.cargo/env" ]]; then
+    source "${FRAME_HOME}/.cargo/env"
+elif [[ -d "${FRAME_HOME}/.cargo/bin" ]]; then
+    export PATH="${FRAME_HOME}/.cargo/bin:${PATH}"
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "[30-wifi-watcher] cargo is required but was not found in PATH." >&2
+    exit 1
+fi
+
+run_as_frame() {
+    local cmd="$1"
+    if [[ "${FRAME_USER}" == "root" ]]; then
+        bash -lc "${cmd}"
+    else
+        sudo -u "${FRAME_USER}" -H bash -lc "${cmd}"
+    fi
+}
+
+echo "[30-wifi-watcher] Building Wi-Fi watcher binaries with cargo (user: ${FRAME_USER})..."
+run_as_frame "cd '${REPO_ROOT}' && cargo build --release"
+echo "[30-wifi-watcher] Build completed. Artifacts available in target/release."

--- a/setup/setup-modules/02-install-rust.sh
+++ b/setup/setup-modules/02-install-rust.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TARGET_USER="${SUDO_USER:-$USER}"
+TARGET_USER="${FRAME_USER:-${SUDO_USER:-$USER}}"
 TARGET_HOME="$(eval echo ~"${TARGET_USER}")"
 CARGO_BIN="${TARGET_HOME}/.cargo/bin"
 

--- a/setup/system-setup.sh
+++ b/setup/system-setup.sh
@@ -2,12 +2,48 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 MODULE_DIR="${SCRIPT_DIR}/setup-modules"
 
 if [[ $EUID -ne 0 ]]; then
-    echo "[ERROR] This script must be run with sudo or as root." >&2
+    export FRAME_USER="${FRAME_USER:-${USER}}"
+    exec sudo FRAME_USER="${FRAME_USER}" "${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"
+fi
+
+prompt_for_frame_user() {
+    local input
+    while true; do
+        read -r -p "Enter the username that should own the rust-photo-frame installation: " input
+        input="${input// /}"
+        if [[ -z "${input}" ]]; then
+            echo "[ERROR] Username cannot be empty." >&2
+            continue
+        fi
+        if ! id -u "${input}" >/dev/null 2>&1; then
+            echo "[ERROR] User '${input}' does not exist on this system." >&2
+            continue
+        fi
+        FRAME_USER="${input}"
+        export FRAME_USER
+        break
+    done
+}
+
+if [[ -z "${FRAME_USER:-}" ]]; then
+    if [[ -n "${SUDO_USER:-}" ]]; then
+        FRAME_USER="${SUDO_USER}"
+        export FRAME_USER
+    else
+        prompt_for_frame_user
+    fi
+fi
+
+if ! id -u "${FRAME_USER}" >/dev/null 2>&1; then
+    echo "[ERROR] Target user '${FRAME_USER}' does not exist. Use FRAME_USER to specify a valid account." >&2
     exit 1
 fi
+
+echo "[INFO] Configuring rust-photo-frame for user '${FRAME_USER}'."
 
 if [[ ! -d "${MODULE_DIR}" ]]; then
     echo "[ERROR] Module directory not found: ${MODULE_DIR}" >&2


### PR DESCRIPTION
## Summary
- teach the setup wrapper to re-exec with sudo when run as a regular user, or prompt for the target account when started as root
- export the resolved FRAME_USER for all modules and make the Rust installer prefer that account
- document the new wrapper behavior so operators know they can launch it without sudo

## Testing
- bash -n setup/system-setup.sh
- bash -n setup/setup-modules/02-install-rust.sh
- bash -n setup/modules/30-wifi-watcher.sh

------
https://chatgpt.com/codex/tasks/task_e_68d766ea4d388323a2ec230d40df69d5