### PR TITLE
Allow photo-effect type selection to be ignored when types empty

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1912,17 +1912,13 @@ impl<'de> Visitor<'de> for PhotoEffectConfigVisitor {
             }
         }
 
-        if let Some(selection) = type_selection.as_ref() {
-            if types.as_ref().map_or(true, |t| t.is_empty()) {
-                return Err(de::Error::custom(format!(
-                    "photo-effect.type-selection {:?} requires photo-effect.types to select from",
-                    selection
-                )));
-            }
-        }
-
         let mut options = options.unwrap_or_default();
         let types = types.unwrap_or_default();
+        let type_selection = if types.is_empty() {
+            None
+        } else {
+            type_selection
+        };
 
         let selection = if types.is_empty() {
             PhotoEffectSelection::Disabled


### PR DESCRIPTION
## Summary
- treat photo-effect type selection as disabled whenever the configured type list is empty
- allow optional type-selection entries to coexist with empty type lists without raising configuration errors

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68da0913ea048323a7e666e2e0de9608