### PR TITLE
Remove legacy photo-frame.service during unit install

### DIFF
--- a/setup/system/install-systemd-units.sh
+++ b/setup/system/install-systemd-units.sh
@@ -41,6 +41,7 @@ fi
 systemctl daemon-reload
 
 LEGACY_UNITS=(
+    photo-frame.service
     sync-photos.service
     sync-photos.timer
     wifi-manager.service


### PR DESCRIPTION
## Summary
- remove the legacy photo-frame.service from hosts during systemd unit installation to avoid start failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de007fb2bc832393e95a874c8d3102