### PR TITLE
Add Raspberry Pi photo frame test plan and harness

### DIFF
--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -1,0 +1,242 @@
+# Raspberry Pi Photo Frame – Developer Test Plan
+
+## Overview & Philosophy
+- [ ] **Purpose:** Validate the end-to-end lifecycle of the Raspberry Pi 5 photo frame from clean install through daily operation and recovery.
+- [ ] **Scope:** Cover the main-line workflows (install → configure → operate → update/recover). Edge-case permutations, GPU micro-benchmarks, and full security audits are **out of scope**.
+- [ ] **Operator:** A developer working directly on the Pi (keyboard/mouse locally or via SSH with physical access when prompted).
+- [ ] **Approach:** Prefer observable evidence (logs, screenshots, journal captures). Automate where practical via `tests/run_smoke.sh`, `tests/run_daily.sh`, and `tests/collect_logs.sh`.
+
+## Test Environments & Matrix
+Exercise each axis at least once per release cycle.
+
+| Matrix ID | Display Mode | Network | Library Size | Internet Availability | Notes |
+|-----------|--------------|---------|--------------|-----------------------|-------|
+| M1        | 3840×2160 @ 60 Hz | Ethernet | Tiny (≤50) | Available | Baseline sanity after clean install. |
+| M2        | 3840×2160 @ 30 Hz | Wi-Fi | Medium (1–3k) | Available | Stress decode/render pipeline. |
+| M3        | 3840×2160 @ 60 Hz | Wi-Fi | Tiny (≤50) | ISP outage (LAN up) | Exercise watcher without WAN. |
+| M4        | 3840×2160 @ 60 Hz | Wi-Fi | Medium (1–3k) | Available | Overnight burn-in with sleep schedule. |
+| M5        | 3840×2160 @ 60 Hz | Ethernet | Medium (1–3k) | Available | Update + rollback rehearsal. |
+
+## Phase 0 – Pre-flight
+- [ ] Confirm hardware power and cooling are connected (Pi 5, active fan, 52Pi PD board, Dell S2725QC on HDMI-1).
+- [ ] Run quick thermal check:
+  ```sh
+  vcgencmd measure_temp
+  ```
+- [ ] (Optional) Stress-check for 2–3 minutes using `stress-ng --cpu 4` if installed; watch fan response.
+- [ ] Verify display handshake via Wayland:
+  ```sh
+  wlr-randr
+  ```
+- [ ] If Wayland tooling missing, fallback to DRM:
+  ```sh
+  cat /sys/class/drm/card*/card*/modes
+  sudo modetest -c    # optional, needs kmscube package
+  ```
+- [ ] Capture evidence via `tests/collect_logs.sh` (provides modes, EDID, journals).
+
+## Phase 1 – Blank-Pi Install
+- [ ] Flash the latest Raspberry Pi OS (Bookworm, 64-bit) onto a reliable microSD.
+- [ ] On first boot, create user `pi` (or desired kiosk user) with password and enable autologin.
+- [ ] Apply OS updates:
+  ```sh
+  sudo apt update && sudo apt full-upgrade
+  ```
+- [ ] Install required packages:
+  ```sh
+  sudo apt install -y git build-essential pkg-config libssl-dev cmake libwayland-client0 wayland-protocols wayland-utils wlr-randr
+  ```
+- [ ] Confirm Wayland session active (`echo $XDG_SESSION_TYPE` should print `wayland`).
+- [ ] Enable kiosk autologin (raspi-config → System Options → Boot / Auto Login → Console Autologin) and set desktop to launch Wayland session.
+
+## Phase 2 – Project Install
+- [ ] Clone repo:
+  ```sh
+  git clone https://github.com/<org>/rust-photo-frame.git
+  cd rust-photo-frame
+  ```
+- [ ] Build release binary (expect ~5–7 minutes on Pi 5):
+  ```sh
+  cargo build --release
+  ```
+- [ ] Install optional Google font system-wide (example: Roboto Slab):
+  ```sh
+  sudo mkdir -p /usr/local/share/fonts/truetype/google
+  sudo cp assets/fonts/RobotoSlab-Regular.ttf /usr/local/share/fonts/truetype/google/
+  sudo fc-cache -f
+  ```
+- [ ] Stage a minimal `config.yaml`:
+  ```yaml
+  fonts:
+    primary: "/usr/local/share/fonts/truetype/google/RobotoSlab-Regular.ttf"
+  mats:
+    default-hex: "#101214"
+  sleep-windows:
+    - start: "23:30"
+      end: "06:30"
+      timezone: "America/Los_Angeles"
+  library-paths:
+    - "/home/pi/photos"
+  wifi-watcher:
+    check-interval-secs: 15
+    retry-limit: 0   # unlimited
+  ```
+- [ ] Populate photo library folder(s) per matrix scenario.
+
+## Phase 3 – Kiosk Autostart & Services
+- [ ] Install systemd unit (example at `setup/photo-app.service` or generated script).
+- [ ] Enable + start:
+  ```sh
+  sudo cp setup/photo-app.service /etc/systemd/system/
+  sudo systemctl daemon-reload
+  sudo systemctl enable --now photo-app.service
+  ```
+- [ ] Verify service:
+  ```sh
+  systemctl status photo-app.service
+  journalctl -u photo-app.service -n 200 --no-pager
+  ```
+- [ ] Reboot (`sudo reboot`) and confirm the app launches full-screen without manual login.
+
+## Phase 4 – Display Mode & Frame Rate
+- [ ] Confirm target mode (4K@60 preferred):
+  ```sh
+  wlr-randr
+  ```
+- [ ] If forced to fallback, confirm DRM mode lines:
+  ```sh
+  cat /sys/class/drm/card*/card*/modes
+  ```
+- [ ] Capture short (≤10 s) phone video to document refresh smoothness.
+- [ ] Note any tearing/flicker and add to `docs/test-plan.md` observations section (Appendix B).
+
+## Phase 5 – Button & Power Behavior
+- [ ] Identify button input device:
+  ```sh
+  sudo evtest    # inspect for gpio-keys or power-button device
+  ```
+- [ ] Short press → expect app sleep toggle (log should show SIGUSR1 or equivalent).
+- [ ] Double-click → expect clean shutdown (`shutdown -h now` path confirmed in journal).
+- [ ] Long press → document expected behavior (hard-off). **Do not perform if risk of corruption.**
+- [ ] Evidence:
+  ```sh
+  journalctl -u photo-app.service -n 100 --no-pager | grep -i "sleep"
+  sudo journalctl -b | grep -i "systemd-logind" | tail -20
+  ```
+
+## Phase 6 – Sleep/Dimming Schedule
+- [ ] Ensure config sleep window matches local timezone.
+- [ ] Manual toggle:
+  ```sh
+  kill -USR1 $(pidof rust-photo-frame)
+  ```
+  Confirm screen dims / slideshow pauses; capture journal snippet.
+- [ ] Scheduled test: temporarily set sleep window to begin in ~5 minutes, reload config (restart service), observe dim-on schedule and subsequent wake.
+- [ ] Evidence: screen photo with timestamp, journal entries referencing scheduler actions.
+
+## Phase 7 – Wi-Fi Provisioning & Watcher
+- [ ] Trigger first-run provisioning portal or local page (follow project-specific instructions). Confirm phone/laptop can join hotspot and submit credentials.
+- [ ] After provisioning, ensure Pi joins target Wi-Fi (`nmcli dev status`).
+- [ ] LAN-up/Internet-down: block WAN (e.g., override DNS `/etc/hosts` or router rule) while keeping Wi-Fi up. Confirm slideshow keeps advancing and `wifi-watcher` logs retries without pausing playback.
+- [ ] Wi-Fi down: power off AP or change SSID. Observe watcher retry cadence and any UI hints. Restore AP and ensure automatic reconnection.
+- [ ] Evidence:
+  ```sh
+  nmcli dev status
+  journalctl -u wifi-watcher.service -n 200 --no-pager  # if separate unit
+  journalctl -u photo-app.service -n 200 --no-pager | grep -i network
+  ```
+
+## Phase 8 – Library Ingest & Rendering
+- [ ] Point to tiny library (≤50). Validate EXIF orientation, mats, transitions.
+- [ ] Swap to medium library (1–3k). Allow 10–15 minutes playback, monitoring CPU/GPU/IO:
+  ```sh
+  top -H -p $(pidof rust-photo-frame)
+  vcgencmd measure_temp
+  ```
+- [ ] Watch for stutters or decode warnings in `journalctl -u photo-app.service`.
+- [ ] Note performance metrics in appendix.
+
+## Phase 9 – Updates & Rollback
+- [ ] Simulate release update:
+  ```sh
+  git fetch origin
+  git checkout <release-tag>
+  cargo build --release
+  sudo systemctl restart photo-app.service
+  ```
+- [ ] Validate new version via `rust-photo-frame --version` in logs or manual run.
+- [ ] Rollback rehearsal: checkout previous known-good commit/tag, rebuild, restart service.
+- [ ] Ensure unit file remains untouched (compare with `systemctl cat photo-app.service`).
+
+## Phase 10 – Power Loss & Recovery
+- [ ] Use 52Pi PD board (if equipped) to momentarily cut power (per manufacturer safe window).
+- [ ] Confirm auto-boot, kiosk autologin, and slideshow resume within expected timeframe.
+- [ ] Check for filesystem warnings:
+  ```sh
+  journalctl -b | grep -i fsck
+  dmesg | grep -i error
+  ```
+
+## Phase 11 – Diagnostics & Log Bundle
+- [ ] Run collector:
+  ```sh
+  tests/collect_logs.sh
+  ```
+- [ ] Verify artifact present: `ls artifacts/FRAME-logs-*.tar.gz`.
+- [ ] Attach bundle to issue tracker entry with notes on observed behavior.
+
+## Acceptance Criteria
+- [ ] Cold boot to slideshow ready in ≤ 45 seconds after login prompt appears.
+- [ ] Display locked to desired mode (4K@60 preferred) with no sustained tearing.
+- [ ] Button behaviors (short press sleep toggle, double-click shutdown) reliable.
+- [ ] Sleep schedule respects configured windows and reacts to manual SIGUSR1 trigger.
+- [ ] Wi-Fi provisioning, outage resilience, and watcher recovery all succeed without slideshow halt.
+- [ ] Library playback smooth for medium set (≤5% CPU spikes >150% overall, no OOM/IO errors).
+- [ ] Updates deploy cleanly and rollback path verified.
+- [ ] Power loss recovery returns to slideshow without manual intervention.
+- [ ] Diagnostics bundle captures all required evidence.
+
+## Recovery & Rollback Notes
+- **Bad config.yaml:**
+  - [ ] Restore last-known-good from backup (`cp config.yaml.bak config.yaml`).
+  - [ ] Validate YAML syntax with `yamllint` (if installed) or `python3 -c "import yaml,sys; yaml.safe_load(open('config.yaml'))"`.
+  - [ ] Restart service: `sudo systemctl restart photo-app.service`.
+- **Broken service (fails to start):**
+  - [ ] Inspect logs: `journalctl -u photo-app.service -b`.
+  - [ ] Rebuild binary: `cargo build --release`.
+  - [ ] Validate unit file dependencies (Wayland, env vars) and run `sudo systemctl daemon-reload`.
+- **Failed update:**
+  - [ ] `git checkout <previous-good>`.
+  - [ ] Rebuild + restart service.
+  - [ ] If binary corrupted, delete `target/` and rebuild.
+- **Network stuck offline:**
+  - [ ] Verify Wi-Fi credentials (`nmcli connection show`).
+  - [ ] Restart NetworkManager: `sudo systemctl restart NetworkManager`.
+  - [ ] Run `tests/collect_logs.sh` and attach bundle to bug report.
+
+## Appendices
+### Appendix A – Helper Commands
+- Temperature: `vcgencmd measure_temp`
+- Display info: `wlr-randr`, `modetest -c`, `cat /sys/class/drm/card*/card*/modes`
+- Services: `systemctl status photo-app.service`, `journalctl -u photo-app.service -n 200 --no-pager`
+- Network: `nmcli dev status`, `nmcli connection show --active`
+- Signals: `kill -USR1 $(pidof rust-photo-frame)`
+- Button events: `sudo evtest`
+
+### Appendix B – Observations Log
+Use this space to jot down anomalies, thermal readings, or TODOs discovered during testing. Copy into issue tracker alongside log bundle.
+
+- [ ] Date / Tester:
+- [ ] Matrix scenario:
+- [ ] Findings:
+
+## Test Harness Quick Reference
+- [ ] **Smoke (10–15 min):** `tests/run_smoke.sh`
+- [ ] **Daily (≤3 min):** `tests/run_daily.sh`
+- [ ] **Log bundle:** `tests/collect_logs.sh`
+- [ ] **Make targets:**
+  ```sh
+  make -f tests/Makefile smoke
+  make -f tests/Makefile daily
+  make -f tests/Makefile collect
+  ```

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,18 @@
+SHELL := /bin/sh
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+
+.PHONY: smoke daily collect clean
+
+smoke:
+@cd $(ROOT)/tests && ./run_smoke.sh
+
+daily:
+@cd $(ROOT)/tests && ./run_daily.sh
+
+collect:
+@cd $(ROOT)/tests && ./collect_logs.sh
+
+clean:
+@rm -rf $(ROOT)/artifacts/* $(ROOT)/tests/tmp 2>/dev/null || true
+@mkdir -p $(ROOT)/artifacts
+@echo "Artifacts directory reset"

--- a/tests/collect_logs.sh
+++ b/tests/collect_logs.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$REPO_ROOT/tests/lib/assert.sh"
+
+main() {
+  section "Collecting diagnostics"
+  require_cmd tar
+  mkdir -p "$REPO_ROOT/artifacts"
+
+  local timestamp bundle tmpdir
+  timestamp="$(date -u +"%Y%m%dT%H%M%SZ")"
+  bundle="$REPO_ROOT/artifacts/FRAME-logs-$timestamp.tar.gz"
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' EXIT
+
+  mkdir -p "$tmpdir/system" "$tmpdir/journal" "$tmpdir/services" "$tmpdir/network" "$tmpdir/display" "$tmpdir/runtime"
+
+  info "Gathering system metadata"
+  uname -a >"$tmpdir/system/uname.txt"
+  if [ -r /etc/os-release ]; then
+    cp /etc/os-release "$tmpdir/system/os-release"
+  fi
+
+  info "Collecting journals"
+  if command -v journalctl >/dev/null 2>&1; then
+    journalctl -b -n 2000 >"$tmpdir/journal/journalctl-b.txt" || warn "journalctl -b truncated"
+    journalctl -u photo-app.service -b >"$tmpdir/journal/photo-app-service.txt" || warn "Unable to read unit journal"
+  else
+    warn "journalctl unavailable"
+  fi
+
+  info "Recording service definitions"
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl status photo-app.service >"$tmpdir/services/photo-app-status.txt" || true
+    systemctl cat photo-app.service >"$tmpdir/services/photo-app.service" || warn "Unable to cat service"
+  fi
+
+  info "Capturing network state"
+  if command -v nmcli >/dev/null 2>&1; then
+    nmcli dev status >"$tmpdir/network/dev-status.txt" || true
+    nmcli connection show --active >"$tmpdir/network/active-connections.txt" || true
+  else
+    warn "nmcli unavailable"
+  fi
+
+  info "Saving display modes"
+  for mode in /sys/class/drm/card*-*/modes; do
+    [ -e "$mode" ] || continue
+    cp "$mode" "$tmpdir/display/${mode##*/}.txt"
+  done
+  if command -v edid-decode >/dev/null 2>&1; then
+    for edid in /sys/class/drm/card*-*/edid; do
+      [ -e "$edid" ] || continue
+      edid-decode "$edid" >"$tmpdir/display/$(basename "${edid%/edid}")-edid.txt" || warn "Failed to decode $edid"
+    done
+  else
+    for edid in /sys/class/drm/card*-*/edid; do
+      [ -e "$edid" ] || continue
+      hexdump -C "$edid" >"$tmpdir/display/$(basename "${edid%/edid}")-edid.hex"
+    done
+  fi
+
+  info "Recording runtime metrics"
+  ps -eo pid,comm,pcpu,pmem --sort=-pcpu | head -20 >"$tmpdir/runtime/top20.txt"
+  if command -v vcgencmd >/dev/null 2>&1; then
+    vcgencmd measure_temp >"$tmpdir/runtime/temperature.txt" || true
+  fi
+
+  if [ -x "$REPO_ROOT/target/release/rust-photo-frame" ]; then
+    "$REPO_ROOT/target/release/rust-photo-frame" --version >"$tmpdir/runtime/app-version.txt" || true
+  elif [ -x "$REPO_ROOT/target/debug/rust-photo-frame" ]; then
+    "$REPO_ROOT/target/debug/rust-photo-frame" --version >"$tmpdir/runtime/app-version.txt" || true
+  else
+    warn "rust-photo-frame binary not found; skipping --version"
+  fi
+
+  info "Copying config"
+  if [ -f "$REPO_ROOT/config.yaml" ]; then
+    cp "$REPO_ROOT/config.yaml" "$tmpdir/runtime/config.yaml"
+  fi
+
+  tar -czf "$bundle" -C "$tmpdir" .
+  pass "Created $bundle"
+}
+
+main "$@"

--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+section() {
+  printf '\n==== %s ====\n' "$1"
+}
+
+info() {
+  printf '[INFO] %s\n' "$1"
+}
+
+warn() {
+  printf 'WARN: %s\n' "$1" >&2
+}
+
+pass() {
+  printf 'PASS: %s\n' "$1"
+}
+
+skip() {
+  printf 'SKIP: %s\n' "$1"
+}
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+log_cmd() {
+  printf '  $ %s\n' "$*"
+}
+
+run_cmd() {
+  local desc="$1"
+  shift
+  info "$desc"
+  log_cmd "$*"
+  if "$@"; then
+    pass "$desc"
+  else
+    fail "$desc"
+  fi
+}
+
+require_cmd() {
+  local cmd="$1"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    pass "Command available: $cmd"
+  else
+    fail "Missing required command: $cmd"
+  fi
+}
+
+confirm() {
+  local prompt="$1"
+  local reply
+  read -rp "$prompt [y/N]: " reply
+  case "${reply:-}" in
+    [yY]|[yY][eE][sS])
+      pass "$prompt"
+      return 0
+      ;;
+    *)
+      fail "$prompt"
+      ;;
+  esac
+}
+
+confirm_or_skip() {
+  local prompt="$1"
+  local reply
+  read -rp "$prompt [y/N/s to skip]: " reply
+  case "${reply:-}" in
+    [yY]|[yY][eE][sS])
+      pass "$prompt"
+      return 0
+      ;;
+    [sS])
+      skip "$prompt"
+      return 1
+      ;;
+    *)
+      fail "$prompt"
+      ;;
+  esac
+}
+
+prompt_continue() {
+  local prompt="$1"
+  read -rp "$prompt Press Enter to continue..." _
+}
+
+with_timeout() {
+  local seconds="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$seconds" "$@"
+  else
+    warn "timeout command unavailable; running without limit"
+    "$@"
+  fi
+}

--- a/tests/run_daily.sh
+++ b/tests/run_daily.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$REPO_ROOT/tests/lib/assert.sh"
+
+main() {
+  section "Service health"
+  require_cmd systemctl
+  run_cmd "photo-app.service is active" systemctl is-active --quiet photo-app.service
+  run_cmd "Process present" pidof rust-photo-frame
+
+  section "Slideshow status"
+  info "Visually confirm that images are advancing and no overlays report errors."
+  confirm "Is the slideshow advancing normally?"
+
+  section "Network"
+  if command -v nmcli >/dev/null 2>&1; then
+    run_cmd "List device status" nmcli dev status
+    run_cmd "Show active connections" nmcli connection show --active
+  else
+    warn "nmcli not available; skipping network detail"
+  fi
+
+  section "Sleep schedule"
+  info "Check upcoming sleep/dim schedule hints from service logs."
+  log_cmd journalctl -u photo-app.service -n 50 --no-pager
+  journalctl -u photo-app.service -n 50 --no-pager || warn "Unable to read journal"
+  confirm "Do the logs show the expected upcoming sleep window?"
+
+  section "Log tail"
+  log_cmd journalctl -u photo-app.service -n 30 --no-pager
+  journalctl -u photo-app.service -n 30 --no-pager || warn "Unable to read journal"
+  confirm "Is the recent service log tail clean (no errors/warnings of concern)?"
+
+  pass "Daily checks complete"
+}
+
+main "$@"

--- a/tests/run_smoke.sh
+++ b/tests/run_smoke.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$REPO_ROOT/tests/lib/assert.sh"
+
+main() {
+  section "Pre-flight"
+  require_cmd vcgencmd
+  run_cmd "Measure SoC temperature" vcgencmd measure_temp
+  if command -v sensors >/dev/null 2>&1; then
+    info "Optional: run 'sensors' if additional thermal data needed"
+  fi
+
+  section "Service health"
+  require_cmd systemctl
+  run_cmd "photo-app.service is active" systemctl is-active --quiet photo-app.service
+  run_cmd "photo-app.service enabled" systemctl is-enabled --quiet photo-app.service
+  run_cmd "Process present" pidof rust-photo-frame
+  info "Recent service log tail"
+  log_cmd journalctl -u photo-app.service -n 20 --no-pager
+  journalctl -u photo-app.service -n 20 --no-pager || warn "Unable to read journal"
+
+  section "Display mode"
+  if command -v wlr-randr >/dev/null 2>&1; then
+    run_cmd "Query Wayland outputs" wlr-randr
+  else
+    warn "wlr-randr not found; falling back to DRM sysfs"
+    for mode in /sys/class/drm/card*-*/modes; do
+      [ -e "$mode" ] || continue
+      info "Modes for ${mode%/modes}"
+      log_cmd cat "$mode"
+      cat "$mode"
+    done
+  fi
+
+  section "Button short press"
+  info "Prepare to short-press the physical power button. Watch the screen for sleep toggle and confirm below."
+  if confirm_or_skip "Did the short press toggle slideshow sleep?"; then
+    info "Capture recent journal entries for evidence"
+    journalctl -u photo-app.service -n 40 --no-pager || warn "Unable to read journal"
+  fi
+
+  section "Sleep toggle via signal"
+  local pid
+  pid=$(pidof rust-photo-frame)
+  info "Sending SIGUSR1 to PID $pid"
+  run_cmd "Send SIGUSR1" kill -USR1 "$pid"
+  sleep 2
+  info "Check journal for sleep toggle acknowledgement"
+  journalctl -u photo-app.service -n 40 --no-pager || warn "Unable to read journal"
+
+  section "Collect log bundle"
+  run_cmd "Run log collector" "$REPO_ROOT/tests/collect_logs.sh"
+
+  pass "Smoke suite complete"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a comprehensive developer-operated end-to-end test plan for the Raspberry Pi photo frame
- introduce manual smoke, daily, and log-collection harness scripts with shared helpers and Make targets

## Testing
- not run (documentation and manual harness only)


------
https://chatgpt.com/codex/tasks/task_e_68dc9914f99c8323a8fb58714d7ad1a7