### PR TITLE
Fix kiosk display-manager alias with shim service

### DIFF
--- a/assets/systemd/cage@.service
+++ b/assets/systemd/cage@.service
@@ -7,6 +7,7 @@ Wants=dbus.socket systemd-logind.service
 After=dbus.socket systemd-logind.service
 Conflicts=getty@%i.service
 After=getty@%i.service
+PartOf=display-manager.service
 
 [Service]
 Type=simple
@@ -25,5 +26,4 @@ PAMName=cage
 
 [Install]
 WantedBy=graphical.target
-Alias=display-manager.service
 DefaultInstance=tty1

--- a/assets/systemd/photoframe-display-manager.service
+++ b/assets/systemd/photoframe-display-manager.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Photoframe display manager shim
+Documentation=https://github.com/vincentl/rust-photo-frame
+Requires=cage@tty1.service
+After=cage@tty1.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/true
+RemainAfterExit=yes
+
+[Install]
+Alias=display-manager.service
+WantedBy=graphical.target

--- a/setup/kiosk-trixie.sh
+++ b/setup/kiosk-trixie.sh
@@ -163,7 +163,7 @@ enable_units() {
     systemd_disable_unit getty@tty1.service
     systemd_stop_unit getty@tty1.service
 
-    local enable_list=(cage@tty1.service photoframe-wifi-manager.service photoframe-buttond.service photoframe-sync.timer)
+    local enable_list=(photoframe-display-manager.service cage@tty1.service photoframe-wifi-manager.service photoframe-buttond.service photoframe-sync.timer)
     for unit in "${enable_list[@]}"; do
         log "Enabling ${unit}"
         systemd_enable_unit "${unit}"


### PR DESCRIPTION
## Summary
- revert the previous attempt to delete the display-manager alias during kiosk provisioning
- add a photoframe-display-manager.service shim that provides the display-manager alias and pulls in cage@tty1
- update the kiosk setup script to install/enable the shim and keep cage@.service tied to display-manager.service

## Testing
- not run (system-level script change)


------
https://chatgpt.com/codex/tasks/task_e_68e09c4cebb48323944f874f1525625d