### PR TITLE
Surface newly added photos immediately

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -13,8 +13,11 @@ pub struct PhotoInfo {
     pub created_at: SystemTime,
 }
 
-#[derive(Debug)]
-pub struct LoadPhoto(pub PathBuf);
+#[derive(Debug, Clone)]
+pub struct LoadPhoto {
+    pub path: PathBuf,
+    pub priority: bool,
+}
 
 #[derive(Debug, Clone)]
 pub struct PreparedImageCpu {
@@ -24,8 +27,11 @@ pub struct PreparedImageCpu {
     pub pixels: Vec<u8>,
 }
 
-#[derive(Debug)]
-pub struct PhotoLoaded(pub PreparedImageCpu);
+#[derive(Debug, Clone)]
+pub struct PhotoLoaded {
+    pub prepared: PreparedImageCpu,
+    pub priority: bool,
+}
 
 #[derive(Debug)]
 pub struct InvalidPhoto(pub PathBuf);


### PR DESCRIPTION
## Summary
- add a priority flag to `LoadPhoto`/`PhotoLoaded` so the slideshow can tag urgent entries
- teach the manager, loader, and viewer pipelines to propagate priority and reshuffle queues for newly discovered photos
- update integration and unit tests to assert the priority path and keep existing ordering guarantees

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ddd7138e748323a4659dc2e5950ab8