### PR TITLE
Ensure wifi-manager is staged and verified in setup pipeline

### DIFF
--- a/setup/app/modules/40-systemd.sh
+++ b/setup/app/modules/40-systemd.sh
@@ -95,6 +95,9 @@ activate_unit() {
 enable_unit photo-frame.service
 activate_unit photo-frame.service
 
+enable_unit wifi-manager.service
+activate_unit wifi-manager.service
+
 if [[ -f "${SYSTEMD_SOURCE}/photo-sync.timer" ]]; then
     enable_unit photo-sync.timer
     activate_unit photo-sync.timer

--- a/setup/files/systemd/wifi-manager.service
+++ b/setup/files/systemd/wifi-manager.service
@@ -5,10 +5,10 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/opt/photo-frame/bin/wifi-manager watch --config /opt/photo-frame/etc/wifi-manager.yaml
-User=photo-frame
-Group=photo-frame
-WorkingDirectory=/opt/photo-frame/var
+ExecStart=@INSTALL_ROOT@/bin/wifi-manager watch --config @INSTALL_ROOT@/etc/wifi-manager.yaml
+User=@SERVICE_USER@
+Group=@SERVICE_GROUP@
+WorkingDirectory=@INSTALL_ROOT@/var
 Restart=on-failure
 RestartSec=2
 


### PR DESCRIPTION
## Summary
- stage the wifi-manager binary along with its config template, helper scripts, and wordlist during the app setup staging step
- install the wifi-manager systemd unit beside the photo-frame service and enable it through the setup automation
- extend the post-install verification to assert that wifi-manager artifacts exist and the service is active

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68db4ad6ea008323942d03e3258db704