### PR TITLE
Add Macondo font installation module to app setup

### DIFF
--- a/setup/app/modules/35-fonts.sh
+++ b/setup/app/modules/35-fonts.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODULE="app:35-fonts"
+DRY_RUN="${DRY_RUN:-0}"
+
+FONT_NAME="Macondo"
+FONT_URL="https://github.com/google/fonts/raw/main/ofl/macondo/Macondo-Regular.ttf"
+FONT_DIR="/usr/local/share/fonts/google/${FONT_NAME}"
+FONT_BASENAME="$(basename "${FONT_URL}")"
+FONT_PATH="${FONT_DIR}/${FONT_BASENAME}"
+
+log() {
+    local level="$1"; shift
+    printf '[%s] %s\n' "${MODULE}" "$level: $*"
+}
+
+run_sudo() {
+    if [[ "${DRY_RUN}" == "1" ]]; then
+        log INFO "DRY_RUN: sudo $*"
+    else
+        sudo "$@"
+    fi
+}
+
+install_font() {
+    if [[ "${DRY_RUN}" == "1" ]]; then
+        log INFO "DRY_RUN: would create ${FONT_DIR}"
+        log INFO "DRY_RUN: would download ${FONT_URL}"
+        log INFO "DRY_RUN: would install ${FONT_BASENAME} into ${FONT_DIR}"
+        log INFO "DRY_RUN: would refresh font cache"
+        return
+    fi
+
+    run_sudo mkdir -p "${FONT_DIR}"
+
+    tmpfile="$(mktemp)"
+    cleanup() {
+        rm -f "${tmpfile}"
+    }
+    trap cleanup EXIT
+
+    log INFO "Downloading ${FONT_NAME} font"
+    curl -fL -o "${tmpfile}" "${FONT_URL}"
+
+    run_sudo install -m 644 "${tmpfile}" "${FONT_PATH}"
+    trap - EXIT
+    cleanup
+
+    log INFO "Refreshing font cache"
+    run_sudo fc-cache -fv >/dev/null
+
+    log INFO "Installed ${FONT_NAME} font at ${FONT_PATH}"
+}
+
+if [[ -f "${FONT_PATH}" ]]; then
+    log INFO "${FONT_NAME} font already present at ${FONT_PATH}; skipping download"
+    if [[ "${DRY_RUN}" == "1" ]]; then
+        log INFO "DRY_RUN: would refresh font cache"
+    else
+        log INFO "Refreshing font cache"
+        run_sudo fc-cache -fv >/dev/null
+    fi
+    exit 0
+fi
+
+install_font


### PR DESCRIPTION
## Summary
- add an app setup module that installs the Macondo font under /usr/local/share/fonts/google
- refresh the font cache after installing or confirming the font so fc-cache stays up to date

## Testing
- bash -n setup/app/modules/35-fonts.sh

------
https://chatgpt.com/codex/tasks/task_e_68d9e16255cc8323873216d5dfdbd623