### PR TITLE
Fix quoting in photoframe-sync systemd unit

### DIFF
--- a/setup/system/units/photoframe-sync.service
+++ b/setup/system/units/photoframe-sync.service
@@ -14,23 +14,27 @@ Environment=SYNC_TOOL=rclone
 Environment="RCLONE_FLAGS=--checkers=8 --transfers=4 --retries=5 --copy-links"
 Environment="RSYNC_FLAGS=-av --delete"
 EnvironmentFile=-/etc/photoframe/sync.env
-ExecStart=/usr/bin/env bash -euo pipefail -c '
-DEST="${PHOTO_LIBRARY_PATH:-}"; if [[ -z "${DEST}" ]]; then echo "PHOTO_LIBRARY_PATH must be set" >&2; exit 2; fi
-case "${SYNC_TOOL}" in
-  rsync)
-    if [[ -z "${RSYNC_SOURCE:-}" ]]; then
-      echo "RSYNC_SOURCE must be set when SYNC_TOOL=rsync" >&2
-      exit 2
-    fi
-    exec rsync ${RSYNC_FLAGS} "${RSYNC_SOURCE}" "${DEST}"
-    ;;
-  *)
-    if [[ -z "${RCLONE_REMOTE:-}" ]]; then
-      echo "RCLONE_REMOTE must be set when SYNC_TOOL=rclone" >&2
-      exit 2
-    fi
-    exec rclone sync "${RCLONE_REMOTE}" "${DEST}" ${RCLONE_FLAGS}
-    ;;
+ExecStart=/usr/bin/env bash -euo pipefail -c '\
+DEST="${PHOTO_LIBRARY_PATH:-}"; \
+if [[ -z "${DEST}" ]]; then \
+  echo "PHOTO_LIBRARY_PATH must be set" >&2; \
+  exit 2; \
+fi; \
+case "${SYNC_TOOL}" in \
+  rsync) \
+    if [[ -z "${RSYNC_SOURCE:-}" ]]; then \
+      echo "RSYNC_SOURCE must be set when SYNC_TOOL=rsync" >&2; \
+      exit 2; \
+    fi; \
+    exec rsync ${RSYNC_FLAGS} "${RSYNC_SOURCE}" "${DEST}"; \
+    ;; \
+  *) \
+    if [[ -z "${RCLONE_REMOTE:-}" ]]; then \
+      echo "RCLONE_REMOTE must be set when SYNC_TOOL=rclone" >&2; \
+      exit 2; \
+    fi; \
+    exec rclone sync "${RCLONE_REMOTE}" "${DEST}" ${RCLONE_FLAGS}; \
+    ;; \
 esac'
 
 [Install]


### PR DESCRIPTION
## Summary
- fix the photoframe-sync.service ExecStart quoting so systemd accepts the unit configuration
- keep the embedded bash script readable by using explicit line continuations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df4fe9501883238c028d3c24e1f575