### PR TITLE
Remove legacy compatibility paths

### DIFF
--- a/docs/setup-audit.md
+++ b/docs/setup-audit.md
@@ -6,14 +6,14 @@ The deployment pipeline was reviewed end-to-end to ensure a Raspberry Pi can pro
 
 1. **NetworkManager permissions were implicit.** `wifi-manager` runs as the unprivileged service user, but nothing granted it permission to modify system connections. The new `system:50-networkmanager` module adds the account to the `netdev` group and installs a dedicated polkit rule so NetworkManager accepts those requests headlessly.
 2. **Legacy systemd units lingered in the install tree.** Staging still shipped `photo-app.service`/`photo-app.target`, which referenced outdated binaries and paths. They are now removed so the only shipped app unit is the current `photo-frame.service`.
-3. **Status tooling referenced obsolete unit names.** `print-status.sh` assumed the legacy `photo-app` and `sync-photos` units. The script now auto-detects `photo-frame`/`photo-sync` names (with fallbacks for older installs) so operators see accurate health information.
-4. **Optional sync automation was never activated.** The systemd installer looked for `photo-sync.*` units even though the repository still packages `sync-photos.*`. The module now enables whichever naming scheme is present, so existing timers come online correctly.
+3. **Status tooling referenced obsolete unit names.** `print-status.sh` assumed the legacy `photo-app` and `sync-photos` units. The script now reports on the canonical `photo-frame`/`photo-sync` services directly so drift is immediately obvious during development.
+4. **Optional sync automation was never activated.** The systemd installer looked for `photo-sync.*` units even though the repository still packages `sync-photos.*`. We standardized on the `photo-sync.*` naming and removed the auto-detection shim so the module only enables the new units.
 
 ## Operator impact
 
 - Running `./setup/system/run.sh` may prompt for a sudo password so it can adjust group membership and write the polkit rule. Reconnect SSH after the script runs to pick up the `netdev` group assignment.
 - `print-status.sh` reports on the new service names and clearly calls out when optional sync units are not installed.
-- Old deployments that still have `photo-app.*` units installed will have them pruned automatically on the next run, avoiding confusion with stale services.
+- Old deployments that still use the retired `photo-app.*` or `sync-photos.*` units need to migrate to the new names; the tooling now surfaces missing expected units instead of hiding the mismatch.
 
 ## Recommended verification
 

--- a/setup/files/bin/print-status.sh
+++ b/setup/files/bin/print-status.sh
@@ -54,17 +54,6 @@ unit_enabled() {
     fi
 }
 
-resolve_unit() {
-    local candidate
-    for candidate in "$@"; do
-        if unit_exists "${candidate}"; then
-            printf '%s' "${candidate}"
-            return 0
-        fi
-    done
-    return 1
-}
-
 print_header "Wi-Fi Connectivity"
 if command -v nmcli >/dev/null 2>&1; then
     CONNECTIVITY_FILE="${TMP_DIR}/connectivity"
@@ -146,11 +135,7 @@ fi
 
 print_header "Photo Frame"
 if [[ -z "${PHOTO_SERVICE:-}" ]]; then
-    if RESOLVED_PHOTO_SERVICE=$(resolve_unit photo-frame.service photo-app.service); then
-        PHOTO_SERVICE="${RESOLVED_PHOTO_SERVICE}"
-    else
-        PHOTO_SERVICE="photo-frame.service"
-    fi
+    PHOTO_SERVICE="photo-frame.service"
 fi
 PHOTO_STATUS="$(unit_status "${PHOTO_SERVICE}")"
 PHOTO_ENABLED="$(unit_enabled "${PHOTO_SERVICE}")"
@@ -158,15 +143,15 @@ printf '%s: %s (enabled: %s)\n' "${PHOTO_SERVICE}" "${PHOTO_STATUS}" "${PHOTO_EN
 
 print_header "Sync"
 if [[ -z "${SYNC_SERVICE:-}" ]]; then
-    if RESOLVED_SYNC_SERVICE=$(resolve_unit photo-sync.service sync-photos.service); then
-        SYNC_SERVICE="${RESOLVED_SYNC_SERVICE}"
+    if unit_exists "photo-sync.service"; then
+        SYNC_SERVICE="photo-sync.service"
     else
         SYNC_SERVICE=""
     fi
 fi
 if [[ -z "${SYNC_TIMER:-}" ]]; then
-    if RESOLVED_SYNC_TIMER=$(resolve_unit photo-sync.timer sync-photos.timer); then
-        SYNC_TIMER="${RESOLVED_SYNC_TIMER}"
+    if unit_exists "photo-sync.timer"; then
+        SYNC_TIMER="photo-sync.timer"
     else
         SYNC_TIMER=""
     fi

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -405,7 +405,7 @@ matting:
 }
 
 #[test]
-fn parse_legacy_random_matting_type_uses_option_keys() {
+fn matting_type_field_is_rejected() {
     let yaml = r#"
 photo-library-path: "/photos"
 matting:
@@ -413,16 +413,12 @@ matting:
   options:
     fixed-color:
       colors: [[5, 15, 25]]
-    blur:
-      sigma: 9.0
-      minimum-mat-percentage: 4.0
 "#;
 
-    let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
-    assert_eq!(
-        cfg.matting.selection(),
-        MattingSelection::Random(vec![MattingKind::FixedColor, MattingKind::Blur])
-    );
+    let err = serde_yaml::from_str::<Configuration>(yaml).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("matting.type is no longer supported"));
 }
 
 #[test]
@@ -573,24 +569,20 @@ transition:
 }
 
 #[test]
-fn parse_legacy_random_transition_type_uses_option_keys() {
+fn transition_type_field_is_rejected() {
     let yaml = r#"
 photo-library-path: "/photos"
 transition:
   type: random
   options:
-    wipe:
+    fade:
       duration-ms: 520
-    push:
-      duration-ms: 480
-      angle-list-degrees: [30.0]
 "#;
 
-    let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
-    assert_eq!(
-        cfg.transition.selection(),
-        TransitionSelection::Random(vec![TransitionKind::Wipe, TransitionKind::Push])
-    );
+    let err = serde_yaml::from_str::<Configuration>(yaml).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("transition.type is no longer supported"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- drop legacy matting and transition compatibility handling and require explicit `types`
- simplify setup scripts to only install and report canonical `photo-frame`/`photo-sync` units
- update status tooling, documentation, and tests to reflect the stricter configuration schema

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68dbce0b27588323b01e7b00c9dc3c1b