### PR TITLE
Force cage to use logind backend

### DIFF
--- a/docs/software.md
+++ b/docs/software.md
@@ -128,7 +128,7 @@ When both setup stages complete successfully the Raspberry Pi is ready to boot d
 
 - The templated systemd unit `cage@tty1.service` binds to `/dev/tty1`, logs in the `kiosk` user through PAM, and `exec`s the Wayland compositor as `cage -- /opt/photo-frame/bin/rust-photo-frame --config /opt/photo-frame/etc/config.yaml`. PAM/logind create a real session so `XDG_RUNTIME_DIR` points at `/run/user/<uid>` and DRM permissions flow automatically while the writable config lives under `/var/lib/photo-frame/config`.
 - Device access comes from the `kiosk` user belonging to the `render`, `video`, and `input` groups. The system stage wires this up, so Vulkan/GL stacks can open `/dev/dri/renderD128` without any extra udev hacks.
-- `seatd` remains optional on Bookworm but harmless to have installed; the compositor happily runs without manual socket management when launched via logind.
+- `seatd` remains optional on Bookworm but harmless to have installed; the compositor happily runs without manual socket management when launched via logind. We force the `LIBSEAT_BACKEND=logind` environment for `cage@tty1.service` so the compositor always binds through logind even when the seatd daemon happens to be present.
 - Disable any other display manager or compositor on the target TTY so Cage can claim DRM master and input devices without contention.
 
 For smoke testing, temporarily adjust the unit to run `kmscube` instead of the photo frame binary. A spinning cube on HDMI verifies DRM, GBM, and input permissions before deploying the full app.

--- a/setup/system/cage@.service
+++ b/setup/system/cage@.service
@@ -15,6 +15,7 @@ User=kiosk
 WorkingDirectory=/var/lib/photo-frame
 Environment=PHOTOF_APP_BIN=/opt/photo-frame/bin/rust-photo-frame
 Environment=PHOTOF_CONFIG=/opt/photo-frame/etc/config.yaml
+Environment=LIBSEAT_BACKEND=logind
 ExecStart=/usr/bin/cage -- /opt/photo-frame/bin/rust-photo-frame /opt/photo-frame/etc/config.yaml
 Restart=always
 RestartSec=5s


### PR DESCRIPTION
## Summary
- ensure the kiosk systemd unit exports LIBSEAT_BACKEND=logind so Cage always binds through logind
- update the software documentation to note the forced backend and avoid seatd conflicts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df50b834548323aa37939ea50e7d66