### PR TITLE
Fix default sleep commands to work without powerctl helper

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -64,8 +64,12 @@ sleep-mode:
       end: "23:30"
   dim-brightness: 0.04
   display-power:
-    sleep-command: "/opt/photo-frame/bin/powerctl sleep"
-    wake-command: "/opt/photo-frame/bin/powerctl wake"
+    # The default commands auto-detect the active Wayland output (falling back to
+    # HDMI-A-1) and issue both a wlroots DPMS request and a vcgencmd fallback.
+    # Keep the `@OUTPUT@` placeholder so the app can substitute the detected
+    # connector name when it runs outside the staged /opt install tree.
+    sleep-command: "wlr-randr --output @OUTPUT@ --off || vcgencmd display_power 0"
+    wake-command:  "wlr-randr --output @OUTPUT@ --on  || vcgencmd display_power 1"
 
 # Number of images to preload in the viewer (aligns with channel capacity)
 viewer-preload-count: 3

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,11 +184,13 @@ sleep:
 
   # True power control (HDMI monitor over Wayland)
   display-power:
-    sleep-command: "wlr-randr --output HDMI-A-1 --off || vcgencmd display_power 0"
-    wake-command:  "wlr-randr --output HDMI-A-1 --on  || vcgencmd display_power 1"
+    # Leave the @OUTPUT@ placeholder so the app can substitute the detected
+    # connector. You can hard-code a name like HDMI-A-1 if preferred.
+    sleep-command: "wlr-randr --output @OUTPUT@ --off || vcgencmd display_power 0"
+    wake-command:  "wlr-randr --output @OUTPUT@ --on  || vcgencmd display_power 1"
 ```
 
-The default configuration installs `/opt/photo-frame/bin/powerctl`, a thin wrapper around the same commands. Replace the example strings with `/opt/photo-frame/bin/powerctl sleep` / `wake` to use the helper and share a consistent detection script across deployments.
+The setup pipeline installs `/opt/photo-frame/bin/powerctl`, a thin wrapper around the same logic. Swap the example strings for `/opt/photo-frame/bin/powerctl sleep` / `wake` if you prefer the helper script once the staged tree has been deployed to `/opt`.
 
 ## Power button daemon
 

--- a/docs/power-and-sleep.md
+++ b/docs/power-and-sleep.md
@@ -9,8 +9,9 @@ This guide focuses on powering down HDMI monitors from the Raspberry Pi 5 runnin
    sudo apt update
    sudo apt install wlr-randr
    ```
-2. Install the app (`./setup/app/run.sh`) so `/opt/photo-frame/bin/powerctl` lands on the device.
-3. Enable sleep in `config.yaml` using the helper:
+2. (Optional) Install the app (`./setup/app/run.sh`) so `/opt/photo-frame/bin/powerctl` lands on the device. The helper mirrors
+   the default inline commands and can be referenced once the staged tree is deployed to `/opt`.
+3. Enable sleep in `config.yaml` using the built-in `@OUTPUT@` placeholder:
    ```yaml
    sleep-mode:
      timezone: America/New_York
@@ -19,8 +20,8 @@ This guide focuses on powering down HDMI monitors from the Raspberry Pi 5 runnin
        end:   "22:00"
      dim-brightness: 0.05
      display-power:
-       sleep-command: "/opt/photo-frame/bin/powerctl sleep"
-       wake-command: "/opt/photo-frame/bin/powerctl wake"
+       sleep-command: "wlr-randr --output @OUTPUT@ --off || vcgencmd display_power 0"
+       wake-command: "wlr-randr --output @OUTPUT@ --on  || vcgencmd display_power 1"
    ```
 4. Start the service. Pressing `SIGUSR1` (or a mapped GPIO button) now toggles sleep/wake regardless of schedule. Run a quick validation with `rust-photo-frame config.yaml --sleep-test 10`.
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -75,8 +75,8 @@ Exercise each axis at least once per release cycle.
       start: "07:00"
       end: "22:00"
     display-power:
-      sleep-command: "/opt/photo-frame/bin/powerctl sleep"
-      wake-command: "/opt/photo-frame/bin/powerctl wake"
+      sleep-command: "wlr-randr --output @OUTPUT@ --off || vcgencmd display_power 0"
+      wake-command: "wlr-randr --output @OUTPUT@ --on  || vcgencmd display_power 1"
   ```
 - [ ] Populate `/opt/photo-frame/var/photos` (or configured library path) according to the test matrix scenario.
 


### PR DESCRIPTION
## Summary
- replace the default sleep-mode display power commands with the inline wlr-randr/vcgencmd pipeline so local runs no longer require the staged powerctl helper
- document the new default and clarify that the powerctl script is optional in the configuration guide, sleep guide, and test plan

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68ddd7d9a5b48323a63bce82faef54a6