### PR TITLE
Set graphical target when installing kiosk units

### DIFF
--- a/setup/system/install-systemd-units.sh
+++ b/setup/system/install-systemd-units.sh
@@ -65,6 +65,11 @@ done
 
 systemctl daemon-reload
 
+# Ensure the system boots into graphical.target so cage starts automatically.
+if [[ "$(systemctl get-default)" != "graphical.target" ]]; then
+    systemctl set-default graphical.target
+fi
+
 ENABLE_UNITS=(
     cage@tty1.service
     photoframe-wifi-manager.service


### PR DESCRIPTION
## Summary
- ensure the systemd unit installer switches the default target to graphical.target so the kiosk session starts on boot

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddfe7df3b8832391b4f9e812889974