### PR TITLE
Update kiosk tooling and docs for Debian Trixie

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ From flashing Raspberry Pi OS to deploying the watcher, hotspot, and sync servic
 >
 > This split keeps upgrades simple—rerunning the installer refreshes `/opt` without clobbering the operator-managed data living under `/var`.
 
-Looking for the Pi 5 kiosk recipe? The Bookworm-specific instructions live in [docs/kiosk.md](docs/kiosk.md).
+Looking for the Pi 5 kiosk recipe? The Trixie-specific instructions live in [docs/kiosk.md](docs/kiosk.md).
 
 ## Wi-Fi Recovery & Provisioning
 

--- a/assets/systemd/photoframe-buttond.service
+++ b/assets/systemd/photoframe-buttond.service
@@ -1,4 +1,4 @@
-# Managed by setup/kiosk-bookworm.sh
+# Managed by setup/kiosk-trixie.sh
 [Unit]
 Description=Photo Frame Power Button Monitor
 After=graphical.target

--- a/assets/systemd/photoframe-sync.service
+++ b/assets/systemd/photoframe-sync.service
@@ -1,4 +1,4 @@
-# Managed by setup/kiosk-bookworm.sh
+# Managed by setup/kiosk-trixie.sh
 [Unit]
 Description=Photo Frame Library Sync
 After=network-online.target

--- a/assets/systemd/photoframe-sync.timer
+++ b/assets/systemd/photoframe-sync.timer
@@ -1,4 +1,4 @@
-# Managed by setup/kiosk-bookworm.sh
+# Managed by setup/kiosk-trixie.sh
 [Unit]
 Description=Run Photo Frame Library Sync hourly
 

--- a/assets/systemd/photoframe-wifi-manager.service
+++ b/assets/systemd/photoframe-wifi-manager.service
@@ -1,4 +1,4 @@
-# Managed by setup/kiosk-bookworm.sh
+# Managed by setup/kiosk-trixie.sh
 [Unit]
 Description=Photo Frame Wi-Fi Manager
 After=network-online.target

--- a/docs/kiosk.md
+++ b/docs/kiosk.md
@@ -1,6 +1,7 @@
-# Raspberry Pi OS Bookworm Kiosk
+# Raspberry Pi OS Trixie Kiosk
 
-This guide documents the canonical Raspberry Pi 5 kiosk stack for Bookworm: a
+This guide documents the canonical Raspberry Pi 5 kiosk stack for Trixie (Debian 13.1,
+released September 6, 2025, following the initial 13.0 launch on August 9, 2025): a
 headless boot into Cage on `tty1`, managed entirely by systemd.
 
 ## Canonical recipe
@@ -26,7 +27,7 @@ headless boot into Cage on `tty1`, managed entirely by systemd.
 Run the provisioning script as root (it re-execs with `sudo` if needed):
 
 ```bash
-sudo ./setup/kiosk-bookworm.sh --user kiosk --app /usr/local/bin/photo-app
+sudo ./setup/kiosk-trixie.sh --user kiosk --app /usr/local/bin/photo-app
 ```
 
 Flags:
@@ -66,12 +67,12 @@ After provisioning on real hardware:
 
 The following legacy paths were removed in favour of the single Cage workflow:
 
-- `setup/system/**` – replaced by `setup/kiosk-bookworm.sh`.
+- `setup/system/**` – replaced by `setup/kiosk-trixie.sh`.
 - `setup/migrate/legacy-cleanup.sh` – superseded by the idempotent installer.
 - `setup/system/cage@.service` and `setup/system/pam.d/cage` – consolidated in
   `assets/systemd/` and `assets/pam/`.
 - `setup/system/units/photoframe-*` – moved to `assets/systemd/` for staging and
   provisioning.
 
-All legacy flows have been removed; rely solely on the Bookworm script outlined
+All legacy flows have been removed; rely solely on the Trixie script outlined
 above.

--- a/docs/power-and-sleep.md
+++ b/docs/power-and-sleep.md
@@ -1,6 +1,6 @@
 # Display Power and Sleep Guide
 
-This guide focuses on powering down HDMI monitors from the Raspberry Pi 5 running Raspberry Pi OS (Bookworm) under Wayfire/wlroots. It explains how the sleep schedule interacts with `wlr-randr`, the default `powerctl` helper, and what to check when the Dell S2725QC refuses to cooperate.
+This guide focuses on powering down HDMI monitors from the Raspberry Pi 5 running Raspberry Pi OS (Trixie) under Wayfire/wlroots. It explains how the sleep schedule interacts with `wlr-randr`, the default `powerctl` helper, and what to check when the Dell S2725QC refuses to cooperate.
 
 ## Quick start
 

--- a/docs/software.md
+++ b/docs/software.md
@@ -33,12 +33,12 @@ Recent releases of Raspberry Pi Imager (v1.8 and newer) prompt for customization
 
 ## Setup with Raspberry Pi Imager
 
-This workflow prepares a Raspberry Pi OS (Bookworm, 64-bit) image that boots directly into a network-connected, SSH-ready system.
+This workflow prepares a Raspberry Pi OS (Trixie, 64-bit) image that boots directly into a network-connected, SSH-ready system.
 
 1. Download and install the latest [Raspberry Pi Imager](https://www.raspberrypi.com/software/).
 1. Insert the target microSD card into your computer and launch Raspberry Pi Imager.
 1. **Choose Device:** Raspberry Pi 5
-1. **Choose OS:** select _Raspberry Pi OS (64-bit)_ (Bookworm).
+1. **Choose OS:** select _Raspberry Pi OS (64-bit)_ (Trixie).
 1. **Choose Storage:** pick the microSD card.
 1. Click **Next**. When prompted to apply OS customization, choose **Edit Settings**. The older gear icon has been replaced with this dialog in recent releases.
 1. In **General** settings:
@@ -117,7 +117,7 @@ Run the automation in three stages. Each script is idempotent, so you can safely
 1. Configure system services and permissions:
 
    ```bash
-   sudo ./setup/kiosk-bookworm.sh --user kiosk --app /usr/local/bin/photo-app
+  sudo ./setup/kiosk-trixie.sh --user kiosk --app /usr/local/bin/photo-app
    ```
 
    When the script finishes, reconnect your SSH session so new group memberships take effect.

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -36,7 +36,7 @@ Exercise each axis at least once per release cycle.
 - [ ] Capture evidence via `tests/collect_logs.sh` (provides modes, EDID, journals).
 
 ## Phase 1 – Blank-Pi Install
-- [ ] Flash the latest Raspberry Pi OS (Bookworm, 64-bit) onto a reliable microSD using Raspberry Pi Imager (preload hostname, user, Wi-Fi, SSH key).
+- [ ] Flash the latest Raspberry Pi OS (Trixie, 64-bit) onto a reliable microSD using Raspberry Pi Imager (preload hostname, user, Wi-Fi, SSH key).
 - [ ] On first boot, sign in as the deployment user (default `frame`) and confirm network connectivity.
 - [ ] (Optional) Run `sudo apt update && sudo apt upgrade -y` once; the automation will also perform a dist-upgrade but this reduces the first-run delta.
 - [ ] Confirm Wayland desktop capability: `echo "$XDG_SESSION_TYPE"` should report `wayland` after logging into the graphical session once.
@@ -49,7 +49,7 @@ Exercise each axis at least once per release cycle.
   ```
 - [ ] Run the kiosk bootstrapper (installs packages, creates the kiosk user, installs units, and enables Cage on tty1):
   ```sh
-  sudo ./setup/kiosk-bookworm.sh --user kiosk --app /usr/local/bin/photo-app
+  sudo ./setup/kiosk-trixie.sh --user kiosk --app /usr/local/bin/photo-app
   ```
   Note: reconnect your SSH session afterwards so refreshed group memberships apply.
 - [ ] After reconnecting, rerun the repo checkout if necessary and execute the app deploy stage (build + install + systemd wiring). Expect 5–7 minutes for the release build on a Pi 5 with active cooling:

--- a/docs/wifi-manager.md
+++ b/docs/wifi-manager.md
@@ -83,12 +83,12 @@ All mutable state lives under `/var/lib/photo-frame` and is owned by the `photo-
 
 The Wi-Fi manager is wired into the refreshed setup pipeline:
 
-- `setup/kiosk-bookworm.sh` provisions the kiosk user, installs the Cage session units, and enables seat management.
+- `setup/kiosk-trixie.sh` provisions the kiosk user, installs the Cage session units, and enables seat management.
 - `setup/packages/install-apt-packages.sh` pulls in NetworkManager, Cage, GPU drivers, and build prerequisites.
 - `setup/app/modules/10-build.sh` compiles `wifi-manager` in release mode as the invoking user (never root).
 - `setup/app/modules/20-stage.sh` stages the binary, config template, wordlist, and docs.
 - `setup/app/modules/30-install.sh` installs artifacts into `/opt/photo-frame` and seeds `/var/lib/photo-frame/config/config.yaml` if missing.
-- `setup/kiosk-bookworm.sh` installs and enables `/etc/systemd/system/photoframe-wifi-manager.service` alongside the other kiosk units.
+- `setup/kiosk-trixie.sh` installs and enables `/etc/systemd/system/photoframe-wifi-manager.service` alongside the other kiosk units.
 
 Re-running the scripts is idempotent: binaries are replaced in place, configs are preserved, ACLs stay intact, and systemd units reload cleanly.
 

--- a/scripts/legacy_sweep/all-files.txt
+++ b/scripts/legacy_sweep/all-files.txt
@@ -38,7 +38,7 @@ maker/cleat-spacers.scad
 maker/cleat-spacers.stl
 maker/maker.md
 setup-AUDIT-RESULTS.md
-setup/10-kiosk-bookworm.sh
+setup/10-kiosk-trixie.sh
 setup/README.md
 setup/app/modules/10-build.sh
 setup/app/modules/20-stage.sh

--- a/setup/README.md
+++ b/setup/README.md
@@ -4,18 +4,18 @@ This directory houses idempotent provisioning scripts for Raspberry Pi photo
 frame deployments. Each script can be re-run safely after OS updates or image
 refreshes.
 
-## One-command kiosk bootstrap (Bookworm)
+## One-command kiosk bootstrap (Trixie)
 
-Provision a Raspberry Pi OS Bookworm kiosk with the canonical Cage + systemd
+Provision a Raspberry Pi OS Trixie kiosk with the canonical Cage + systemd
 recipe:
 
 ```bash
-sudo ./setup/kiosk-bookworm.sh --user kiosk --app /usr/local/bin/photo-app
+sudo ./setup/kiosk-trixie.sh --user kiosk --app /usr/local/bin/photo-app
 ```
 
 The script performs the following actions:
 
-- verifies the OS is Raspberry Pi OS Bookworm,
+- verifies the OS is Raspberry Pi OS Trixie,
 - installs `cage`, `seatd`, and `plymouth` and enables the seatd service,
 - ensures the `kiosk` user exists and belongs to the `render`, `video`, and
   `input` groups,

--- a/setup/app/modules/50-postcheck.sh
+++ b/setup/app/modules/50-postcheck.sh
@@ -125,7 +125,7 @@ if command -v systemctl >/dev/null 2>&1; then
         fi
     }
 
-    kiosk_hint="run setup/kiosk-bookworm.sh to provision kiosk services"
+    kiosk_hint="run setup/kiosk-trixie.sh to provision kiosk services"
 
     check_service "${KIOSK_SERVICE}" "ERROR" "${kiosk_hint}"
     check_enabled "${KIOSK_SERVICE}" "${kiosk_hint}"

--- a/setup/kiosk-trixie.sh
+++ b/setup/kiosk-trixie.sh
@@ -11,7 +11,7 @@ log() {
 
 usage() {
     cat <<USAGE
-Usage: sudo ./setup/kiosk-bookworm.sh [--user NAME] [--app PATH]
+Usage: sudo ./setup/kiosk-trixie.sh [--user NAME] [--app PATH]
 
 Options:
   --user NAME   Kiosk service account to run Cage (default: kiosk)
@@ -53,15 +53,15 @@ parse_args() {
     done
 }
 
-require_bookworm() {
+require_trixie() {
     if [[ ! -f /etc/os-release ]]; then
         echo "/etc/os-release not found; unable to detect OS" >&2
         exit 1
     fi
     # shellcheck disable=SC1091
     . /etc/os-release
-    if [[ "${VERSION_CODENAME:-}" != "bookworm" ]]; then
-        echo "This script supports Raspberry Pi OS Bookworm only." >&2
+    if [[ "${VERSION_CODENAME:-}" != "trixie" ]]; then
+        echo "This script supports Raspberry Pi OS Trixie only." >&2
         exit 1
     fi
 }
@@ -202,7 +202,7 @@ update_cmdline() {
 main() {
     reexec_as_root "$@"
     parse_args "$@"
-    require_bookworm
+    require_trixie
     require_commands
     # shellcheck source=/dev/null
     . "${LIB_DIR}/systemd.sh"


### PR DESCRIPTION
## Summary
- rename the kiosk provisioning script to target Debian Trixie and enforce the new codename at runtime
- refresh setup hints, systemd headers, and automation messaging to reference the trixie script name
- update user-facing documentation to call out Raspberry Pi OS Trixie and the 2025 Debian 13.0/13.1 releases

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0994db9048323a84461c8c1b190b3