### PR TITLE
Add sleep scheduling config and viewer sleep controls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ serde = { version = "1.0.227", features = ["derive"] }
 serde_yaml = "0.9.34"
 humantime-serde = "1.1.1"
 humantime = "2.3.0"
+chrono = { version = "0.4.38", features = ["serde"] }
+chrono-tz = "0.8.6"
 crossbeam-channel = "0.5.15"
 tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "signal", "sync", "time"] }
 tokio-util = "0.7.16"

--- a/config.yaml
+++ b/config.yaml
@@ -49,6 +49,21 @@ greeting-screen:
     font: "#f8fafc"
     accent: "#38bdf8"
 
+# Sleep schedule that pauses rendering and dims the display outside active hours
+sleep-mode:
+  timezone: America/Los_Angeles
+  on-hours:
+    start: "07:00"
+    end: "22:00"
+  weekend-override:
+    start: "08:30 America/Los_Angeles"
+    end: "23:00 America/Los_Angeles"
+  days:
+    friday:
+      start: "09:00"
+      end: "23:30"
+  dim-brightness: 0.04
+
 # Number of images to preload in the viewer (aligns with channel capacity)
 viewer-preload-count: 3
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,7 @@ Use the quick reference below to locate the knobs you care about, then dive into
 | **Deterministic runs** | `startup-shuffle-seed`                                                |
 | **Presentation**       | `photo-affect`, `matting`                                             |
 | **Greeting Screen**    | `greeting-screen`                                                     |
+| **Power schedule**     | `sleep-mode`                                                          |
 
 ## Key reference
 
@@ -136,6 +137,19 @@ Use the quick reference below to locate the knobs you care about, then dive into
   - `colors.background`, `colors.font`, `colors.accent` (hex sRGB strings; default palette keeps high contrast).
 - **Effect on behavior:** The renderer fits and centers the configured message inside a rounded double-line frame. `duration-seconds` guarantees the greeting remains on screen for at least that many seconds before the first photo appears, even when decoding finishes instantly.
 - **Notes:** Colors accept `#rgb`, `#rgba`, `#rrggbb`, or `#rrggbbaa` notation. Low-contrast combinations log a warning so you can tweak readability, and the viewer continues with sensible defaults if fonts or colors are omitted.
+
+### `sleep-mode`
+
+- **Purpose:** Defines when the frame should pause the slideshow, blank the screen to a dim level, and resume automatically.
+- **Required?** Optional; when omitted the frame runs 24/7.
+- **Accepted values & defaults:** Mapping with the keys below. Times accept `HH:MM` or `HH:MM:SS` strings and may optionally include a trailing IANA timezone name (for example `"07:30 America/Los_Angeles"`). When no timezone is specified on a field, the top-level `timezone` value applies.
+  - `timezone` — Required IANA timezone identifier. Sets the base clock used to pick weekday/weekend overrides and interpret times that do not specify their own zone.
+  - `on-hours.start` / `on-hours.end` — Required local times describing when the frame should be awake each day. Start must be earlier than end within the same day.
+  - `weekday-override` / `weekend-override` — Optional blocks with their own `start`/`end` that replace the default window on weekdays (`Mon–Fri`) or weekends (`Sat/Sun`).
+  - `days` — Optional map keyed by weekday name (`monday`, `tues`, …) that replaces both default and weekday/weekend overrides for specific days.
+  - `dim-brightness` — Optional float between `0.0` (black) and `1.0` (white). Controls the solid color used while sleeping. Defaults to `0.05`.
+- **Effect on behavior:** Outside the configured "on" window the viewer stops advancing slides, cancels any in-flight transitions, and clears the surface to the dim color. When the schedule says to wake up, the currently loaded image is shown again and normal dwell/transition pacing resumes.
+- **Notes:** Sending `SIGUSR1` to the process toggles a manual override—handy for a single-button GPIO input. One press flips between the scheduled state and its opposite (wake vs. sleep), and the next press returns control to the schedule. When the override is released the frame snaps back to whatever the schedule dictates at that moment.
 
 ### `matting`
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -33,3 +33,8 @@ pub struct InvalidPhoto(pub PathBuf);
 /// Emitted by the viewer after a photo is shown (for now, immediately).
 #[derive(Debug)]
 pub struct Displayed(pub PathBuf);
+
+#[derive(Debug, Clone)]
+pub enum ViewerCommand {
+    ToggleSleep,
+}

--- a/src/tasks/viewer.rs
+++ b/src/tasks/viewer.rs
@@ -1,12 +1,13 @@
 use crate::config::{
-    MattingConfig, MattingMode, MattingOptions, TransitionConfig, TransitionKind, TransitionMode,
-    TransitionOptions,
+    MattingConfig, MattingMode, MattingOptions, SleepModeRuntime, TransitionConfig, TransitionKind,
+    TransitionMode, TransitionOptions,
 };
-use crate::events::{Displayed, PhotoLoaded, PreparedImageCpu};
+use crate::events::{Displayed, PhotoLoaded, PreparedImageCpu, ViewerCommand};
 use crate::processing::blur::apply_blur;
 use crate::processing::color::average_color;
 use crate::processing::layout::{center_offset, resize_to_cover};
 use crate::tasks::greeting_screen::GreetingScreen;
+use chrono::Utc;
 use crossbeam_channel::{bounded, Receiver as CbReceiver, Sender as CbSender, TrySendError};
 use image::{imageops, Rgba, RgbaImage};
 use rand::Rng;
@@ -23,6 +24,7 @@ pub fn run_windowed(
     to_manager_displayed: Sender<Displayed>,
     cancel: CancellationToken,
     cfg: crate::config::Configuration,
+    control: Receiver<ViewerCommand>,
 ) -> anyhow::Result<()> {
     use winit::application::ApplicationHandler;
     use winit::event::WindowEvent;
@@ -541,10 +543,105 @@ pub fn run_windowed(
         Some(ImgTex { plane, path })
     }
 
+    #[derive(Debug, Clone, Copy)]
+    enum SleepTrigger {
+        Schedule,
+        Manual,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum SleepTransition {
+        None,
+        EnteredSleep { trigger: SleepTrigger },
+        ExitedSleep { trigger: SleepTrigger },
+    }
+
+    struct SleepToggleResult {
+        transition: SleepTransition,
+        override_active: bool,
+    }
+
+    struct SleepController {
+        runtime: SleepModeRuntime,
+        manual_override: Option<bool>,
+        awake: bool,
+    }
+
+    impl SleepController {
+        fn new(runtime: SleepModeRuntime) -> Self {
+            let awake = runtime.is_awake(Utc::now());
+            Self {
+                runtime,
+                manual_override: None,
+                awake,
+            }
+        }
+
+        fn is_awake(&self) -> bool {
+            self.awake
+        }
+
+        fn dim_color(&self) -> wgpu::Color {
+            let level = self.runtime.dim_brightness().clamp(0.0, 1.0) as f64;
+            wgpu::Color {
+                r: level,
+                g: level,
+                b: level,
+                a: 1.0,
+            }
+        }
+
+        fn toggle(&mut self) -> SleepToggleResult {
+            if self.manual_override.is_some() {
+                self.manual_override = None;
+                let transition = self.apply_target(self.scheduled_awake(), SleepTrigger::Manual);
+                SleepToggleResult {
+                    transition,
+                    override_active: false,
+                }
+            } else {
+                let scheduled = self.scheduled_awake();
+                let target = !scheduled;
+                self.manual_override = Some(target);
+                let transition = self.apply_target(target, SleepTrigger::Manual);
+                SleepToggleResult {
+                    transition,
+                    override_active: true,
+                }
+            }
+        }
+
+        fn advance_schedule(&mut self) -> SleepTransition {
+            if self.manual_override.is_some() {
+                SleepTransition::None
+            } else {
+                self.apply_target(self.scheduled_awake(), SleepTrigger::Schedule)
+            }
+        }
+
+        fn scheduled_awake(&self) -> bool {
+            self.runtime.is_awake(Utc::now())
+        }
+
+        fn apply_target(&mut self, target_awake: bool, trigger: SleepTrigger) -> SleepTransition {
+            if target_awake == self.awake {
+                SleepTransition::None
+            } else {
+                self.awake = target_awake;
+                if target_awake {
+                    SleepTransition::ExitedSleep { trigger }
+                } else {
+                    SleepTransition::EnteredSleep { trigger }
+                }
+            }
+        }
+    }
+
     struct App {
         from_loader: Receiver<PhotoLoaded>,
         to_manager_displayed: Sender<Displayed>,
         cancel: CancellationToken,
+        control: Receiver<ViewerCommand>,
         window: Option<Arc<Window>>,
         gpu: Option<GpuCtx>,
         current: Option<ImgTex>,
@@ -566,6 +663,27 @@ pub fn run_windowed(
         clear_color: wgpu::Color,
         rng: rand::rngs::ThreadRng,
         full_config: crate::config::Configuration,
+        sleep: Option<SleepController>,
+    }
+
+    impl App {
+        fn handle_sleep_transition(&mut self, transition: SleepTransition) {
+            match transition {
+                SleepTransition::None => {}
+                SleepTransition::EnteredSleep { trigger } => {
+                    info!(?trigger, "sleep mode entered");
+                    self.transition_state = None;
+                    self.next = None;
+                    self.displayed_at = None;
+                }
+                SleepTransition::ExitedSleep { trigger } => {
+                    info!(?trigger, "sleep mode exited");
+                    if self.current.is_some() {
+                        self.displayed_at = Some(std::time::Instant::now());
+                    }
+                }
+            }
+        }
     }
 
     impl ApplicationHandler for App {
@@ -860,6 +978,36 @@ pub fn run_windowed(
                                 label: Some("draw-encoder"),
                             });
 
+                    let sleeping = self.sleep.as_ref().is_some_and(|ctrl| !ctrl.is_awake());
+                    if sleeping {
+                        let dim_color = self
+                            .sleep
+                            .as_ref()
+                            .map(|ctrl| ctrl.dim_color())
+                            .unwrap_or(self.clear_color);
+                        {
+                            let _sleep_pass =
+                                encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                                    label: Some("sleep-pass"),
+                                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                                        view: &view,
+                                        depth_slice: None,
+                                        resolve_target: None,
+                                        ops: wgpu::Operations {
+                                            load: wgpu::LoadOp::Clear(dim_color),
+                                            store: wgpu::StoreOp::Store,
+                                        },
+                                    })],
+                                    depth_stencil_attachment: None,
+                                    occlusion_query_set: None,
+                                    timestamp_writes: None,
+                                });
+                        }
+                        gpu.queue.submit(Some(encoder.finish()));
+                        frame.present();
+                        return;
+                    }
+
                     if self.current.is_none() && self.transition_state.is_none() {
                         gpu.greeting.render(&mut encoder, &view);
                         gpu.queue.submit(Some(encoder.finish()));
@@ -989,6 +1137,34 @@ pub fn run_windowed(
                 event_loop.exit();
                 return;
             }
+            while let Ok(cmd) = self.control.try_recv() {
+                match cmd {
+                    ViewerCommand::ToggleSleep => {
+                        if let Some(ctrl) = self.sleep.as_mut() {
+                            let result = ctrl.toggle();
+                            if result.override_active {
+                                info!(
+                                    sleep_mode_manual_override = true,
+                                    "sleep mode manual override engaged"
+                                );
+                            } else {
+                                info!(
+                                    sleep_mode_manual_override = false,
+                                    "sleep mode manual override cleared"
+                                );
+                            }
+                            self.handle_sleep_transition(result.transition);
+                        } else {
+                            warn!("sleep mode toggle requested but configuration is absent");
+                        }
+                    }
+                }
+            }
+            if let Some(ctrl) = self.sleep.as_mut() {
+                let transition = ctrl.advance_schedule();
+                self.handle_sleep_transition(transition);
+            }
+            let sleeping = self.sleep.as_ref().is_some_and(|ctrl| !ctrl.is_awake());
             while let Some(result) = self.mat_pipeline.try_recv() {
                 self.mat_inflight = self.mat_inflight.saturating_sub(1);
                 self.ready_results.push_back(result);
@@ -1037,7 +1213,7 @@ pub fn run_windowed(
                     }
                 }
             }
-            if self.current.is_none() && self.transition_state.is_none() {
+            if !sleeping && self.current.is_none() && self.transition_state.is_none() {
                 let greeting_finished = self
                     .greeting_deadline
                     .map(|deadline| Instant::now() >= deadline)
@@ -1078,7 +1254,7 @@ pub fn run_windowed(
                     let _ = self.to_manager_displayed.try_send(Displayed(path));
                 }
             }
-            if self.transition_state.is_none() {
+            if !sleeping && self.transition_state.is_none() {
                 if let Some(shown_at) = self.displayed_at {
                     if shown_at.elapsed() >= std::time::Duration::from_millis(self.dwell_ms) {
                         if self.next.is_none() {
@@ -1136,10 +1312,24 @@ pub fn run_windowed(
             a: 1.0,
         })
         .unwrap_or(wgpu::Color::BLACK);
+    let mut sleep_controller = cfg
+        .sleep_mode
+        .as_ref()
+        .and_then(|cfg| cfg.runtime().cloned())
+        .map(SleepController::new);
+    if let Some(ctrl) = sleep_controller.as_ref() {
+        if !ctrl.is_awake() {
+            info!(
+                sleep_mode_startup_state = "sleeping",
+                "sleep mode active at startup"
+            );
+        }
+    }
     let mut app = App {
         from_loader,
         to_manager_displayed,
         cancel,
+        control,
         window: None,
         gpu: None,
         current: None,
@@ -1161,6 +1351,7 @@ pub fn run_windowed(
         clear_color,
         rng: rand::rng(),
         full_config: cfg.clone(),
+        sleep: sleep_controller.take(),
     };
     event_loop.run_app(&mut app)?;
     Ok(())


### PR DESCRIPTION
## Summary
- add a `sleep-mode` section to the configuration that parses timezone-aware on-hours plus weekday/weekend overrides and documents the feature
- teach the viewer to honor the sleep schedule, dim the display, and respond to external `SIGUSR1` signals for manual toggles

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d93f6f0f8c8323a7f80ce121598425