### PR TITLE
Update workspace to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-photo-frame"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0.100"

--- a/crates/buttond/Cargo.toml
+++ b/crates/buttond/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "photo-buttond"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "Power button handler daemon for the Rust photo frame"
 authors = ["Rust Photo Frame Team"]
 license = "MIT OR Apache-2.0"

--- a/crates/wifi-manager/Cargo.toml
+++ b/crates/wifi-manager/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wifi-manager"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
## Summary
- update the root crate and workspace members to Rust 2024 edition

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68dc9db02888832393489896e1d9b46e