### PR TITLE
Capture kiosk logs via systemd-cat and add operator SOP

### DIFF
--- a/docs/kiosk.md
+++ b/docs/kiosk.md
@@ -15,7 +15,7 @@ The script performs the following actions:
 - verifies `/etc/os-release` reports `VERSION_CODENAME=trixie`;
 - installs the Wayland stack required for kiosk mode (`greetd`, `cage`, `mesa-vulkan-drivers`, `vulkan-tools`, `wlr-randr`, and `wayland-protocols`);
 - creates the `kiosk` account with a locked shell and ensures it belongs to the `video`, `render`, and `input` groups;
-- writes `/etc/greetd/config.toml` so virtual terminal 1 runs `cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` as the `kiosk` user;
+- writes `/etc/greetd/config.toml` so virtual terminal 1 runs `cage -s -- systemd-cat --identifier=rust-photo-frame env RUST_LOG=info /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` as the `kiosk` user;
 - disables other display managers (`gdm3`, `sddm`, `lightdm`), enables `greetd.service` as the system `display-manager.service`, sets `graphical.target` as the default boot target, and masks `getty@tty1.service` to keep greetd in control of tty1;
 - deploys the `photoframe-*` helper units (wifi manager, sync timer, button daemon); and
 - enables `greetd.service`, `photoframe-wifi-manager.service`, `photoframe-buttond.service`, and `photoframe-sync.timer`.
@@ -31,7 +31,7 @@ Re-run the script after OS updates to reapply package dependencies or to repair 
 vt = 1
 
 [default_session]
-command = "cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml"
+command = "cage -s -- systemd-cat --identifier=rust-photo-frame env RUST_LOG=info /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml"
 user = "kiosk"
 ```
 
@@ -44,7 +44,7 @@ systemctl status display-manager
 journalctl -u greetd -b
 ```
 
-`systemctl status greetd` should show the unit as `active (running)` with `/usr/bin/cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` in the command line. The journal contains both greetd session logs and the photo frame application output.
+`systemctl status greetd` should show the unit as `active (running)` with `/usr/bin/cage -s -- systemd-cat --identifier=rust-photo-frame env RUST_LOG=info /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` in the command line. The journal contains both greetd session logs and the photo frame application output.
 
 ## Operations quick reference
 

--- a/docs/software.md
+++ b/docs/software.md
@@ -158,13 +158,13 @@ systemctl status display-manager
 journalctl -u greetd -b
 ```
 
-`systemctl status` should report `active (running)` and show `cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` in the command line. The journal should contain the photo frame application logs for the current boot. Once these checks pass, reboot the device to land directly in the fullscreen photo frame experience.
+`systemctl status` should report `active (running)` and show `cage -s -- systemd-cat --identifier=rust-photo-frame env RUST_LOG=info /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` in the command line. The journal should contain the photo frame application logs for the current boot. Once these checks pass, reboot the device to land directly in the fullscreen photo frame experience.
 
 ## Kiosk session reference
 
 When both setup stages complete successfully the Raspberry Pi is ready to boot directly into a kiosk session:
 
-- `/etc/greetd/config.toml` binds greetd to virtual terminal 1 and runs `cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` as the `kiosk` user. greetd creates the login session so `XDG_RUNTIME_DIR` points at `/run/user/<uid>` while `/var/lib/photo-frame` remains writable by the kiosk account.
+- `/etc/greetd/config.toml` binds greetd to virtual terminal 1 and runs `cage -s -- systemd-cat --identifier=rust-photo-frame env RUST_LOG=info /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` as the `kiosk` user. greetd creates the login session so `XDG_RUNTIME_DIR` points at `/run/user/<uid>` while `/var/lib/photo-frame` remains writable by the kiosk account.
 - Device access comes from the `kiosk` user belonging to the `render`, `video`, and `input` groups. The setup stage wires this up so Vulkan/GL stacks can open `/dev/dri/renderD128` without any extra udev hacks.
 - The kiosk stack relies on `greetd` + `cage`; no display-manager compatibility targets or tty autologin services are installed.
 

--- a/docs/sop.md
+++ b/docs/sop.md
@@ -1,0 +1,33 @@
+# Operations SOP
+
+This document captures routine operational procedures for the kiosk deployment.
+
+## Viewing runtime logs
+
+The kiosk session launches the photo frame through `cage` and pipes stdout/stderr into journald with `systemd-cat`. All runtime log lines carry the identifier `rust-photo-frame` and default to the `info` level.
+
+To follow the live log stream:
+
+```bash
+sudo journalctl -t rust-photo-frame -f
+```
+
+Use `Ctrl+C` to stop tailing.
+
+## Increasing log verbosity
+
+When additional detail is required, edit `/etc/greetd/config.toml` so the launch command exports a higher `RUST_LOG` level. For example, swap the default `RUST_LOG=info` for `RUST_LOG=debug`:
+
+```toml
+[default_session]
+command = "cage -s -- systemd-cat --identifier=rust-photo-frame env RUST_LOG=debug /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml"
+user = "kiosk"
+```
+
+Apply the change by restarting the kiosk session:
+
+```bash
+sudo systemctl restart greetd.service
+```
+
+Revert the command to `RUST_LOG=info` once troubleshooting is complete to reduce noise in the journal.

--- a/setup/README.md
+++ b/setup/README.md
@@ -15,7 +15,7 @@ The script performs the following actions:
 - verifies the OS is Raspberry Pi OS Trixie,
 - installs `greetd`, `cage`, `mesa-vulkan-drivers`, `vulkan-tools`, `wlr-randr`, and `wayland-protocols`,
 - ensures the `kiosk` user exists with `/usr/sbin/nologin` and belongs to the `render`, `video`, and `input` groups,
-- writes `/etc/greetd/config.toml` to launch `cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` on virtual terminal 1,
+- writes `/etc/greetd/config.toml` to launch `cage -s -- systemd-cat --identifier=rust-photo-frame env RUST_LOG=info /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` on virtual terminal 1,
 - disables conflicting display managers (`gdm3`, `sddm`, `lightdm`), enables `greetd.service` as the system `display-manager.service`, sets the default boot target to `graphical.target`, and masks `getty@tty1.service` to avoid VT races, and
 - deploys and enables the supporting `photoframe-*` helper units.
 

--- a/setup/diag-kiosk.sh
+++ b/setup/diag-kiosk.sh
@@ -62,7 +62,7 @@ check_greetd_config() {
         err 'config missing "vt = 1"'
     fi
 
-    if grep -Fxq 'command = "cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml"' "${config}"; then
+    if grep -Fxq 'command = "cage -s -- systemd-cat --identifier=rust-photo-frame env RUST_LOG=info /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml"' "${config}"; then
         ok 'command matches cage launch'
     else
         err 'config missing cage command'

--- a/setup/kiosk-trixie.sh
+++ b/setup/kiosk-trixie.sh
@@ -102,7 +102,7 @@ write_greetd_config() {
 vt = 1
 
 [default_session]
-command = "cage -s -- /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml"
+command = "cage -s -- systemd-cat --identifier=rust-photo-frame env RUST_LOG=info /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml"
 user = "kiosk"
 CONFIG
     chmod 0644 "${config_file}"


### PR DESCRIPTION
## Summary
- wrap the greetd session command in `systemd-cat` so kiosk logs land in journald with an explicit identifier
- update kiosk provisioning docs and diagnostics to reflect the new launch command
- add an operations SOP covering log collection and raising verbosity

## Testing
- not run (docs and configuration updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e1ea87e8ec8323a7a0176064993240