### PR TITLE
Fix cargo environment defaults

### DIFF
--- a/setup/app/run.sh
+++ b/setup/app/run.sh
@@ -37,16 +37,13 @@ if [[ $(id -u) -eq 0 ]]; then
     exit 1
 fi
 
-CARGO_HOME_DEFAULT="${HOME}/.cargo"
-if [[ -d "/usr/local/cargo/bin" ]]; then
-    CARGO_HOME_DEFAULT="/usr/local/cargo"
-fi
-CARGO_HOME="${CARGO_HOME:-${CARGO_HOME_DEFAULT}}"
-if [[ -d "${CARGO_HOME}/bin" ]]; then
+CARGO_HOME="${CARGO_HOME:-${HOME}/.cargo}"
+SYSTEM_CARGO_BIN="/usr/local/cargo/bin"
+if [[ -d "${SYSTEM_CARGO_BIN}" ]]; then
     case ":${PATH}:" in
-        *:"${CARGO_HOME}/bin":*) ;;
+        *:"${SYSTEM_CARGO_BIN}":*) ;;
         *)
-            export PATH="${CARGO_HOME}/bin:${PATH}"
+            export PATH="${SYSTEM_CARGO_BIN}:${PATH}"
             ;;
     esac
 fi

--- a/setup/packages/install-rust.sh
+++ b/setup/packages/install-rust.sh
@@ -38,7 +38,7 @@ echo "Ensuring PATH export for system-wide cargo bin directory"
 cat <<'PROFILE' >/etc/profile.d/cargo-bin.sh
 SYSTEM_CARGO_BIN="/usr/local/cargo/bin"
 
-if [ -f "/usr/local/cargo/env" ]; then
+if [ "$(id -u)" -eq 0 ] && [ -f "/usr/local/cargo/env" ]; then
     # shellcheck source=/dev/null
     . /usr/local/cargo/env
 fi

--- a/setup/packages/install-rust.sh
+++ b/setup/packages/install-rust.sh
@@ -36,13 +36,22 @@ env RUSTUP_HOME="${RUSTUP_HOME}" CARGO_HOME="${CARGO_HOME}" \
 
 echo "Ensuring PATH export for system-wide cargo bin directory"
 cat <<'PROFILE' >/etc/profile.d/cargo-bin.sh
-if [ -d "${CARGO_HOME}/bin" ]; then
+SYSTEM_CARGO_BIN="/usr/local/cargo/bin"
+
+if [ -f "/usr/local/cargo/env" ]; then
+    # shellcheck source=/dev/null
+    . /usr/local/cargo/env
+fi
+
+if [ -d "${SYSTEM_CARGO_BIN}" ]; then
     case ":${PATH}:" in
-        *:"${CARGO_HOME}/bin":*) ;;
-        *) PATH="${CARGO_HOME}/bin:${PATH}" ;;
+        *:"${SYSTEM_CARGO_BIN}":*) ;;
+        *) PATH="${SYSTEM_CARGO_BIN}:${PATH}" ;;
     esac
 fi
-export PATH
+
+: "${CARGO_HOME:=${HOME}/.cargo}"
+export PATH CARGO_HOME
 PROFILE
 
 chmod 0644 /etc/profile.d/cargo-bin.sh


### PR DESCRIPTION
## Summary
- ensure the global profile snippet sources the rustup environment, adds the system cargo bin directory to PATH, and defaults CARGO_HOME to a per-user directory
- keep app setup runs on a user-scoped CARGO_HOME while still exposing the system cargo binary on PATH

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df4d980bd883238ed2884f0ad141f9