### PR TITLE
Support multiple fixed-image matting backgrounds

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -100,5 +100,9 @@ matting:
       weft-period-px: 5.2 # spacing between horizontal weft threads in px
     fixed-image:
       minimum-mat-percentage: 6.0
-      path: /opt/photo-frame/share/backgrounds/default-fixed.jpg
+      path: [
+        /opt/photo-frame/share/backgrounds/default-0.jpg,
+        /opt/photo-frame/share/backgrounds/default-1.jpg,
+      ]
+      path-selection: sequential # or random
       fit: cover # options: cover, contain, stretch

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -349,7 +349,8 @@ The studio mat derives a uniform base color from the photo’s average RGB, rend
 
 ### `fixed-image`
 
-- **`path`** (string, required): Filesystem path to the background image that should appear behind every photo. The file is loaded once at startup and cached for reuse.
+- **`path`** (string or string array, required): One or more filesystem paths to the backdrop image(s). All referenced files are loaded and cached at startup. Supplying an empty array disables the `fixed-image` mat without raising an error.
+- **`path-selection`** (`sequential` or `random`; default `sequential`): Chooses how to rotate through the configured backgrounds when more than one path is supplied.
 - **`fit`** (`cover`, `contain`, or `stretch`; default `cover`): Chooses how the background scales to the canvas—fill while cropping (`cover`), letterbox without cropping (`contain`), or distort to fit exactly (`stretch`).
 
-Selecting `fixed-image` keeps the backdrop perfectly consistent across slides, which is ideal for branded frames or themed installations.
+Selecting `fixed-image` keeps the backdrop perfectly consistent across slides when only one path is listed, or rotates through a curated set of branded backgrounds when multiple paths are available.

--- a/src/tasks/viewer.rs
+++ b/src/tasks/viewer.rs
@@ -352,7 +352,8 @@ pub fn run_windowed(
             }
             MattingMode::Studio { .. } => unreachable!(),
             MattingMode::FixedImage { fit, .. } => {
-                if let Some(bg) = matting.runtime.fixed_image.as_ref() {
+                let mut rng = rand::rng();
+                if let Some(bg) = matting.runtime.select_fixed_image(&mut rng) {
                     match bg.canvas_for(*fit, canvas_w, canvas_h, max_dim) {
                         Ok(prepared) => prepared.as_ref().clone(),
                         Err(err) => {


### PR DESCRIPTION
## Summary
- allow the fixed-image matting configuration to accept multiple paths with sequential or random selection and ignore empty lists
- preload every configured fixed background at startup and pick one per frame while keeping the viewer fallback safe
- refresh the sample config, documentation, and config tests to cover the new list syntax and behaviors

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d93ecea20c8323b82fe612d27bf5fc