### PR TITLE
Document runtime filesystem layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Plan your build around a Raspberry Pi 5, a portrait-capable 4K monitor, and moun
 
 From flashing Raspberry Pi OS to deploying the watcher, hotspot, and sync services, the setup guide walks through every command you need to bring the slideshow online. It also documents CLI flags for local debugging and a quickstart checklist for provisioning. [Full details →](docs/software.md)
 
+> **Install layout at a glance**
+>
+> - `/opt/photo-frame` holds the read-only release artifacts that ship with the project: compiled binaries, unit files, and the pristine configuration templates staged by the setup scripts.
+> - `/var/lib/photo-frame` carries the live state: the editable configuration (`config/config.yaml`), logs, caches, hotspot artifacts, and any synchronized media. Treat this tree as the working area that systemd services mutate at runtime.
+>
+> This split keeps upgrades simple—rerunning the installer refreshes `/opt` without clobbering the operator-managed data living under `/var`.
+
 Looking for the Pi 5 kiosk recipe? The Bookworm-specific instructions live in [docs/kiosk.md](docs/kiosk.md).
 
 ## Wi-Fi Recovery & Provisioning

--- a/docs/software.md
+++ b/docs/software.md
@@ -105,6 +105,13 @@ Run the automation in three stages. Each script is idempotent, so you can safely
 
    Run this command as the unprivileged operator account. It compiles the photo frame, stages the release artifacts, and installs them into `/opt/photo-frame`. The stage verifies the kiosk service account exists and will prompt for sudo to create it (along with its primary group) when missing. The closing postcheck confirms binaries and templates are in place and will warn if the runtime config at `/var/lib/photo-frame/config/config.yaml` is missing; re-running the command recreates it from the staged template.
 
+   > **Filesystem roles**
+   >
+   > - `/opt/photo-frame` is treated as read-only at runtime. It contains the versioned binaries, systemd unit templates, and stock configuration files delivered by the setup scripts.
+   > - `/var/lib/photo-frame` is writable and owned by the service account. Configuration overrides, logs, hotspot artifacts, and synchronized media all live here. Systemd services expect to mutate this tree, so backups and troubleshooting should start in `/var`.
+   >
+   > Keeping code and mutable state separate allows updates to replace the staged artifacts in `/opt` without disturbing operator-managed data in `/var/lib/photo-frame`.
+
    The postcheck now defers systemd validation until the kiosk environment is provisioned. Expect warnings about `cage@tty1.service` and related helper units until you run the kiosk installer in the next step.
 
 1. Configure system services and permissions:


### PR DESCRIPTION
## Summary
- highlight the separation between the staged artifacts in /opt/photo-frame and the writable runtime data in /var/lib/photo-frame inside the README
- expand the software setup guide with a callout that explains how installers should treat /opt and /var during upgrades and troubleshooting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0960ca97483239860847bce59d92b