### PR TITLE
Ensure wifi-manager binary is built and staged

### DIFF
--- a/setup/app/modules/10-build.sh
+++ b/setup/app/modules/10-build.sh
@@ -27,12 +27,12 @@ if [[ "${CARGO_PROFILE}" == "release" ]]; then
     profile_flag=(--release)
 fi
 
-log INFO "Building rust-photo-frame with cargo ${profile_flag[*]}"
+log INFO "Building workspace binaries with cargo ${profile_flag[*]}"
 cd "${REPO_ROOT}"
 if [[ "${DRY_RUN}" == "1" ]]; then
-    log INFO "DRY_RUN: would run cargo build ${profile_flag[*]}"
+    log INFO "DRY_RUN: would run cargo build --workspace --bins ${profile_flag[*]}"
 else
-    cargo build "${profile_flag[@]}"
+    cargo build --workspace --bins "${profile_flag[@]}"
 fi
 
 if [[ "${DRY_RUN}" != "1" && -d "${REPO_ROOT}/target" ]]; then

--- a/setup/app/modules/20-stage.sh
+++ b/setup/app/modules/20-stage.sh
@@ -47,6 +47,7 @@ create_stage_layout() {
         "${STAGE_DIR}/docs" \
         "${STAGE_DIR}/systemd" \
         "${STAGE_DIR}/share" \
+        "${STAGE_DIR}/var" \
         "${STAGE_DIR}/share/backgrounds"; do
         ensure_dir "${dir}"
     done


### PR DESCRIPTION
## Summary
- build all workspace binaries during the app build stage so the wifi-manager executable is produced
- add the staging var directory so the wifi-manager service has a working directory during installation

## Testing
- `cargo build --workspace --bins`


------
https://chatgpt.com/codex/tasks/task_e_68db558f3f6483238b0881f2671af733