### PR TITLE
Rename photo effect pipeline and allow empty effect list

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -58,10 +58,10 @@ loader-max-concurrent-decodes: 4
 # Optional deterministic seed for the initial shuffle (set to null for random)
 startup-shuffle-seed: null
 
-photo-affect:
-  # List zero or more affect types; set to [] to disable the stage entirely.
+photo-effect:
+  # List zero or more effect types; set to [] to disable the stage entirely.
   types: [print-simulation]
-  # Choose how to iterate through affects when multiple are configured.
+  # Choose how to iterate through effects when multiple are configured.
   type-selection: random
   options:
     print-simulation:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,8 +19,8 @@ loader-max-concurrent-decodes: 4 # Concurrent decodes in the loader
 oversample: 1.0 # GPU render oversample vs. screen size
 startup-shuffle-seed: null # Optional deterministic seed for initial shuffle
 
-photo-affect:
-  types: [print-simulation] # Set to [] to disable all affects
+photo-effect:
+  types: [print-simulation] # Set to [] to disable all effects
   options:
     print-simulation:
       relief-strength: 0.35
@@ -54,7 +54,7 @@ Use the quick reference below to locate the knobs you care about, then dive into
 | **Core timing**        | `transition`, `dwell-ms`, `playlist`                                  |
 | **Performance tuning** | `viewer-preload-count`, `loader-max-concurrent-decodes`, `oversample` |
 | **Deterministic runs** | `startup-shuffle-seed`                                                |
-| **Presentation**       | `photo-affect`, `matting`                                             |
+| **Presentation**       | `photo-effect`, `matting`                                             |
 | **Greeting Screen**    | `greeting-screen`                                                     |
 
 ## Key reference
@@ -116,12 +116,12 @@ Use the quick reference below to locate the knobs you care about, then dive into
 - **Accepted values & defaults:** Mapping described in [Playlist weighting](#playlist-weighting); defaults to three copies for new images and a one-day half-life.
 - **Effect on behavior:** Aggressive settings make new imports loop repeatedly until they age; conservative settings let the library settle into an even rotation.
 
-### `photo-affect`
+### `photo-effect`
 
-- **Type:** mapping (see [Photo affect configuration](#photo-affect-configuration))
+- **Type:** mapping (see [Photo effect configuration](#photo-effect-configuration))
 - **Default:** disabled (`types: []`)
-- **What it does:** Inserts an optional post-processing stage between the loader and viewer. The built-in `print-simulation` affect relights each frame with directional shading and paper sheen inspired by _3D Simulation of Prints for Improved Soft Proofing_.
-- **When to change it:** Enable when you want the frame to mimic how ink interacts with paper under gallery lighting, or when you add additional affects in future releases.
+- **What it does:** Inserts an optional post-processing stage between the loader and viewer. The built-in `print-simulation` effect relights each frame with directional shading and paper sheen inspired by _3D Simulation of Prints for Improved Soft Proofing_.
+- **When to change it:** Enable when you want the frame to mimic how ink interacts with paper under gallery lighting, or when you add additional effects in future releases.
 
 ### `greeting-screen`
 
@@ -177,20 +177,20 @@ The command prints the multiplicity assigned to each discovered photo and the fi
 | `new-multiplicity` | Optional  | `3`     | Integer ≥ 1                                                                 | Sets how many times a brand-new photo appears in the next loop; higher values surface newcomers more often. |
 | `half-life`        | Optional  | `1 day` | Positive duration string parsed by [`humantime`](https://docs.rs/humantime) | Controls how quickly the extra repeats decay; shorter half-lives return the playlist to equilibrium faster. |
 
-## Photo affect configuration
+## Photo effect configuration
 
-The optional `photo-affect` task sits between the loader and the viewer. When enabled it reconstructs the decoded RGBA pixels, applies any configured affects, and forwards the modified image downstream. Leave `types` empty (or omit the block entirely) to short-circuit the stage and pass photos through untouched.
+The optional `photo-effect` task sits between the loader and the viewer. When enabled it reconstructs the decoded RGBA pixels, applies any configured effects, and forwards the modified image downstream. Leave `types` empty (or omit the block entirely) to short-circuit the stage and pass photos through untouched.
 
-### Scheduling affects
+### Scheduling effects
 
-- **`types`** — List the affect kinds to rotate through. Supported values today: `print-simulation`. Set to `[]` to keep the stage disabled while preserving the scaffold for future affects.
-- **`type-selection`** — Optional. `random` (default) or `sequential`. `random` draws an affect independently for each slide, while `sequential` walks the `types` list in order and loops back to the first entry after the last.
-- **`options`** — Map of per-affect controls. Every affect referenced in `types` must appear here so the runtime can look up its parameters.
+- **`types`** — List the effect kinds to rotate through. Supported values today: `print-simulation`. Set to `[]` to keep the stage disabled while preserving the scaffold for future effects.
+- **`type-selection`** — Optional. `random` (default) or `sequential`. `random` draws an effect independently for each slide, while `sequential` walks the `types` list in order and loops back to the first entry after the last.
+- **`options`** — Map of per-effect controls. Every effect referenced in `types` must appear here so the runtime can look up its parameters.
 
-Example: enable the print simulation affect while keeping its debug split active for quick before/after checks.
+Example: enable the print simulation effect while keeping its debug split active for quick before/after checks.
 
 ```yaml
-photo-affect:
+photo-effect:
   types: [print-simulation]
   type-selection: sequential
   options:
@@ -198,7 +198,7 @@ photo-affect:
       debug: true
 ```
 
-### Print-simulation affect
+### Print-simulation effect
 
 `print-simulation` adapts ideas from _3D Simulation of Prints for Improved Soft Proofing_ to mimic how a framed print interacts with gallery lighting. It derives a shallow height-field from local luminance gradients, shades that relief with a configurable key light, and layers in ink compression plus paper sheen so highlights glow like coated stock. Tunable controls let operators dial in their paper stock and lighting rig:
 
@@ -207,7 +207,7 @@ photo-affect:
 - `ink-spread` (float ≥ 0, default `0.18`): Tone compression coefficient that emulates dye absorption.
 - `sheen-strength` (float ≥ 0, default `0.22`): How strongly the simulated paper sheen is blended into highlights.
 - `paper-color` (RGB array, default `[245, 244, 240]`): Base tint of the reflective sheen layer.
-- `debug` (bool, default `false`): When `true`, only the left half of the image receives the affect so you can compare it against the untouched right half.
+- `debug` (bool, default `false`): When `true`, only the left half of the image receives the effect so you can compare it against the untouched right half.
 
 ## Transition configuration
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1159,11 +1159,11 @@ impl MattingMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum PhotoAffectKind {
+pub enum PhotoEffectKind {
     PrintSimulation,
 }
 
-impl PhotoAffectKind {
+impl PhotoEffectKind {
     const ALL: &'static [Self] = &[Self::PrintSimulation];
     const NAMES: &'static [&'static str] = &["print-simulation"];
 
@@ -1174,13 +1174,13 @@ impl PhotoAffectKind {
     }
 }
 
-impl fmt::Display for PhotoAffectKind {
+impl fmt::Display for PhotoEffectKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
 
-impl<'de> Deserialize<'de> for PhotoAffectKind {
+impl<'de> Deserialize<'de> for PhotoEffectKind {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -1251,19 +1251,19 @@ impl PrintSimulationOptions {
     pub fn validate(&self) -> Result<()> {
         ensure!(
             self.relief_strength.is_finite() && self.relief_strength >= 0.0,
-            "photo-affect.print-simulation.relief-strength must be non-negative"
+            "photo-effect.print-simulation.relief-strength must be non-negative"
         );
         ensure!(
             self.ink_spread.is_finite() && self.ink_spread >= 0.0,
-            "photo-affect.print-simulation.ink-spread must be non-negative"
+            "photo-effect.print-simulation.ink-spread must be non-negative"
         );
         ensure!(
             self.sheen_strength.is_finite() && self.sheen_strength >= 0.0,
-            "photo-affect.print-simulation.sheen-strength must be non-negative"
+            "photo-effect.print-simulation.sheen-strength must be non-negative"
         );
         ensure!(
             self.light_angle_degrees.is_finite(),
-            "photo-affect.print-simulation.light-angle-degrees must be a finite value"
+            "photo-effect.print-simulation.light-angle-degrees must be a finite value"
         );
         Ok(())
     }
@@ -1283,20 +1283,20 @@ impl Default for PrintSimulationOptions {
 }
 
 #[derive(Debug, Clone)]
-pub enum PhotoAffectOptions {
+pub enum PhotoEffectOptions {
     PrintSimulation(PrintSimulationOptions),
 }
 
-impl PhotoAffectOptions {
-    pub fn kind(&self) -> PhotoAffectKind {
+impl PhotoEffectOptions {
+    pub fn kind(&self) -> PhotoEffectKind {
         match self {
-            Self::PrintSimulation(_) => PhotoAffectKind::PrintSimulation,
+            Self::PrintSimulation(_) => PhotoEffectKind::PrintSimulation,
         }
     }
 
     pub fn validate(&self) -> Result<()> {
         match self {
-            PhotoAffectOptions::PrintSimulation(options) => options
+            PhotoEffectOptions::PrintSimulation(options) => options
                 .validate()
                 .context("invalid print-simulation options"),
         }
@@ -1304,63 +1304,63 @@ impl PhotoAffectOptions {
 }
 
 #[derive(Debug, Clone)]
-pub enum PhotoAffectSelection {
+pub enum PhotoEffectSelection {
     Disabled,
-    Fixed(PhotoAffectKind),
-    Random(Vec<PhotoAffectKind>),
+    Fixed(PhotoEffectKind),
+    Random(Vec<PhotoEffectKind>),
     Sequential {
-        kinds: Vec<PhotoAffectKind>,
+        kinds: Vec<PhotoEffectKind>,
         runtime: SequentialState,
     },
 }
 
-impl PartialEq for PhotoAffectSelection {
+impl PartialEq for PhotoEffectSelection {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (PhotoAffectSelection::Disabled, PhotoAffectSelection::Disabled) => true,
-            (PhotoAffectSelection::Fixed(a), PhotoAffectSelection::Fixed(b)) => a == b,
-            (PhotoAffectSelection::Random(a), PhotoAffectSelection::Random(b)) => a == b,
+            (PhotoEffectSelection::Disabled, PhotoEffectSelection::Disabled) => true,
+            (PhotoEffectSelection::Fixed(a), PhotoEffectSelection::Fixed(b)) => a == b,
+            (PhotoEffectSelection::Random(a), PhotoEffectSelection::Random(b)) => a == b,
             (
-                PhotoAffectSelection::Sequential { kinds: a, .. },
-                PhotoAffectSelection::Sequential { kinds: b, .. },
+                PhotoEffectSelection::Sequential { kinds: a, .. },
+                PhotoEffectSelection::Sequential { kinds: b, .. },
             ) => a == b,
             _ => false,
         }
     }
 }
 
-impl Eq for PhotoAffectSelection {}
+impl Eq for PhotoEffectSelection {}
 
 #[derive(Debug, Clone)]
-pub struct PhotoAffectConfig {
-    selection: PhotoAffectSelection,
-    options: BTreeMap<PhotoAffectKind, PhotoAffectOptions>,
+pub struct PhotoEffectConfig {
+    selection: PhotoEffectSelection,
+    options: BTreeMap<PhotoEffectKind, PhotoEffectOptions>,
 }
 
-impl Default for PhotoAffectConfig {
+impl Default for PhotoEffectConfig {
     fn default() -> Self {
         Self {
-            selection: PhotoAffectSelection::Disabled,
+            selection: PhotoEffectSelection::Disabled,
             options: BTreeMap::new(),
         }
     }
 }
 
-impl PhotoAffectConfig {
+impl PhotoEffectConfig {
     pub fn is_enabled(&self) -> bool {
-        !matches!(self.selection, PhotoAffectSelection::Disabled)
+        !matches!(self.selection, PhotoEffectSelection::Disabled)
     }
 
-    pub fn choose_option<R: Rng + ?Sized>(&self, rng: &mut R) -> Option<PhotoAffectOptions> {
+    pub fn choose_option<R: Rng + ?Sized>(&self, rng: &mut R) -> Option<PhotoEffectOptions> {
         match &self.selection {
-            PhotoAffectSelection::Disabled => None,
-            PhotoAffectSelection::Fixed(kind) => self.options.get(kind).cloned(),
-            PhotoAffectSelection::Random(kinds) => kinds
+            PhotoEffectSelection::Disabled => None,
+            PhotoEffectSelection::Fixed(kind) => self.options.get(kind).cloned(),
+            PhotoEffectSelection::Random(kinds) => kinds
                 .iter()
                 .copied()
                 .choose(rng)
                 .and_then(|kind| self.options.get(&kind).cloned()),
-            PhotoAffectSelection::Sequential { kinds, runtime } => {
+            PhotoEffectSelection::Sequential { kinds, runtime } => {
                 if kinds.is_empty() {
                     None
                 } else {
@@ -1374,23 +1374,23 @@ impl PhotoAffectConfig {
 
     pub fn prepare_runtime(&mut self) -> Result<()> {
         match &self.selection {
-            PhotoAffectSelection::Disabled => {}
-            PhotoAffectSelection::Fixed(kind) => {
+            PhotoEffectSelection::Disabled => {}
+            PhotoEffectSelection::Fixed(kind) => {
                 ensure!(
                     self.options.contains_key(kind),
-                    "photo-affect.types entry {kind} must match a key in photo-affect.options"
+                    "photo-effect.types entry {kind} must match a key in photo-effect.options"
                 );
             }
-            PhotoAffectSelection::Random(kinds)
-            | PhotoAffectSelection::Sequential { kinds, .. } => {
+            PhotoEffectSelection::Random(kinds)
+            | PhotoEffectSelection::Sequential { kinds, .. } => {
                 ensure!(
                     !kinds.is_empty(),
-                    "photo-affect.types must include at least one entry"
+                    "photo-effect.types must include at least one entry"
                 );
                 for kind in kinds {
                     ensure!(
                         self.options.contains_key(kind),
-                        "photo-affect.types entry {kind} must match a key in photo-affect.options"
+                        "photo-effect.types entry {kind} must match a key in photo-effect.options"
                     );
                 }
             }
@@ -1404,31 +1404,31 @@ impl PhotoAffectConfig {
     }
 }
 
-impl<'de> Deserialize<'de> for PhotoAffectConfig {
+impl<'de> Deserialize<'de> for PhotoEffectConfig {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_map(PhotoAffectConfigVisitor)
+        deserializer.deserialize_map(PhotoEffectConfigVisitor)
     }
 }
 
-struct PhotoAffectConfigVisitor;
+struct PhotoEffectConfigVisitor;
 
-impl<'de> Visitor<'de> for PhotoAffectConfigVisitor {
-    type Value = PhotoAffectConfig;
+impl<'de> Visitor<'de> for PhotoEffectConfigVisitor {
+    type Value = PhotoEffectConfig;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("a photo affect configuration map")
+        formatter.write_str("a photo effect configuration map")
     }
 
     fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
     where
         A: MapAccess<'de>,
     {
-        let mut types: Option<Vec<PhotoAffectKind>> = None;
+        let mut types: Option<Vec<PhotoEffectKind>> = None;
         let mut type_selection: Option<TypeSelection> = None;
-        let mut options: Option<BTreeMap<PhotoAffectKind, PhotoAffectOptions>> = None;
+        let mut options: Option<BTreeMap<PhotoEffectKind, PhotoEffectOptions>> = None;
 
         while let Some(key) = map.next_key::<String>()? {
             match key.as_str() {
@@ -1436,12 +1436,12 @@ impl<'de> Visitor<'de> for PhotoAffectConfigVisitor {
                     if types.is_some() {
                         return Err(de::Error::duplicate_field("types"));
                     }
-                    let raw: Vec<PhotoAffectKind> = map.next_value()?;
+                    let raw: Vec<PhotoEffectKind> = map.next_value()?;
                     let mut unique = Vec::new();
                     for kind in raw {
                         if unique.contains(&kind) {
                             return Err(de::Error::custom(format!(
-                                "photo-affect.types cannot repeat the entry {}",
+                                "photo-effect.types cannot repeat the entry {}",
                                 kind
                             )));
                         }
@@ -1459,7 +1459,7 @@ impl<'de> Visitor<'de> for PhotoAffectConfigVisitor {
                     if options.is_some() {
                         return Err(de::Error::duplicate_field("options"));
                     }
-                    options = Some(map.next_value_seed(PhotoAffectOptionsMapSeed)?);
+                    options = Some(map.next_value_seed(PhotoEffectOptionsMapSeed)?);
                 }
                 other => {
                     return Err(de::Error::unknown_field(
@@ -1473,7 +1473,7 @@ impl<'de> Visitor<'de> for PhotoAffectConfigVisitor {
         if let Some(selection) = type_selection.as_ref() {
             if types.as_ref().map_or(true, |t| t.is_empty()) {
                 return Err(de::Error::custom(format!(
-                    "photo-affect.type-selection {:?} requires photo-affect.types to select from",
+                    "photo-effect.type-selection {:?} requires photo-effect.types to select from",
                     selection
                 )));
             }
@@ -1483,68 +1483,68 @@ impl<'de> Visitor<'de> for PhotoAffectConfigVisitor {
         let types = types.unwrap_or_default();
 
         let selection = if types.is_empty() {
-            PhotoAffectSelection::Disabled
+            PhotoEffectSelection::Disabled
         } else if types.len() == 1 {
-            PhotoAffectSelection::Fixed(types[0])
+            PhotoEffectSelection::Fixed(types[0])
         } else {
             match type_selection.unwrap_or(TypeSelection::Random) {
-                TypeSelection::Random => PhotoAffectSelection::Random(types.clone()),
-                TypeSelection::Sequential => PhotoAffectSelection::Sequential {
+                TypeSelection::Random => PhotoEffectSelection::Random(types.clone()),
+                TypeSelection::Sequential => PhotoEffectSelection::Sequential {
                     kinds: types.clone(),
                     runtime: SequentialState::default(),
                 },
             }
         };
 
-        if !matches!(selection, PhotoAffectSelection::Disabled) {
+        if !matches!(selection, PhotoEffectSelection::Disabled) {
             match &selection {
-                PhotoAffectSelection::Fixed(kind) => {
+                PhotoEffectSelection::Fixed(kind) => {
                     if !options.contains_key(kind) {
                         options.insert(
                             *kind,
-                            PhotoAffectOptions::PrintSimulation(PrintSimulationOptions::default()),
+                            PhotoEffectOptions::PrintSimulation(PrintSimulationOptions::default()),
                         );
                     }
                 }
-                PhotoAffectSelection::Random(kinds)
-                | PhotoAffectSelection::Sequential { kinds, .. } => {
+                PhotoEffectSelection::Random(kinds)
+                | PhotoEffectSelection::Sequential { kinds, .. } => {
                     for kind in kinds {
                         if !options.contains_key(kind) {
                             return Err(de::Error::custom(format!(
-                                "photo-affect.types entry {} must match a key in photo-affect.options",
+                                "photo-effect.types entry {} must match a key in photo-effect.options",
                                 kind
                             )));
                         }
                     }
                 }
-                PhotoAffectSelection::Disabled => {}
+                PhotoEffectSelection::Disabled => {}
             }
         }
 
-        Ok(PhotoAffectConfig { selection, options })
+        Ok(PhotoEffectConfig { selection, options })
     }
 }
 
-struct PhotoAffectOptionsMapSeed;
+struct PhotoEffectOptionsMapSeed;
 
-impl<'de> DeserializeSeed<'de> for PhotoAffectOptionsMapSeed {
-    type Value = BTreeMap<PhotoAffectKind, PhotoAffectOptions>;
+impl<'de> DeserializeSeed<'de> for PhotoEffectOptionsMapSeed {
+    type Value = BTreeMap<PhotoEffectKind, PhotoEffectOptions>;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_map(PhotoAffectOptionsMapVisitor)
+        deserializer.deserialize_map(PhotoEffectOptionsMapVisitor)
     }
 }
 
-struct PhotoAffectOptionsMapVisitor;
+struct PhotoEffectOptionsMapVisitor;
 
-impl<'de> Visitor<'de> for PhotoAffectOptionsMapVisitor {
-    type Value = BTreeMap<PhotoAffectKind, PhotoAffectOptions>;
+impl<'de> Visitor<'de> for PhotoEffectOptionsMapVisitor {
+    type Value = BTreeMap<PhotoEffectKind, PhotoEffectOptions>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("a map of photo affect options keyed by affect type")
+        formatter.write_str("a map of photo effect options keyed by effect type")
     }
 
     fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
@@ -1552,17 +1552,17 @@ impl<'de> Visitor<'de> for PhotoAffectOptionsMapVisitor {
         A: MapAccess<'de>,
     {
         let mut options = BTreeMap::new();
-        while let Some(kind) = map.next_key::<PhotoAffectKind>()? {
+        while let Some(kind) = map.next_key::<PhotoEffectKind>()? {
             if options.contains_key(&kind) {
                 return Err(de::Error::custom(format!(
-                    "duplicate photo-affect option for type {}",
+                    "duplicate photo-effect option for type {}",
                     kind
                 )));
             }
-            let option = map.next_value_seed(PhotoAffectOptionSeed { kind })?;
+            let option = map.next_value_seed(PhotoEffectOptionSeed { kind })?;
             if option.kind() != kind {
                 return Err(de::Error::custom(format!(
-                    "photo-affect option for key {} does not match its configuration",
+                    "photo-effect option for key {} does not match its configuration",
                     kind
                 )));
             }
@@ -1572,21 +1572,21 @@ impl<'de> Visitor<'de> for PhotoAffectOptionsMapVisitor {
     }
 }
 
-struct PhotoAffectOptionSeed {
-    kind: PhotoAffectKind,
+struct PhotoEffectOptionSeed {
+    kind: PhotoEffectKind,
 }
 
-impl<'de> DeserializeSeed<'de> for PhotoAffectOptionSeed {
-    type Value = PhotoAffectOptions;
+impl<'de> DeserializeSeed<'de> for PhotoEffectOptionSeed {
+    type Value = PhotoEffectOptions;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
     where
         D: Deserializer<'de>,
     {
         match self.kind {
-            PhotoAffectKind::PrintSimulation => {
+            PhotoEffectKind::PrintSimulation => {
                 let options = PrintSimulationOptions::deserialize(deserializer)?;
-                Ok(PhotoAffectOptions::PrintSimulation(options))
+                Ok(PhotoEffectOptions::PrintSimulation(options))
             }
         }
     }
@@ -2515,8 +2515,8 @@ pub struct Configuration {
     pub loader_max_concurrent_decodes: usize,
     /// Optional deterministic seed for initial photo shuffle.
     pub startup_shuffle_seed: Option<u64>,
-    /// Optional post-processing affects applied after loading and before display.
-    pub photo_affect: PhotoAffectConfig,
+    /// Optional post-processing effects applied after loading and before display.
+    pub photo_effect: PhotoEffectConfig,
     /// Matting configuration for displayed photos.
     pub matting: MattingConfig,
     /// Playlist weighting options for how frequently new photos repeat.
@@ -2546,9 +2546,9 @@ impl Configuration {
         self.transition
             .validate()
             .context("invalid transition configuration")?;
-        self.photo_affect
+        self.photo_effect
             .prepare_runtime()
-            .context("invalid photo affect configuration")?;
+            .context("invalid photo effect configuration")?;
         self.matting
             .prepare_runtime()
             .context("invalid matting configuration")?;
@@ -2570,7 +2570,7 @@ impl Default for Configuration {
             viewer_preload_count: 3,
             loader_max_concurrent_decodes: 4,
             startup_shuffle_seed: None,
-            photo_affect: PhotoAffectConfig::default(),
+            photo_effect: PhotoEffectConfig::default(),
             matting: MattingConfig::default(),
             playlist: PlaylistOptions::default(),
             greeting_screen: GreetingScreenConfig::default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,6 @@ pub mod tasks {
     pub mod greeting_screen;
     pub mod loader;
     pub mod manager;
-    pub mod photo_affect;
+    pub mod photo_effect;
     pub mod viewer;
 }


### PR DESCRIPTION
## Summary
- rename the photo processing configuration, modules, and errors from `photo-affect` to `photo-effect`
- permit `photo-effect.types` to be empty and treat the stage as a no-op when no effects are configured
- refresh configuration docs and samples to reflect the new naming and behavior

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d940f102588323bc20c0e8ba942921