### PR TITLE
Reflow markdown documents

### DIFF
--- a/LEGACY_SWEEP.md
+++ b/LEGACY_SWEEP.md
@@ -5,8 +5,7 @@
 - UPDATE: 2
 - DELETE: 5
 
-Major themes: retired historical setup documentation and unused tooling; consolidated staging assets under a single path.
-CI status: repository ships no GitHub workflows after this sweep.
+Major themes: retired historical setup documentation and unused tooling; consolidated staging assets under a single path. CI status: repository ships no GitHub workflows after this sweep.
 
 ## Findings
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ This project was developed with significant assistance from OpenAI’s AI tools:
 
 ## License
 
-This project is licensed under the **MIT License**.
-See the [LICENSE](LICENSE) file for full text.
+This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) file for full text.
 
 © 2025 Vincent Lucarelli

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -7,8 +7,7 @@ The photo frame targets Raspberry Pi hardware and a wall-mounted display. This g
 - **Raspberry Pi 5 (4 GiB or higher).** Provides the GPU performance and memory headroom needed to render transitions smoothly.
 - **4K monitor.** Any portrait-capable monitor with solid viewing angles works. Aim for thin bezels if you plan to hide the display behind a custom frame.
 - **Power supply.** Use an official Pi PSU or a USB-C power brick that can sustain the Pi 5 under load.
-- **Momentary power button.** Wire a normally-open pushbutton across the Pi 5 power pads. A short press is routed to the photo
-  frame daemon for sleep and shutdown control; a long hardware press still forces power-off through the firmware watchdog.
+- **Momentary power button.** Wire a normally-open pushbutton across the Pi 5 power pads. A short press is routed to the photo frame daemon for sleep and shutdown control; a long hardware press still forces power-off through the firmware watchdog.
 - **HDMI cable.** Connects the Pi to the display. Keep runs short to avoid signal degradation.
 - **High-endurance SD card.** Stores the operating system, binaries, and cached thumbnails.
 - **Mounting plan.** Decide how you will secure the Pi behind the screen and route power safely.

--- a/docs/kiosk.md
+++ b/docs/kiosk.md
@@ -1,14 +1,10 @@
 # Debian 13 Wayland Kiosk
 
-The photo frame boots straight into the Wayland app using a greetd-managed
-session on Debian 13 (trixie). greetd starts `cage` on virtual terminal 1 and
-runs the photo frame as the dedicated `kiosk` user—no display manager shims or
-PAM templates are required.
+The photo frame boots straight into the Wayland app using a greetd-managed session on Debian 13 (trixie). greetd starts `cage` on virtual terminal 1 and runs the photo frame as the dedicated `kiosk` user—no display manager shims or PAM templates are required.
 
 ## Provisioning workflow
 
-Run the kiosk installer on a fresh Debian 13 (or Raspberry Pi OS trixie)
-image:
+Run the kiosk installer on a fresh Debian 13 (or Raspberry Pi OS trixie) image:
 
 ```bash
 sudo ./setup/kiosk-trixie.sh
@@ -17,24 +13,14 @@ sudo ./setup/kiosk-trixie.sh
 The script performs the following actions:
 
 - verifies `/etc/os-release` reports `VERSION_CODENAME=trixie`;
-- installs the Wayland stack required for kiosk mode (`greetd`, `cage`,
-  `mesa-vulkan-drivers`, `vulkan-tools`, `wlr-randr`, and
-  `wayland-protocols`);
-- creates the `kiosk` account with a locked shell and ensures it belongs to the
-  `video`, `render`, and `input` groups;
-- writes `/etc/greetd/config.toml` so virtual terminal 1 runs
-  `cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` as the `kiosk` user;
-- disables other display managers (`gdm3`, `sddm`, `lightdm`), enables
-  `greetd.service` as the system `display-manager.service`, sets
-  `graphical.target` as the default boot target, and masks `getty@tty1.service`
-  to keep greetd in control of tty1;
-- deploys the `photoframe-*` helper units (wifi manager, sync timer, button
-  daemon); and
-- enables `greetd.service`, `photoframe-wifi-manager.service`,
-  `photoframe-buttond.service`, and `photoframe-sync.timer`.
+- installs the Wayland stack required for kiosk mode (`greetd`, `cage`, `mesa-vulkan-drivers`, `vulkan-tools`, `wlr-randr`, and `wayland-protocols`);
+- creates the `kiosk` account with a locked shell and ensures it belongs to the `video`, `render`, and `input` groups;
+- writes `/etc/greetd/config.toml` so virtual terminal 1 runs `cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` as the `kiosk` user;
+- disables other display managers (`gdm3`, `sddm`, `lightdm`), enables `greetd.service` as the system `display-manager.service`, sets `graphical.target` as the default boot target, and masks `getty@tty1.service` to keep greetd in control of tty1;
+- deploys the `photoframe-*` helper units (wifi manager, sync timer, button daemon); and
+- enables `greetd.service`, `photoframe-wifi-manager.service`, `photoframe-buttond.service`, and `photoframe-sync.timer`.
 
-Re-run the script after OS updates to reapply package dependencies or to repair
-systemd units; it is idempotent.
+Re-run the script after OS updates to reapply package dependencies or to repair systemd units; it is idempotent.
 
 ## Resulting configuration
 
@@ -58,9 +44,7 @@ systemctl status display-manager
 journalctl -u greetd -b
 ```
 
-`systemctl status greetd` should show the unit as `active (running)` with
-`/usr/bin/cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` in the command line. The journal
-contains both greetd session logs and the photo frame application output.
+`systemctl status greetd` should show the unit as `active (running)` with `/usr/bin/cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` in the command line. The journal contains both greetd session logs and the photo frame application output.
 
 ## Operations quick reference
 
@@ -69,5 +53,4 @@ contains both greetd session logs and the photo frame application output.
 - Pause the slideshow: `sudo systemctl stop greetd` (resume with `start`).
 - Inspect display state: `wlr-randr` (installed by the kiosk setup script).
 
-No `display-manager.service`, login overrides, or tty autologin hacks are
-required—the greetd unit owns kiosk launch entirely.
+No `display-manager.service`, login overrides, or tty autologin hacks are required—the greetd unit owns kiosk launch entirely.

--- a/docs/power-and-sleep.md
+++ b/docs/power-and-sleep.md
@@ -9,8 +9,7 @@ This guide focuses on powering down HDMI monitors from the Raspberry Pi 5 runnin
    sudo apt update
    sudo apt install wlr-randr
    ```
-2. (Optional) Install the app (`./setup/app/run.sh`) so `/opt/photo-frame/bin/powerctl` lands on the device. The helper mirrors
-   the default inline commands and can be referenced once the staged tree is deployed to `/opt`.
+2. (Optional) Install the app (`./setup/app/run.sh`) so `/opt/photo-frame/bin/powerctl` lands on the device. The helper mirrors the default inline commands and can be referenced once the staged tree is deployed to `/opt`.
 3. Enable sleep in `config.yaml` using the built-in `@OUTPUT@` placeholder:
    ```yaml
    sleep-mode:

--- a/docs/software.md
+++ b/docs/software.md
@@ -1,18 +1,10 @@
 # Raspberry Pi Provisioning and Installation
 
-These instructions cover the full workflow for preparing a Raspberry Pi to run
-the Photo Frame project, from creating the SD card image to verifying the kiosk
-session.
+These instructions cover the full workflow for preparing a Raspberry Pi to run the Photo Frame project, from creating the SD card image to verifying the kiosk session.
 
 ## Before you image: prepare SSH keys
 
-Recent releases of Raspberry Pi Imager (v1.8 and newer) prompt for customization
-_after_ you choose the OS and storage. Because you will need an SSH public key at
-that point, confirm that one is available before you begin flashing the card.
-Commands in this section are examples that should work on macOS or Linux.
-Consult documentation about your computer's OS for details about how to carry
-out these steps. See `ssh-keygen` documentation to choose appropriate parameters
-if you generate a new ssh key.
+Recent releases of Raspberry Pi Imager (v1.8 and newer) prompt for customization _after_ you choose the OS and storage. Because you will need an SSH public key at that point, confirm that one is available before you begin flashing the card. Commands in this section are examples that should work on macOS or Linux. Consult documentation about your computer's OS for details about how to carry out these steps. See `ssh-keygen` documentation to choose appropriate parameters if you generate a new ssh key.
 
 1. Check for an existing public SSH key.
 
@@ -20,22 +12,16 @@ if you generate a new ssh key.
    ls ~/.ssh/id_*.pub
    ```
 
-   If you see `no matches found` or `No such file or directory`, then you must
-   generate an ssh key. If there is an existing public ssh key, decide if you
-   want to use that key or create a new key just for the photo frame.
+   If you see `no matches found` or `No such file or directory`, then you must generate an ssh key. If there is an existing public ssh key, decide if you want to use that key or create a new key just for the photo frame.
 
-1. **To generate a new ssh key**, use `ssh-keygen`. This example creates a key
-   with the basename `photoframe` to distinguish the key.
+1. **To generate a new ssh key**, use `ssh-keygen`. This example creates a key with the basename `photoframe` to distinguish the key.
 
    ```bash
    ssh-keygen -t ed25519 -f ~/.ssh/photoframe -C "frame@photoframe.local"
    ```
 
-1. Note the key paths. If you create a new key specifically for this frame with
-   the above command, the private key path is `~/.ssh/photoframe` and the public
-   key path is `~/.ssh/photoframe.pub`.
-1. **Optional:** add an entry to `~/.ssh/config` so you can connect with
-   `ssh photoframe` later:
+1. Note the key paths. If you create a new key specifically for this frame with the above command, the private key path is `~/.ssh/photoframe` and the public key path is `~/.ssh/photoframe.pub`.
+1. **Optional:** add an entry to `~/.ssh/config` so you can connect with `ssh photoframe` later:
 
    ```config
    Host photoframe
@@ -47,16 +33,14 @@ if you generate a new ssh key.
 
 ## Flash Raspberry Pi OS with Raspberry Pi Imager
 
-This workflow prepares a Raspberry Pi OS (Trixie, 64-bit) image that boots
-directly into a network-connected, SSH-ready system.
+This workflow prepares a Raspberry Pi OS (Trixie, 64-bit) image that boots directly into a network-connected, SSH-ready system.
 
 1. Download and install the latest [Raspberry Pi Imager](https://www.raspberrypi.com/software/).
 1. Insert the target microSD card into your computer and launch Raspberry Pi Imager.
 1. **Choose Device:** Raspberry Pi 5
 1. **Choose OS:** select _Raspberry Pi OS (64-bit)_ (Trixie).
 1. **Choose Storage:** pick the microSD card.
-1. Click **Next**. When prompted to apply OS customization, choose **Edit Settings**.
-   The older gear icon has been replaced with this dialog in recent releases.
+1. Click **Next**. When prompted to apply OS customization, choose **Edit Settings**. The older gear icon has been replaced with this dialog in recent releases.
 1. In **General** settings:
    - **Hostname:** `photoframe`
    - **Username / Password:** create a dedicated user (e.g., `frame`) with a strong password.
@@ -69,31 +53,24 @@ directly into a network-connected, SSH-ready system.
 
 ## First boot and base OS checks
 
-1. Insert the prepared microSD card into the Raspberry Pi, connect the display,
-   and power it on.
-1. Give the device a minute to join Wi-Fi. From your Mac, connect via SSH using
-   the host alias configured earlier:
+1. Insert the prepared microSD card into the Raspberry Pi, connect the display, and power it on.
+1. Give the device a minute to join Wi-Fi. From your Mac, connect via SSH using the host alias configured earlier:
 
    ```bash
    ssh frame@photoframe.local
    ```
 
-   If you did not preload the key, log in with the username/password you
-   configured, then add the key to `~/.ssh/authorized_keys` on the Pi.
+   If you did not preload the key, log in with the username/password you configured, then add the key to `~/.ssh/authorized_keys` on the Pi.
 
-1. Confirm the operating system reports the expected codename before installing
-   anything:
+1. Confirm the operating system reports the expected codename before installing anything:
 
    ```bash
    grep VERSION_CODENAME /etc/os-release
    ```
 
-   The output must include `VERSION_CODENAME=trixie`. Earlier Debian releases are
-   no longer supported by the setup scripts.
+   The output must include `VERSION_CODENAME=trixie`. Earlier Debian releases are no longer supported by the setup scripts.
 
-1. (Recommended) Update the package cache and upgrade packages before running
-   the automation. Although the setup scripts will also check for OS updates, the
-   first update after a fresh install can be more involved and may include user prompts.
+1. (Recommended) Update the package cache and upgrade packages before running the automation. Although the setup scripts will also check for OS updates, the first update after a fresh install can be more involved and may include user prompts.
 
    ```bash
    sudo apt update && sudo apt upgrade -y
@@ -118,8 +95,7 @@ directly into a network-connected, SSH-ready system.
 
 ## Run the automated setup
 
-Run the automation in three stages. Each script is idempotent, so you can safely
-re-run it if the connection drops or you need to retry after a reboot.
+Run the automation in three stages. Each script is idempotent, so you can safely re-run it if the connection drops or you need to retry after a reboot.
 
 ### 1. Provision OS packages and the Rust toolchain
 
@@ -127,9 +103,7 @@ re-run it if the connection drops or you need to retry after a reboot.
 sudo ./setup/packages/run.sh
 ```
 
-This script installs the apt dependencies and a system-wide Rust toolchain under
-`/usr/local/cargo`. Log out and back in (or reconnect your SSH session)
-afterwards so your shell picks up the updated `PATH`.
+   This script installs the apt dependencies and a system-wide Rust toolchain under `/usr/local/cargo`. Log out and back in (or reconnect your SSH session) afterwards so your shell picks up the updated `PATH`.
 
 ### 2. Build and stage the application
 
@@ -137,31 +111,16 @@ afterwards so your shell picks up the updated `PATH`.
 ./setup/app/run.sh
 ```
 
-Run this command as the unprivileged operator account. It compiles the photo
-frame, stages the release artifacts, and installs them into `/opt/photo-frame`.
-The stage verifies the kiosk service account exists and will prompt for sudo to
-create it (along with its primary group) when missing. The closing postcheck
-confirms binaries and templates are in place and will warn if the runtime config
-at `/var/lib/photo-frame/config/config.yaml` is missing; re-running the command
-recreates it from the staged template.
+   Run this command as the unprivileged operator account. It compiles the photo frame, stages the release artifacts, and installs them into `/opt/photo-frame`. The stage verifies the kiosk service account exists and will prompt for sudo to create it (along with its primary group) when missing. The closing postcheck confirms binaries and templates are in place and will warn if the runtime config at `/var/lib/photo-frame/config/config.yaml` is missing; re-running the command recreates it from the staged template.
 
 > **Filesystem roles**
 >
-> - `/opt/photo-frame` is treated as read-only at runtime. It contains the
->   versioned binaries, systemd unit templates, and stock configuration files
->   delivered by the setup scripts.
-> - `/var/lib/photo-frame` is writable and owned by the service account.
->   Configuration overrides, logs, hotspot artifacts, and synchronized media all
->   live here. Systemd services expect to mutate this tree, so backups and
->   troubleshooting should start in `/var`.
+> - `/opt/photo-frame` is treated as read-only at runtime. It contains the versioned binaries, systemd unit templates, and stock configuration files delivered by the setup scripts.
+> - `/var/lib/photo-frame` is writable and owned by the service account. Configuration overrides, logs, hotspot artifacts, and synchronized media all live here. Systemd services expect to mutate this tree, so backups and troubleshooting should start in `/var`.
 >
-> Keeping code and mutable state separate allows updates to replace the staged
-> artifacts in `/opt` without disturbing operator-managed data in
-> `/var/lib/photo-frame`.
+> Keeping code and mutable state separate allows updates to replace the staged artifacts in `/opt` without disturbing operator-managed data in `/var/lib/photo-frame`.
 
-The postcheck defers systemd validation until the kiosk environment is
-provisioned. Expect warnings about `greetd.service` and related helper units
-until you run the kiosk installer in the next step.
+   The postcheck defers systemd validation until the kiosk environment is provisioned. Expect warnings about `greetd.service` and related helper units until you run the kiosk installer in the next step.
 
 Use the following environment variables to customize an installation:
 
@@ -180,17 +139,14 @@ sudo ./setup/kiosk-trixie.sh
 
 Run the greetd installer with root privileges. The script:
 
-- Installs `greetd`, `cage`, `mesa-vulkan-drivers`, `vulkan-tools`,
-  `wlr-randr`, and `wayland-protocols`.
+- Installs `greetd`, `cage`, `mesa-vulkan-drivers`, `vulkan-tools`, `wlr-randr`, and `wayland-protocols`.
 - Creates the locked `kiosk` user.
-- Writes `/etc/greetd/config.toml` and disables other display managers in favor
-  of the `greetd`-provided `display-manager.service`.
+- Writes `/etc/greetd/config.toml` and disables other display managers in favor of the `greetd`-provided `display-manager.service`.
 - Sets the default boot target to `graphical.target`.
 - Masks `getty@tty1.service`.
 - Enables `greetd` alongside the `photoframe-*` helpers.
 
-When the script finishes, reconnect your SSH session so new group memberships
-take effect.
+   When the script finishes, reconnect your SSH session so new group memberships take effect.
 
 ## Validate the kiosk stack
 
@@ -202,32 +158,16 @@ systemctl status display-manager
 journalctl -u greetd -b
 ```
 
-`systemctl status` should report `active (running)` and show
-`cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml`
-in the command line. The journal should contain the photo frame application logs
-for the current boot. Once these checks pass, reboot the device to land directly
-in the fullscreen photo frame experience.
+`systemctl status` should report `active (running)` and show `cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` in the command line. The journal should contain the photo frame application logs for the current boot. Once these checks pass, reboot the device to land directly in the fullscreen photo frame experience.
 
 ## Kiosk session reference
 
-When both setup stages complete successfully the Raspberry Pi is ready to boot
-directly into a kiosk session:
+When both setup stages complete successfully the Raspberry Pi is ready to boot directly into a kiosk session:
 
-- `/etc/greetd/config.toml` binds greetd to virtual terminal 1 and runs
-  `cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml`
-  as the `kiosk` user. greetd creates the login session so `XDG_RUNTIME_DIR`
-  points at `/run/user/<uid>` while `/var/lib/photo-frame` remains writable by
-  the kiosk account.
-- Device access comes from the `kiosk` user belonging to the `render`, `video`,
-  and `input` groups. The setup stage wires this up so Vulkan/GL stacks can open
-  `/dev/dri/renderD128` without any extra udev hacks.
-- The kiosk stack relies on `greetd` + `cage`; no display-manager compatibility
-  targets or tty autologin services are installed.
+- `/etc/greetd/config.toml` binds greetd to virtual terminal 1 and runs `cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` as the `kiosk` user. greetd creates the login session so `XDG_RUNTIME_DIR` points at `/run/user/<uid>` while `/var/lib/photo-frame` remains writable by the kiosk account.
+- Device access comes from the `kiosk` user belonging to the `render`, `video`, and `input` groups. The setup stage wires this up so Vulkan/GL stacks can open `/dev/dri/renderD128` without any extra udev hacks.
+- The kiosk stack relies on `greetd` + `cage`; no display-manager compatibility targets or tty autologin services are installed.
 
-For smoke testing, temporarily modify `/etc/greetd/config.toml` to run
-`kmscube` instead of the photo frame binary. A spinning cube on HDMI verifies
-DRM, GBM, and input permissions before deploying the full app.
+For smoke testing, temporarily modify `/etc/greetd/config.toml` to run `kmscube` instead of the photo frame binary. A spinning cube on HDMI verifies DRM, GBM, and input permissions before deploying the full app.
 
-To pause the slideshow for maintenance, SSH into the Pi and run
-`sudo systemctl stop greetd`. Start it again with `sudo systemctl start greetd`
-when you are ready to resume playback.
+To pause the slideshow for maintenance, SSH into the Pi and run `sudo systemctl stop greetd`. Start it again with `sudo systemctl start greetd` when you are ready to resume playback.

--- a/maker/fabrication.md
+++ b/maker/fabrication.md
@@ -14,8 +14,7 @@ The `maker` directory contains files used to outfit a Dell 27-inch 4K monitor (m
 
 ## Manifest
 
-- `cleat-spacers.scad`: OpenSCAD source file for spacer blocks.  
-  Ensures the French cleat bolts tighten into the VESA screw holes without crushing the monitor’s plastic back shell.
+- `cleat-spacers.scad`: OpenSCAD source file for spacer blocks. Ensures the French cleat bolts tighten into the VESA screw holes without crushing the monitor’s plastic back shell.
 
 - `cleat-spacers.stl`: STL render of the spacer blocks, ready for 3D printing.
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,8 +1,6 @@
 # Photo Frame Setup Pipeline
 
-This directory houses idempotent provisioning scripts for Raspberry Pi photo
-frame deployments. Each script can be re-run safely after OS updates or image
-refreshes.
+This directory houses idempotent provisioning scripts for Raspberry Pi photo frame deployments. Each script can be re-run safely after OS updates or image refreshes.
 
 ## One-command kiosk bootstrap (Trixie)
 
@@ -15,32 +13,23 @@ sudo ./setup/kiosk-trixie.sh
 The script performs the following actions:
 
 - verifies the OS is Raspberry Pi OS Trixie,
-- installs `greetd`, `cage`, `mesa-vulkan-drivers`, `vulkan-tools`,
-  `wlr-randr`, and `wayland-protocols`,
-- ensures the `kiosk` user exists with `/usr/sbin/nologin` and belongs to the
-  `render`, `video`, and `input` groups,
-- writes `/etc/greetd/config.toml` to launch `cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml`
-  on virtual terminal 1,
-- disables conflicting display managers (`gdm3`, `sddm`, `lightdm`), enables
-  `greetd.service` as the system `display-manager.service`, sets the default
-  boot target to `graphical.target`, and masks `getty@tty1.service` to avoid VT
-  races, and
+- installs `greetd`, `cage`, `mesa-vulkan-drivers`, `vulkan-tools`, `wlr-randr`, and `wayland-protocols`,
+- ensures the `kiosk` user exists with `/usr/sbin/nologin` and belongs to the `render`, `video`, and `input` groups,
+- writes `/etc/greetd/config.toml` to launch `cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` on virtual terminal 1,
+- disables conflicting display managers (`gdm3`, `sddm`, `lightdm`), enables `greetd.service` as the system `display-manager.service`, sets the default boot target to `graphical.target`, and masks `getty@tty1.service` to avoid VT races, and
 - deploys and enables the supporting `photoframe-*` helper units.
 
-Re-run the script after OS updates to reapply package dependencies or repair
-systemd state; it is safe and idempotent.
+Re-run the script after OS updates to reapply package dependencies or repair systemd state; it is safe and idempotent.
 
 ## Package provisioning helpers
 
-For development images you may still want the extended toolchain provided by
-`setup/packages/run.sh`:
+For development images you may still want the extended toolchain provided by `setup/packages/run.sh`:
 
 ```bash
 sudo ./setup/packages/run.sh
 ```
 
-This installs the Rust toolchain under `/usr/local/cargo` and pulls additional
-utilities (e.g., `rclone`, `kmscube`) useful during development.
+This installs the Rust toolchain under `/usr/local/cargo` and pulls additional utilities (e.g., `rclone`, `kmscube`) useful during development.
 
 ## Application deployment
 
@@ -50,9 +39,7 @@ Build and install release artifacts from an unprivileged shell:
 ./setup/app/run.sh
 ```
 
-The app stage compiles the workspace, stages binaries and documentation under
-`setup/app/build/stage`, ensures the kiosk service user exists, and installs
-the artifacts into `/opt/photo-frame`.
+The app stage compiles the workspace, stages binaries and documentation under `setup/app/build/stage`, ensures the kiosk service user exists, and installs the artifacts into `/opt/photo-frame`.
 
 ## Operator quick reference
 
@@ -61,5 +48,4 @@ the artifacts into `/opt/photo-frame`.
 - Tail kiosk logs: `sudo journalctl -u greetd -f`
 - Upload new media: copy into `/var/lib/photo-frame/photos`
 
-The kiosk account is unprivileged; use the `frame` operator account (see
-`docs/configuration.md`) for maintenance commands.
+The kiosk account is unprivileged; use the `frame` operator account (see `docs/configuration.md`) for maintenance commands.


### PR DESCRIPTION
## Summary
- reflow documentation paragraphs and list items to remove manual hard wraps that disrupted rendered formatting
- preserve blockquotes, tables, and nested list indentation while expanding sentences to single logical lines across the docs

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e1e4ae71f0832387c0762ade7b373f