### PR TITLE
Accept single color matting alias

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -404,6 +404,7 @@ Every entry inside `matting.options` accepts the shared settings below:
 ### `fixed-color`
 
 - **`colors`** (array of `[r, g, b]` triples, default `[[0, 0, 0]]`): One or more RGB swatches (0–255 per channel) to rotate through. Channels outside the valid range are clamped before rendering. Supply multiple entries to keep the frame palette fresh or stick with a single swatch for a consistent backdrop.
+- **`color`** (`[r, g, b]` triple): Convenience alias for `colors` when you only want to specify a single swatch.
 - **`color-selection`** (`sequential` or `random`; default `sequential`): Chooses how the viewer advances through the configured swatches. Sequential mode cycles in order, while random selects a new color for each slide.
 
 ### `blur`

--- a/src/config.rs
+++ b/src/config.rs
@@ -832,6 +832,13 @@ where
                     }
                     builder.fixed_colors = Some(inline_value_to::<Vec<[u8; 3]>, E>(value)?);
                 }
+                "color" => {
+                    if builder.fixed_colors.is_some() {
+                        return Err(de::Error::duplicate_field("color"));
+                    }
+                    let color = inline_value_to::<[u8; 3], E>(value)?;
+                    builder.fixed_colors = Some(vec![color]);
+                }
                 "color-selection" => {
                     if builder.color_selection.is_some() {
                         return Err(de::Error::duplicate_field("color-selection"));
@@ -843,6 +850,7 @@ where
                         other,
                         &[
                             "colors",
+                            "color",
                             "color-selection",
                             "minimum-mat-percentage",
                             "max-upscale-factor",
@@ -1269,6 +1277,13 @@ impl<'de> Visitor<'de> for MattingOptionVisitor {
                             }
                             builder.fixed_colors = Some(map.next_value()?);
                         }
+                        "color" => {
+                            if builder.fixed_colors.is_some() {
+                                return Err(de::Error::duplicate_field("color"));
+                            }
+                            let color: [u8; 3] = map.next_value()?;
+                            builder.fixed_colors = Some(vec![color]);
+                        }
                         "color-selection" => {
                             if builder.color_selection.is_some() {
                                 return Err(de::Error::duplicate_field("color-selection"));
@@ -1280,6 +1295,7 @@ impl<'de> Visitor<'de> for MattingOptionVisitor {
                                 other,
                                 &[
                                     "colors",
+                                    "color",
                                     "color-selection",
                                     "minimum-mat-percentage",
                                     "max-upscale-factor",

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -182,6 +182,29 @@ matting:
 }
 
 #[test]
+fn parse_fixed_color_single_color_alias() {
+    let yaml = r#"
+photo-library-path: "/photos"
+matting:
+  types: [fixed-color]
+  options:
+    fixed-color:
+      color: [17, 34, 51]
+"#;
+
+    let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
+    let options = cfg.matting.options();
+    let fixed = options
+        .get(&MattingKind::FixedColor)
+        .expect("expected fixed-color mat option");
+    if let rust_photo_frame::config::MattingMode::FixedColor { colors, .. } = &fixed.style {
+        assert_eq!(colors.as_slice(), &[[17, 34, 51]]);
+    } else {
+        panic!("expected fixed-color matting");
+    }
+}
+
+#[test]
 fn parse_sequential_matting_configuration() {
     let yaml = r#"
 photo-library-path: "/photos"


### PR DESCRIPTION
## Summary
- allow `matting.options.fixed-color.color` to deserialize as a single-swatch palette
- document the alias in the configuration guide and cover it with a regression test

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dc80876804832396f3797fd3d4a637