### PR TITLE
Remove display output fallbacks in power control

### DIFF
--- a/setup/files/bin/powerctl
+++ b/setup/files/bin/powerctl
@@ -7,10 +7,81 @@ if [[ -z "$MODE" ]]; then
   exit 2
 fi
 detect_out() {
-  wlr-randr | awk '/connected/ {print $1; exit}'
+  wlr-randr | awk '
+    function commit() {
+      if (current == "") {
+        return
+      }
+
+      if (status_seen) {
+        connected = status_connected
+      } else if (enabled_seen) {
+        connected = enabled
+      } else {
+        connected = 0
+      }
+
+      if (!connected || internal) {
+        return
+      }
+
+      if (best == "") {
+        best = current
+      }
+    }
+
+    /^[[:space:]]*$/ {
+      next
+    }
+
+    /^[^[:space:]]/ {
+      commit()
+      current = $1
+      internal = ($1 ~ /^(eDP|LVDS)/)
+      enabled = 0
+      enabled_seen = 0
+      status_connected = 0
+      status_seen = 0
+      next
+    }
+
+    /^[[:space:]]+Enabled:[[:space:]]*/ {
+      value = tolower($2)
+      if (value == "yes" || value == "on" || value == "true" || value == "1") {
+        enabled = 1
+        enabled_seen = 1
+      } else if (value == "no" || value == "off" || value == "false" || value == "0") {
+        enabled = 0
+        enabled_seen = 1
+      }
+      next
+    }
+
+    /^[[:space:]]+Status:[[:space:]]*/ {
+      status_seen = 1
+      if (tolower($2) ~ /^connected/) {
+        status_connected = 1
+      } else if (tolower($2) ~ /^disconnected/) {
+        status_connected = 0
+      }
+      next
+    }
+
+    END {
+      commit()
+      if (best != "") {
+        print best
+        exit 0
+      }
+      exit 1
+    }
+  '
 }
 if [[ "$OUT" == "@AUTO@" ]]; then
-  OUT="$(detect_out || echo HDMI-A-1)"
+  if ! OUT="$(detect_out)"; then
+    echo "powerctl: failed to detect connected output" >&2
+    exit 1
+  fi
 fi
 if [[ "$MODE" == "sleep" ]]; then
   wlr-randr --output "$OUT" --off || vcgencmd display_power 0


### PR DESCRIPTION
## Summary
- update `powerctl` auto-detection to fail when no external connectors are reported instead of falling back to a hard-coded output
- mirror the modern wlr-randr parsing logic inside `display_power`, dropping the internal/HDMI fallbacks and updating fixtures
- adjust regression coverage for the Rust parser and the `powerctl` helper to expect detection failures when only internal outputs remain

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e1d6b485348323b3416df8789f26c0