### PR TITLE
Fix wifi-manager hotspot permissions and gateway parsing

### DIFF
--- a/setup/system/modules/50-networkmanager.sh
+++ b/setup/system/modules/50-networkmanager.sh
@@ -74,8 +74,8 @@ write_config_if_changed() {
 
 rule_content=$(cat <<EOF_INNER
 polkit.addRule(function(action, subject) {
-    if (subject.user == "${SERVICE_USER}" &&
-        action.id.indexOf("org.freedesktop.NetworkManager.") === 0) {
+    if (action.id.indexOf("org.freedesktop.NetworkManager.") === 0 &&
+        (subject.user == "${SERVICE_USER}" || subject.isInGroup("${NETDEV_GROUP}"))) {
         return polkit.Result.YES;
     }
 });


### PR DESCRIPTION
## Summary
- extend the NetworkManager polkit rule to authorize any service user in the `netdev` group
- normalize nmcli key/value output so gateway pings use the actual IPv4 address
- add unit tests that cover the new nmcli parsing helper

## Testing
- cargo test -p wifi-manager

------
https://chatgpt.com/codex/tasks/task_e_68ddd8fd6c888323a4f1754643590207