### PR TITLE
Disable systemd-logind power key handling for button daemon

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,6 +209,7 @@ The setup pipeline installs `/opt/photo-frame/bin/powerctl`, a thin wrapper arou
 - **Short press:** sends `SIGUSR1` to the running app (using the pidfile when present, otherwise `pkill -USR1 -f rust-photo-frame`).
 - **Double press:** runs `/opt/photo-frame/bin/photo-safe-shutdown`, which wraps `shutdown -h now`.
 - **Long press:** bypassed so the Pi firmware can force power-off.
+- **System integration:** The provisioning script also installs a `systemd-logind` drop-in that sets `HandlePowerKey=ignore` so the desktop stack never interprets the press as a global poweroff request; only the daemon reacts to the event.
 
 Auto-detection scans `/dev/input/by-path/*power*` before falling back to `/dev/input/event*`. If the wrong device is chosen, override it by editing the unit to pass `--device /dev/input/by-path/...-event`. Debounce, single-press, and double-press windows are configurable in milliseconds.
 

--- a/setup/system/logind.conf.d/photoframe.conf
+++ b/setup/system/logind.conf.d/photoframe.conf
@@ -1,0 +1,2 @@
+[Login]
+HandlePowerKey=ignore


### PR DESCRIPTION
## Summary
- install a systemd-logind drop-in so HandlePowerKey is ignored and single presses no longer trigger a shutdown
- ensure the provisioning script copies the drop-in, restarts logind, and document the integration in the power button section

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68df370a64a483239b599d2072ed6f75