### PR TITLE
Ensure systemd unit exports Wayland environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ After a successful install the filesystem layout is:
   systemd/   # Deployed unit files sourced by the installer
 ```
 
-The `photo-frame.service` unit runs the application with its working directory set to `/opt/photo-frame/var` and automatically restarts on failure. Override configuration can be dropped in `/etc/default/photo-frame` when needed.
+The `photo-frame.service` unit runs the application with its working directory set to `/opt/photo-frame/var` and automatically restarts on failure. It exports the `XDG_RUNTIME_DIR` and `WAYLAND_DISPLAY` variables so the compositor grants fullscreen access when the service starts outside an interactive login. Override configuration can be dropped in `/etc/default/photo-frame` when needed.
 
 ## Features
 

--- a/setup/app/systemd/photo-frame.service
+++ b/setup/app/systemd/photo-frame.service
@@ -9,6 +9,8 @@ User=@SERVICE_USER@
 Group=@SERVICE_GROUP@
 EnvironmentFile=-/etc/default/photo-frame
 WorkingDirectory=@INSTALL_ROOT@/var
+Environment=XDG_RUNTIME_DIR=/run/user/%U
+Environment=WAYLAND_DISPLAY=wayland-0
 ExecStart=@INSTALL_ROOT@/bin/rust-photo-frame @INSTALL_ROOT@/var/config.yaml
 Restart=on-failure
 RestartSec=5s


### PR DESCRIPTION
## Summary
- set the Wayland runtime environment in `photo-frame.service` so the service can start without an interactive login
- document the exported environment variables in the README for future operators

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9e4951fac83239ce2df7b72c1ce09