### PR TITLE
Relax postcheck service checks before kiosk provisioning

### DIFF
--- a/docs/software.md
+++ b/docs/software.md
@@ -103,7 +103,9 @@ Run the automation in three stages. Each script is idempotent, so you can safely
    ./setup/app/run.sh
    ```
 
-   Run this command as the unprivileged operator account. It compiles the photo frame, stages the release artifacts, and installs them into `/opt/photo-frame`. The stage verifies the kiosk service account exists and will prompt for sudo to create it (along with its primary group) when missing.
+   Run this command as the unprivileged operator account. It compiles the photo frame, stages the release artifacts, and installs them into `/opt/photo-frame`. The stage verifies the kiosk service account exists and will prompt for sudo to create it (along with its primary group) when missing. The closing postcheck confirms binaries and templates are in place and will warn if the runtime config at `/var/lib/photo-frame/config/config.yaml` is missing; re-running the command recreates it from the staged template.
+
+   The postcheck now defers systemd validation until the kiosk environment is provisioned. Expect warnings about `cage@tty1.service` and related helper units until you run the kiosk installer in the next step.
 
 1. Configure system services and permissions:
 


### PR DESCRIPTION
## Summary
- allow the app postcheck to skip failing when kiosk systemd units are not yet installed and surface a hint toward running the kiosk installer
- clarify the runtime config warning to point back to the staged template
- document that service warnings are expected until the kiosk provisioning script runs

## Testing
- bash -n setup/app/modules/50-postcheck.sh

------
https://chatgpt.com/codex/tasks/task_e_68e0934d18e08323aea62ab9c9bc12ee