### PR TITLE
Fix sleep toggle fallback when schedule matches manual override

### DIFF
--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -691,9 +691,24 @@ pub fn run_windowed(
             if self.override_state.is_some() {
                 self.override_state = None;
                 let transition = self.apply_target(self.snapshot.awake, SleepTrigger::Manual);
-                SleepToggleOutcome {
-                    transition,
-                    override_state: None,
+                if transition.is_some() {
+                    SleepToggleOutcome {
+                        transition,
+                        override_state: None,
+                    }
+                } else {
+                    let state = if self.awake {
+                        ManualOverride::ForcedSleep
+                    } else {
+                        ManualOverride::ForcedAwake
+                    };
+                    self.override_state = Some(state);
+                    let transition =
+                        self.apply_target(state.desired_awake(), SleepTrigger::Manual);
+                    SleepToggleOutcome {
+                        transition,
+                        override_state: Some(state),
+                    }
                 }
             } else {
                 let state = if self.awake {


### PR DESCRIPTION
## Summary
- ensure releasing a manual sleep override that matches the schedule falls back to a forced toggle so wake commands fire reliably

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e1d71226c88323aa0e3686328d88eb