### PR TITLE
Ensure blur matting background covers canvas

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -104,7 +104,7 @@ matting:
     blur:
       minimum-mat-percentage: 3.5
       sigma: 20.0
-      max-sample-dimension: 1536
+      sample-scale: 1.0 # reduce toward 0.0 to trade fidelity for blur speed
       backend: neon # options: cpu, neon (auto-falls back to cpu if unsupported)
     studio:
       minimum-mat-percentage: 8.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -348,7 +348,7 @@ Every entry inside `matting.options` accepts the shared settings below:
 ### `blur`
 
 - **`sigma`** (float, default `20.0`): Gaussian blur radius applied to a scaled copy of the photo that covers the screen. Larger values yield softer backgrounds; zero disables the blur but keeps the scaled image.
-- **`max-sample-dimension`** (integer or `null`, default `null`; falls back to `2048` on 64-bit ARM, otherwise the canvas size): Optional cap on the intermediate blur resolution. Lower caps downsample before blurring, cutting CPU/GPU cost while preserving the dreamy backdrop.
+- **`sample-scale`** (float, default `1.0`): Ratio between the canvas resolution and the intermediate blur buffer. The renderer first scales the photo to the canvas at 1:1, then optionally downsamples by this factor before blurring. Values below `1.0` trade fidelity for speed; keep it at `1.0` for distortion-free mats.
 - **`backend`** (`cpu` or `neon`, default `cpu`): Blur implementation to use. `neon` opts into the vector-accelerated path on 64-bit ARM; if unsupported at runtime the app gracefully falls back to the CPU renderer.
 
 ### `studio`

--- a/src/config.rs
+++ b/src/config.rs
@@ -300,8 +300,11 @@ pub enum MattingMode {
     Blur {
         #[serde(default = "MattingMode::default_blur_sigma")]
         sigma: f32,
-        #[serde(default, rename = "max-sample-dimension")]
-        max_sample_dimension: Option<u32>,
+        #[serde(
+            default = "MattingMode::default_blur_sample_scale",
+            rename = "sample-scale"
+        )]
+        sample_scale: f32,
         #[serde(default)]
         backend: BlurBackend,
     },
@@ -492,7 +495,9 @@ impl MattingOptions {
             },
             MattingKind::Blur => MattingMode::Blur {
                 sigma: base.sigma.unwrap_or_else(MattingMode::default_blur_sigma),
-                max_sample_dimension: base.max_sample_dimension,
+                sample_scale: base
+                    .sample_scale
+                    .unwrap_or_else(MattingMode::default_blur_sample_scale),
                 backend: base.blur_backend.unwrap_or_default(),
             },
             MattingKind::Studio => MattingMode::Studio {
@@ -543,7 +548,7 @@ struct MattingOptionBuilder {
     max_upscale_factor: Option<f32>,
     color: Option<[u8; 3]>,
     sigma: Option<f32>,
-    max_sample_dimension: Option<u32>,
+    sample_scale: Option<f32>,
     blur_backend: Option<BlurBackend>,
     bevel_width_px: Option<f32>,
     bevel_color: Option<[u8; 3]>,
@@ -627,11 +632,11 @@ where
                     }
                     builder.sigma = Some(inline_value_to::<f32, E>(value)?);
                 }
-                "max-sample-dimension" => {
-                    if builder.max_sample_dimension.is_some() {
-                        return Err(de::Error::duplicate_field("max-sample-dimension"));
+                "sample-scale" => {
+                    if builder.sample_scale.is_some() {
+                        return Err(de::Error::duplicate_field("sample-scale"));
                     }
-                    builder.max_sample_dimension = Some(inline_value_to::<u32, E>(value)?);
+                    builder.sample_scale = Some(inline_value_to::<f32, E>(value)?);
                 }
                 "backend" => {
                     if builder.blur_backend.is_some() {
@@ -644,7 +649,7 @@ where
                         other,
                         &[
                             "sigma",
-                            "max-sample-dimension",
+                            "sample-scale",
                             "backend",
                             "minimum-mat-percentage",
                             "max-upscale-factor",
@@ -1097,11 +1102,11 @@ impl<'de> Visitor<'de> for MattingOptionVisitor {
                             }
                             builder.sigma = Some(map.next_value()?);
                         }
-                        "max-sample-dimension" => {
-                            if builder.max_sample_dimension.is_some() {
-                                return Err(de::Error::duplicate_field("max-sample-dimension"));
+                        "sample-scale" => {
+                            if builder.sample_scale.is_some() {
+                                return Err(de::Error::duplicate_field("sample-scale"));
                             }
-                            builder.max_sample_dimension = Some(map.next_value()?);
+                            builder.sample_scale = Some(map.next_value()?);
                         }
                         "backend" => {
                             if builder.blur_backend.is_some() {
@@ -1114,7 +1119,7 @@ impl<'de> Visitor<'de> for MattingOptionVisitor {
                                 other,
                                 &[
                                     "sigma",
-                                    "max-sample-dimension",
+                                    "sample-scale",
                                     "backend",
                                     "minimum-mat-percentage",
                                     "max-upscale-factor",
@@ -1297,9 +1302,8 @@ impl MattingMode {
         20.0
     }
 
-    #[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
-    pub const fn default_blur_max_sample_dimension() -> u32 {
-        2048
+    pub const fn default_blur_sample_scale() -> f32 {
+        1.0
     }
 
     const fn default_studio_bevel_width_px() -> f32 {

--- a/src/processing/layout.rs
+++ b/src/processing/layout.rs
@@ -5,13 +5,17 @@ pub fn resize_to_cover(
     src_h: u32,
     max_dim: u32,
 ) -> (u32, u32) {
-    let iw = src_w.max(1) as f32;
-    let ih = src_h.max(1) as f32;
-    let cw = canvas_w.max(1) as f32;
-    let ch = canvas_h.max(1) as f32;
-    let scale = (cw / iw).max(ch / ih).max(1.0);
-    let w = (iw * scale).round().clamp(1.0, max_dim as f32);
-    let h = (ih * scale).round().clamp(1.0, max_dim as f32);
+    let iw = src_w.max(1) as f64;
+    let ih = src_h.max(1) as f64;
+    let cw = canvas_w.max(1) as f64;
+    let ch = canvas_h.max(1) as f64;
+    let mut scale = (cw / iw).max(ch / ih);
+    if !scale.is_finite() || scale <= 0.0 {
+        scale = 1.0;
+    }
+
+    let w = (iw * scale).ceil().clamp(1.0, max_dim as f64);
+    let h = (ih * scale).ceil().clamp(1.0, max_dim as f64);
     (w as u32, h as u32)
 }
 
@@ -22,14 +26,14 @@ pub fn resize_to_contain(
     src_h: u32,
     max_dim: u32,
 ) -> (u32, u32) {
-    let iw = src_w.max(1) as f32;
-    let ih = src_h.max(1) as f32;
-    let cw = canvas_w.max(1) as f32;
-    let ch = canvas_h.max(1) as f32;
+    let iw = src_w.max(1) as f64;
+    let ih = src_h.max(1) as f64;
+    let cw = canvas_w.max(1) as f64;
+    let ch = canvas_h.max(1) as f64;
     let scale = (cw / iw).min(ch / ih).max(0.0);
     let scale = if scale.is_finite() { scale } else { 1.0 };
-    let w = (iw * scale).round().clamp(1.0, max_dim as f32);
-    let h = (ih * scale).round().clamp(1.0, max_dim as f32);
+    let w = (iw * scale).round().clamp(1.0, max_dim as f64);
+    let h = (ih * scale).round().clamp(1.0, max_dim as f64);
     (w as u32, h as u32)
 }
 
@@ -37,4 +41,28 @@ pub fn center_offset(inner_w: u32, inner_h: u32, outer_w: u32, outer_h: u32) -> 
     let ox = outer_w.saturating_sub(inner_w) / 2;
     let oy = outer_h.saturating_sub(inner_h) / 2;
     (ox, oy)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resize_to_cover;
+
+    #[test]
+    fn cover_upscales_to_fill_canvas() {
+        let (w, h) = resize_to_cover(1920, 1080, 800, 600, 8192);
+        assert_eq!((w, h), (1920, 1440));
+    }
+
+    #[test]
+    fn cover_downscales_when_source_is_larger() {
+        let (w, h) = resize_to_cover(1920, 1080, 4000, 3000, 8192);
+        assert_eq!((w, h), (1920, 1440));
+    }
+
+    #[test]
+    fn cover_never_underfills_within_limits() {
+        let (w, h) = resize_to_cover(1921, 1080, 3217, 2000, 8192);
+        assert!(w >= 1921);
+        assert!(h >= 1080);
+    }
 }

--- a/src/tasks/viewer.rs
+++ b/src/tasks/viewer.rs
@@ -288,7 +288,7 @@ pub fn run_windowed(
             }
             MattingMode::Blur {
                 sigma,
-                max_sample_dimension,
+                sample_scale,
                 backend,
             } => {
                 let (bg_w, bg_h) = resize_to_cover(canvas_w, canvas_h, width, height, max_dim);
@@ -305,35 +305,27 @@ pub fn run_windowed(
                     bg = canvas;
                 }
                 if *sigma > 0.0 {
-                    let limit = max_sample_dimension
-                        .filter(|v| *v > 0)
-                        .unwrap_or({
-                            #[cfg(target_arch = "aarch64")]
-                            {
-                                MattingMode::default_blur_max_sample_dimension()
-                            }
-                            #[cfg(not(target_arch = "aarch64"))]
-                            {
-                                max_dim
-                            }
-                        })
-                        .min(max_dim)
-                        .max(1);
-
                     let mut sample = bg;
                     let mut sigma_px = *sigma;
-                    let canvas_max = canvas_w.max(canvas_h).max(1);
-                    if canvas_max > limit {
-                        let scale = (limit as f32) / (canvas_max as f32);
-                        let sample_w =
-                            ((canvas_w as f32) * scale).round().clamp(1.0, limit as f32) as u32;
-                        let sample_h =
-                            ((canvas_h as f32) * scale).round().clamp(1.0, limit as f32) as u32;
+                    let scale = sample_scale
+                        .is_finite()
+                        .then_some(*sample_scale)
+                        .unwrap_or_else(MattingMode::default_blur_sample_scale)
+                        .clamp(0.01, 1.0);
+                    if scale < 1.0 {
+                        let sample_w = ((canvas_w as f32) * scale)
+                            .round()
+                            .clamp(1.0, canvas_w as f32)
+                            as u32;
+                        let sample_h = ((canvas_h as f32) * scale)
+                            .round()
+                            .clamp(1.0, canvas_h as f32)
+                            as u32;
                         sample = imageops::resize(
                             &sample,
                             sample_w,
                             sample_h,
-                            imageops::FilterType::Triangle,
+                            imageops::FilterType::CatmullRom,
                         );
                         sigma_px *= scale.max(0.01);
                     }


### PR DESCRIPTION
## Summary
- replace the blur matting `max-sample-dimension` setting with a `sample-scale` ratio so the background is prepared at 1:1 resolution before blurring
- update the viewer pipeline to clamp the sampling scale and blur at full resolution by default while keeping an optional downscale path for performance tuning
- refresh the configuration example and documentation to describe the new `sample-scale` control
- ensure the blur matting background scales to cover the canvas before blurring and add regression tests for the layout helper

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d99fb6ee9c8323b253815c7ad9399c