### PR TITLE
Fix NEON blur unsafe pointer warnings

### DIFF
--- a/src/processing/blur.rs
+++ b/src/processing/blur.rs
@@ -141,13 +141,15 @@ mod neon {
                     } else {
                         let sy = clamp_i((y as isize) + offset, height as isize);
                         ((sy * width) + x) * 4
-                    } as isize;
-                    let pix = vld1q_f32(src_ptr.offset(sample_index));
+                    };
+                    let pix = unsafe { vld1q_f32(src_ptr.add(sample_index)) };
                     let weight_vec = vdupq_n_f32(weight);
                     acc = vmlaq_f32(acc, pix, weight_vec);
                 }
-                let out_index = ((y * width + x) * 4) as isize;
-                vst1q_f32(dst_ptr.offset(out_index), acc);
+                let out_index = (y * width + x) * 4;
+                unsafe {
+                    vst1q_f32(dst_ptr.add(out_index), acc);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- adjust the NEON blur pass to use `add` pointer arithmetic and explicit unsafe blocks, silencing Rust 2024 warnings

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68ddd5015d608323a1f14b04053d1c84