### PR TITLE
Fix kiosk setup to remove stale display manager alias

### DIFF
--- a/setup/kiosk-trixie.sh
+++ b/setup/kiosk-trixie.sh
@@ -186,6 +186,12 @@ cleanup_display_managers() {
             systemd_stop_unit "${dm}"
         fi
     done
+
+    local alias_path="/etc/systemd/system/display-manager.service"
+    if [[ -L "${alias_path}" || -e "${alias_path}" ]]; then
+        log "Removing existing display-manager.service alias"
+        rm -f "${alias_path}"
+    fi
 }
 
 update_cmdline() {


### PR DESCRIPTION
## Summary
- remove any pre-existing display-manager.service alias before enabling cage@tty1
- log the cleanup so kiosk installs are easier to debug

## Testing
- bash -n setup/kiosk-trixie.sh

------
https://chatgpt.com/codex/tasks/task_e_68e09aeeb5d88323b6f86e527ddd0ff1