### PR TITLE
Add display service switching to wifi-manager watcher

### DIFF
--- a/crates/wifi-manager/src/config.rs
+++ b/crates/wifi-manager/src/config.rs
@@ -21,6 +21,8 @@ pub struct Config {
     pub hotspot: HotspotConfig,
     #[serde(default)]
     pub ui: UiConfig,
+    #[serde(default)]
+    pub display: DisplayConfig,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -41,6 +43,17 @@ pub struct UiConfig {
     pub bind_address: String,
     #[serde(default = "default_ui_port")]
     pub port: u16,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DisplayConfig {
+    #[serde(default = "default_photo_frame_service")]
+    pub photo_frame_service: String,
+    #[serde(default = "default_wifi_manager_service")]
+    pub wifi_manager_service: String,
+    #[serde(default = "default_systemctl_path")]
+    pub systemctl_path: PathBuf,
 }
 
 impl Config {
@@ -68,6 +81,16 @@ impl Default for UiConfig {
         Self {
             bind_address: default_ui_bind(),
             port: default_ui_port(),
+        }
+    }
+}
+
+impl Default for DisplayConfig {
+    fn default() -> Self {
+        Self {
+            photo_frame_service: default_photo_frame_service(),
+            wifi_manager_service: default_wifi_manager_service(),
+            systemctl_path: default_systemctl_path(),
         }
     }
 }
@@ -110,4 +133,16 @@ fn default_ui_bind() -> String {
 
 fn default_ui_port() -> u16 {
     8080
+}
+
+fn default_photo_frame_service() -> String {
+    "photo-frame.service".to_string()
+}
+
+fn default_wifi_manager_service() -> String {
+    "wifi-manager.service".to_string()
+}
+
+fn default_systemctl_path() -> PathBuf {
+    PathBuf::from("/usr/bin/systemctl")
 }

--- a/crates/wifi-manager/src/watch.rs
+++ b/crates/wifi-manager/src/watch.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::config::{Config, DisplayConfig};
 use crate::hotspot;
 use crate::nm;
 use crate::qr;
@@ -13,6 +13,41 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DisplayOwner {
+    PhotoFrame,
+    WifiManager,
+}
+
+struct DisplaySwitcher {
+    config: DisplayConfig,
+    active: Option<DisplayOwner>,
+}
+
+impl DisplaySwitcher {
+    fn new(config: DisplayConfig) -> Self {
+        Self {
+            config,
+            active: None,
+        }
+    }
+
+    async fn switch_to(&mut self, owner: DisplayOwner) -> Result<()> {
+        if self.active == Some(owner) {
+            return Ok(());
+        }
+
+        let (service, label) = match owner {
+            DisplayOwner::PhotoFrame => (&self.config.photo_frame_service, "photo frame"),
+            DisplayOwner::WifiManager => (&self.config.wifi_manager_service, "wifi manager"),
+        };
+
+        start_service(&self.config.systemctl_path, service, label).await?;
+        self.active = Some(owner);
+        Ok(())
+    }
+}
+
 pub async fn run(config: Config, config_path: PathBuf) -> Result<()> {
     fs::create_dir_all(&config.var_dir)
         .with_context(|| format!("failed to create var dir at {}", config.var_dir.display()))?;
@@ -20,6 +55,7 @@ pub async fn run(config: Config, config_path: PathBuf) -> Result<()> {
     let mut state = WatchState::Online;
     let mut offline_since: Option<Instant> = None;
     let mut hotspot_state: Option<ActiveHotspot> = None;
+    let mut display = DisplaySwitcher::new(config.display.clone());
 
     let mut sigterm =
         signal(SignalKind::terminate()).context("failed to register SIGTERM handler")?;
@@ -75,6 +111,12 @@ pub async fn run(config: Config, config_path: PathBuf) -> Result<()> {
                                             info!("Hotspot password ready; QR updated");
                                         }
                                         hotspot_state = Some(active);
+                                        if let Err(err) = display
+                                            .switch_to(DisplayOwner::WifiManager)
+                                            .await
+                                        {
+                                            warn!(error = ?err, "failed to start wifi-manager display service");
+                                        }
                                         WatchState::Hotspot
                                     }
                                     Err(err) => {
@@ -94,6 +136,9 @@ pub async fn run(config: Config, config_path: PathBuf) -> Result<()> {
                         info!("state transition: HOTSPOT -> ONLINE");
                         if let Some(mut active) = hotspot_state.take() {
                             active.stop(&config).await.ok();
+                        }
+                        if let Err(err) = display.switch_to(DisplayOwner::PhotoFrame).await {
+                            warn!(error = ?err, "failed to restore photo frame display service");
                         }
                         offline_since = None;
                         WatchState::Online
@@ -119,6 +164,22 @@ async fn start_hotspot(config: &Config, config_path: &PathBuf) -> Result<ActiveH
     );
     let child = spawn_ui(config_path).await?;
     Ok(ActiveHotspot { ui_process: child })
+}
+
+async fn start_service(systemctl_path: &PathBuf, service: &str, label: &str) -> Result<()> {
+    let mut command = Command::new(systemctl_path);
+    command.arg("start").arg(service);
+    command.stdout(Stdio::null());
+    command.stderr(Stdio::null());
+    let status = command
+        .status()
+        .await
+        .with_context(|| format!("failed to invoke systemctl for {label}"))?;
+    if !status.success() {
+        anyhow::bail!("systemctl start {service} exited with status {status}");
+    }
+    info!(service = %service, "systemctl start succeeded");
+    Ok(())
 }
 
 async fn check_online(config: &Config) -> Result<bool> {

--- a/setup/files/etc/wifi-manager.yaml
+++ b/setup/files/etc/wifi-manager.yaml
@@ -11,3 +11,6 @@ hotspot:
 ui:
   bind-address: 0.0.0.0
   port: 8080
+display:
+  photo-frame-service: photo-frame.service
+  wifi-manager-service: wifi-manager.service


### PR DESCRIPTION
## Summary
- add display service configuration to wifi-manager so the watcher knows which units control the display
- start the configured wifi-manager/photo-frame systemd units as the watcher transitions between hotspot and online states
- document the new display configuration keys in the template and guide

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e1bf15d5748323aa7fbd016872a657