### PR TITLE
Detect system Rust toolchain in app setup script

### DIFF
--- a/setup/app/run.sh
+++ b/setup/app/run.sh
@@ -37,9 +37,17 @@ if [[ $(id -u) -eq 0 ]]; then
     exit 1
 fi
 
-CARGO_HOME="${CARGO_HOME:-${HOME}/.cargo}"
-SYSTEM_CARGO_BIN="/usr/local/cargo/bin"
+SYSTEM_CARGO_HOME="/usr/local/cargo"
+SYSTEM_RUSTUP_HOME="/usr/local/rustup"
+SYSTEM_CARGO_BIN="${SYSTEM_CARGO_HOME}/bin"
+
 if [[ -d "${SYSTEM_CARGO_BIN}" ]]; then
+    if [[ -z "${CARGO_HOME+x}" ]]; then
+        CARGO_HOME="${SYSTEM_CARGO_HOME}"
+    fi
+    if [[ -z "${RUSTUP_HOME+x}" ]]; then
+        RUSTUP_HOME="${SYSTEM_RUSTUP_HOME}"
+    fi
     case ":${PATH}:" in
         *:"${SYSTEM_CARGO_BIN}":*) ;;
         *)
@@ -48,11 +56,17 @@ if [[ -d "${SYSTEM_CARGO_BIN}" ]]; then
     esac
 fi
 
+CARGO_HOME="${CARGO_HOME:-${HOME}/.cargo}"
+RUSTUP_HOME="${RUSTUP_HOME:-${HOME}/.rustup}"
+
 STAGE_ROOT="${STAGE_ROOT:-${SCRIPT_DIR}/build}"
 export STAGE_ROOT
 
+# The app stage expects the system-level Rust toolchain installed by
+# setup/packages/install-rust.sh, but developers may override the toolchain
+# location by setting CARGO_HOME and RUSTUP_HOME before invoking this script.
 export INSTALL_ROOT SERVICE_USER SERVICE_GROUP CARGO_PROFILE REPO_ROOT
-export CARGO_HOME
+export CARGO_HOME RUSTUP_HOME
 export PATH
 
 shopt -s nullglob


### PR DESCRIPTION
## Summary
- detect the system-provided Rust toolchain in setup/app/run.sh and set default CARGO_HOME and RUSTUP_HOME when available
- document that the app stage expects the toolchain installed by setup/packages/install-rust.sh while still allowing overrides

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e08a4d4e248323a0fd09055d741f1a