### PR TITLE
Refine Wi-Fi provisioning server configuration and templates

### DIFF
--- a/crates/wifi-setter/Cargo.toml
+++ b/crates/wifi-setter/Cargo.toml
@@ -13,4 +13,3 @@ tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "signal"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 thiserror = "1.0"
-parking_lot = "0.12"

--- a/crates/wifi-setter/src/main.rs
+++ b/crates/wifi-setter/src/main.rs
@@ -3,6 +3,7 @@ mod web;
 
 use std::env;
 use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
@@ -31,22 +32,17 @@ struct FrameConfig {
 
 impl Settings {
     fn load() -> Result<Self> {
-        let config_path = std::path::PathBuf::from(
-            env::var("PHOTO_FRAME_CONFIG")
-                .unwrap_or_else(|_| "/etc/photo-frame/config.yaml".to_string()),
-        );
+        let config_path = Self::config_path();
         let mut wifi_ifname = env::var("WIFI_IFNAME").unwrap_or_else(|_| "wlan0".to_string());
         let mut hotspot_ip = env::var("HOTSPOT_IP").unwrap_or_else(|_| "192.168.4.1".to_string());
 
         if config_path.exists() {
-            if let Ok(contents) = std::fs::read_to_string(&config_path) {
-                if let Ok(cfg) = serde_yaml::from_str::<FrameConfig>(&contents) {
-                    if let Some(value) = cfg.wifi_ifname {
-                        wifi_ifname = value;
-                    }
-                    if let Some(value) = cfg.hotspot_ip {
-                        hotspot_ip = value;
-                    }
+            if let Some(cfg) = read_config(&config_path).ok().flatten() {
+                if let Some(value) = cfg.wifi_ifname {
+                    wifi_ifname = value;
+                }
+                if let Some(value) = cfg.hotspot_ip {
+                    hotspot_ip = value;
                 }
             }
         }
@@ -62,18 +58,21 @@ impl Settings {
             bind_addr,
         })
     }
+
+    fn config_path() -> PathBuf {
+        env::var("PHOTO_FRAME_CONFIG")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("/etc/photo-frame/config.yaml"))
+    }
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     init_tracing();
     let settings = Settings::load()?;
-    info!(?settings.bind_addr, "starting wifi setter");
+    info!(bind_addr = %settings.bind_addr, wifi_ifname = %settings.wifi_ifname, "starting wifi setter");
 
-    let state = AppState {
-        ifname: settings.wifi_ifname.clone(),
-        hotspot_ip: settings.hotspot_ip.clone(),
-    };
+    let state = AppState::from(&settings);
 
     let listener = TcpListener::bind(settings.bind_addr)
         .await
@@ -98,5 +97,18 @@ async fn shutdown() {
         info!("wifi setter received shutdown signal");
     } else {
         warn!("wifi setter shutdown signal stream errored");
+    }
+}
+
+fn read_config(path: &Path) -> Result<Option<FrameConfig>> {
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("reading config at {}", path.display()))?;
+    let cfg: FrameConfig = serde_yaml::from_str(&contents).context("parsing config.yaml")?;
+    Ok(Some(cfg))
+}
+
+impl From<&Settings> for AppState {
+    fn from(settings: &Settings) -> Self {
+        AppState::new(settings.wifi_ifname.clone(), settings.hotspot_ip.clone())
     }
 }

--- a/crates/wifi-setter/src/web.rs
+++ b/crates/wifi-setter/src/web.rs
@@ -1,36 +1,44 @@
 use axum::extract::{Form, State};
 use axum::http::StatusCode;
-use axum::response::{Html, IntoResponse};
+use axum::response::Html;
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 use tracing::{error, info, warn};
 
 use crate::nm::{self, Connectivity, ScannedNetwork};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct AppState {
-    pub ifname: String,
-    pub hotspot_ip: String,
+    ifname: String,
+    hotspot_ip: String,
+}
+
+impl AppState {
+    pub fn new(ifname: String, hotspot_ip: String) -> Self {
+        Self { ifname, hotspot_ip }
+    }
+
+    pub fn wifi_ifname(&self) -> &str {
+        &self.ifname
+    }
+
+    pub fn hotspot_ip(&self) -> &str {
+        &self.hotspot_ip
+    }
 }
 
 pub fn app(state: AppState) -> Router {
-    let shared = Arc::new(state);
     Router::new()
         .route("/", get(index))
         .route("/apply", post(apply))
         .route("/scan", get(scan))
         .route("/api/status", get(status))
-        .with_state(shared)
+        .with_state(state)
 }
 
-async fn index(State(state): State<Arc<AppState>>) -> Html<String> {
-    let html = format!(
-        "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>WiFi Setup</title><style>body{{font-family:Arial,sans-serif;background:#0b0c10;color:#f4f4f4;margin:0;padding:2rem;}}main{{max-width:480px;margin:0 auto;}}h1{{margin-bottom:0.5rem;}}label{{display:block;margin-top:1rem;}}input,button{{width:100%;padding:0.75rem;margin-top:0.25rem;border-radius:0.5rem;border:none;}}button{{background:#45a29e;color:#0b0c10;font-weight:bold;cursor:pointer;}}button:hover{{background:#66fcf1;}}.status{{margin-top:1.5rem;padding:1rem;background:#1f2833;border-radius:0.5rem;}}</style></head><body><main><h1>Connect to your Wi-Fi</h1><p>Enter the Wi-Fi network and password to bring the frame online. The hotspot is reachable at <strong>http://{ip}/</strong>.</p><form method=\"post\" action=\"/apply\"><label for=\"ssid\">Network name (SSID)</label><input id=\"ssid\" name=\"ssid\" list=\"ssid-options\" required autofocus><datalist id=\"ssid-options\"></datalist><label for=\"password\">Password</label><input id=\"password\" name=\"password\" type=\"password\" autocomplete=\"off\" required><button type=\"submit\">Connect</button></form><section class=\"status\"><h2>Status</h2><p id=\"status-text\">Checking&hellip;</p></section></main><script>async function refreshNetworks(){{try{{const res=await fetch('/scan');if(!res.ok)return;const networks=await res.json();const list=document.getElementById('ssid-options');list.innerHTML='';networks.forEach(n=>{{const opt=document.createElement('option');opt.value=n.ssid;list.appendChild(opt);}});}}catch(e){{console.error(e);}}}}async function refreshStatus(){{try{{const res=await fetch('/api/status');if(!res.ok)return;const data=await res.json();const text=document.getElementById('status-text');if(data.connected){{const label=data.ssid?'Connected to '+data.ssid:'Connected';text.textContent=label;}}else{{text.textContent='Not connected';}}}}catch(e){{console.error(e);}}}}refreshNetworks();refreshStatus();setInterval(refreshStatus,2000);setInterval(refreshNetworks,15000);</script></body></html>",
-        ip = state.hotspot_ip
-    );
-    Html(html)
+async fn index(State(state): State<AppState>) -> Html<String> {
+    Html(render_index(&state))
 }
 
 #[derive(Deserialize)]
@@ -40,63 +48,50 @@ struct ApplyForm {
 }
 
 async fn apply(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Form(form): Form<ApplyForm>,
-) -> impl IntoResponse {
-    let ssid = form.ssid.trim();
-    if ssid.is_empty() {
-        return (
+) -> Result<Html<String>, (StatusCode, Html<String>)> {
+    let ApplyForm { ssid, password } = form;
+    let ssid_trimmed = ssid.trim();
+    if ssid_trimmed.is_empty() {
+        return Err((
             StatusCode::BAD_REQUEST,
-            Html("<p>SSID is required.</p>".to_string()),
-        )
-            .into_response();
+            Html(render_validation_error("SSID is required.")),
+        ));
     }
-    let password = form.password.trim();
-    if password.is_empty() {
-        return (
+    let password_trimmed = password.trim();
+    if password_trimmed.is_empty() {
+        return Err((
             StatusCode::BAD_REQUEST,
-            Html("<p>Password is required.</p>".to_string()),
-        )
-            .into_response();
+            Html(render_validation_error("Password is required.")),
+        ));
     }
 
-    let result: Result<(), nm::NmError> = match nm::connection_for_ssid(ssid) {
+    let result: Result<(), nm::NmError> = match nm::connection_for_ssid(ssid_trimmed) {
         Ok(Some(conn)) => {
-            info!(ssid, "updating known network");
-            nm::modify_known_wifi(&conn.name, password)
+            info!(ssid = ssid_trimmed, "updating known network");
+            nm::modify_known_wifi(&conn.name, password_trimmed)
         }
         Ok(None) => {
-            info!(ssid, "creating new network");
-            nm::create_new_wifi(ssid, password, &state.ifname)
+            info!(ssid = ssid_trimmed, "creating new network");
+            nm::create_new_wifi(ssid_trimmed, password_trimmed, state.wifi_ifname())
         }
         Err(err) => Err(err),
     };
 
     match result {
-        Ok(()) => Html(connecting_page(ssid)).into_response(),
+        Ok(()) => Ok(Html(render_connecting(ssid_trimmed))),
         Err(err) => {
             error!(?err, "failed to apply Wi-Fi settings");
-            (StatusCode::INTERNAL_SERVER_ERROR, Html(error_page())).into_response()
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Html(render_generic_error_page()),
+            ))
         }
     }
 }
 
-fn connecting_page(ssid: &str) -> String {
-    let mut html = String::from(
-        "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><meta http-equiv=\"refresh\" content=\"3\"><title>Connecting</title><style>body{font-family:Arial,sans-serif;background:#0b0c10;color:#f4f4f4;display:flex;align-items:center;justify-content:center;height:100vh;}div{max-width:420px;text-align:center;}h1{margin-bottom:0.5rem;}</style></head><body><div><h1>Connecting…</h1><p>Attempting to join <strong>"
-    );
-    html.push_str(ssid);
-    html.push_str(
-        "</strong>. This page refreshes once the frame is online.</p><script>async function poll(){try{const res=await fetch('/api/status');if(res.ok){const data=await res.json();if(data.connected){window.location='/';}}}catch(e){console.error(e);}setTimeout(poll,2000);}poll();</script></div></body></html>",
-    );
-    html
-}
-
-fn error_page() -> String {
-    "<html><body style=\"font-family:Arial,sans-serif;background:#0b0c10;color:#f4f4f4;display:flex;align-items:center;justify-content:center;height:100vh;\"><div><h1>Connection failed</h1><p>We could not apply those Wi-Fi settings. Please go back and try again.</p><p><a href=\"/\" style=\"color:#66fcf1\">Return to form</a></p></div></body></html>".to_string()
-}
-
-async fn scan(State(_state): State<Arc<AppState>>) -> Json<Vec<ScannedNetwork>> {
+async fn scan() -> Json<Vec<ScannedNetwork>> {
     match nm::scan_networks() {
         Ok(list) => Json(list),
         Err(err) => {
@@ -112,7 +107,7 @@ struct StatusResponse {
     ssid: Option<String>,
 }
 
-async fn status(State(_state): State<Arc<AppState>>) -> Json<StatusResponse> {
+async fn status() -> Json<StatusResponse> {
     let connected = matches!(nm::connectivity(), Ok(Connectivity::Full));
     let ssid = match nm::active_ssid() {
         Ok(value) => value,
@@ -122,4 +117,71 @@ async fn status(State(_state): State<Arc<AppState>>) -> Json<StatusResponse> {
         }
     };
     Json(StatusResponse { connected, ssid })
+}
+
+fn render_index(state: &AppState) -> String {
+    templates::INDEX.replace("{HOTSPOT_IP}", state.hotspot_ip())
+}
+
+fn render_connecting(ssid: &str) -> String {
+    templates::CONNECTING.replace("{SSID}", &escape_html(ssid))
+}
+
+fn render_validation_error(message: &str) -> String {
+    render_message_page("Invalid input", message)
+}
+
+fn render_generic_error_page() -> String {
+    render_message_page(
+        "Connection failed",
+        "We could not apply those Wi-Fi settings. Please go back and try again.",
+    )
+}
+
+fn render_message_page(title: &str, message: &str) -> String {
+    templates::MESSAGE_PAGE
+        .replace("{TITLE}", &escape_html(title))
+        .replace("{BODY}", &escape_html(message))
+}
+
+fn escape_html(input: &str) -> String {
+    let mut escaped = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#39;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+mod templates {
+    pub(super) const INDEX: &str = r#"<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Wi-Fi Setup</title><style>body { font-family: Arial, sans-serif; background: #0b0c10; color: #f4f4f4; margin: 0; padding: 2rem; } main { max-width: 480px; margin: 0 auto; } h1 { margin-bottom: 0.5rem; } label { display: block; margin-top: 1rem; } input, button { width: 100%; padding: 0.75rem; margin-top: 0.25rem; border-radius: 0.5rem; border: none; } button { background: #45a29e; color: #0b0c10; font-weight: bold; cursor: pointer; } button:hover { background: #66fcf1; } .status { margin-top: 1.5rem; padding: 1rem; background: #1f2833; border-radius: 0.5rem; }</style></head><body><main><h1>Connect to your Wi-Fi</h1><p>Enter the Wi-Fi network and password to bring the frame online. The hotspot is reachable at <strong>http://{HOTSPOT_IP}/</strong>.</p><form method="post" action="/apply"><label for="ssid">Network name (SSID)</label><input id="ssid" name="ssid" list="ssid-options" required autofocus><datalist id="ssid-options"></datalist><label for="password">Password</label><input id="password" name="password" type="password" autocomplete="off" required><button type="submit">Connect</button></form><section class="status"><h2>Status</h2><p id="status-text">Checking&hellip;</p></section></main><script>async function refreshNetworks(){try{const res=await fetch('/scan');if(!res.ok)return;const networks=await res.json();const list=document.getElementById('ssid-options');list.innerHTML='';networks.forEach(n=>{const opt=document.createElement('option');opt.value=n.ssid;list.appendChild(opt);});}catch(e){console.error(e);}}async function refreshStatus(){try{const res=await fetch('/api/status');if(!res.ok)return;const data=await res.json();const text=document.getElementById('status-text');if(data.connected){const label=data.ssid?'Connected to '+data.ssid:'Connected';text.textContent=label;}else{text.textContent='Not connected';}}catch(e){console.error(e);}}refreshNetworks();refreshStatus();setInterval(refreshStatus,2000);setInterval(refreshNetworks,15000);</script></body></html>"#;
+
+    pub(super) const CONNECTING: &str = r#"<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta http-equiv="refresh" content="3"><title>Connecting</title><style>body { font-family: Arial, sans-serif; background: #0b0c10; color: #f4f4f4; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; } div { max-width: 420px; text-align: center; } h1 { margin-bottom: 0.5rem; }</style></head><body><div><h1>Connecting…</h1><p>Attempting to join <strong>{SSID}</strong>. This page refreshes once the frame is online.</p><script>async function poll(){try{const res=await fetch('/api/status');if(res.ok){const data=await res.json();if(data.connected){window.location='/';}}}catch(e){console.error(e);}setTimeout(poll,2000);}poll();</script></div></body></html>"#;
+
+    pub(super) const MESSAGE_PAGE: &str = r#"<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Wi-Fi Setup</title><style>body { font-family: Arial, sans-serif; background: #0b0c10; color: #f4f4f4; display: flex; align-items: center; justify-content: center; height: 100vh; margin: 0; } div { max-width: 420px; text-align: center; padding: 1.5rem; background: #1f2833; border-radius: 0.75rem; } a { color: #66fcf1; }</style></head><body><div><h1>{TITLE}</h1><p>{BODY}</p><p><a href="/">Return to form</a></p></div></body></html>"#;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_html_replaces_special_characters() {
+        let input = "<ssid>&\"'";
+        let escaped = escape_html(input);
+        assert_eq!(escaped, "&lt;ssid&gt;&amp;&quot;&#39;");
+    }
+
+    #[test]
+    fn connecting_page_escapes_ssid() {
+        let html = render_connecting("My <SSID>");
+        assert!(html.contains("My &lt;SSID&gt;"));
+        assert!(!html.contains("My <SSID>"));
+    }
 }


### PR DESCRIPTION
## Summary
- reuse the shared config loading style in the Wi-Fi setter and construct the web state from Settings
- restructure the provisioning handlers around reusable HTML templates with proper escaping and validation messaging
- drop the unused `parking_lot` dependency and cover the new escaping helper with unit tests

## Testing
- cargo check --manifest-path crates/wifi-setter/Cargo.toml
- cargo test --manifest-path crates/wifi-setter/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68d8c68ccdf083239c7a16eaac43adf8