### PR TITLE
Document safe greetd restart procedure

### DIFF
--- a/developer/test-plan.md
+++ b/developer/test-plan.md
@@ -154,7 +154,9 @@ Exercise each axis at least once per release cycle.
   git fetch origin
   git checkout <release-tag>
   cargo build --release -p rust-photo-frame
-  sudo systemctl restart greetd.service
+  sudo systemctl stop greetd.service
+  sleep 1
+  sudo systemctl start greetd.service
   ```
 - [ ] Validate new version via `rust-photo-frame --version` in logs or manual run.
 - [ ] Rollback rehearsal: checkout previous known-good commit/tag, rebuild, restart service.
@@ -193,14 +195,14 @@ Exercise each axis at least once per release cycle.
 - **Bad config.yaml:**
   - [ ] Restore last-known-good from backup (`sudo cp /var/lib/photo-frame/config.yaml.bak /var/lib/photo-frame/config.yaml`).
   - [ ] Validate YAML syntax with `yamllint` (if installed) or `python3 -c "import yaml,sys; yaml.safe_load(open('/var/lib/photo-frame/config.yaml'))"`.
-  - [ ] Restart service: `sudo systemctl restart greetd.service`.
+  - [ ] Restart service: `sudo systemctl stop greetd.service && sleep 1 && sudo systemctl start greetd.service`.
 - **Broken service (fails to start):**
   - [ ] Inspect logs: `journalctl -u greetd.service -b` and `journalctl -u photoframe-wifi-manager.service -b`.
   - [ ] Rebuild binary: `cargo build --release -p rust-photo-frame`.
   - [ ] Validate unit file dependencies (Wayland, env vars) and run `sudo systemctl daemon-reload`.
 - **Failed update:**
   - [ ] `git checkout <previous-good>`.
-  - [ ] Rebuild + restart service (`sudo systemctl restart greetd.service`).
+  - [ ] Rebuild + restart service (`sudo systemctl stop greetd.service && sleep 1 && sudo systemctl start greetd.service`).
   - [ ] If binary corrupted, delete `target/` and rebuild.
 - **Network stuck offline:**
   - [ ] Verify Wi-Fi credentials (`nmcli connection show`).

--- a/docs/kiosk.md
+++ b/docs/kiosk.md
@@ -48,9 +48,12 @@ journalctl -u greetd -b
 
 ## Operations quick reference
 
-- Restart the kiosk session: `sudo systemctl restart greetd`.
+- Restart the kiosk session: `sudo systemctl stop greetd && sleep 1 && sudo systemctl start greetd`.
 - Tail runtime logs: `sudo journalctl -u greetd -f`.
 - Pause the slideshow: `sudo systemctl stop greetd` (resume with `start`).
 - Inspect display state: `wlr-randr` (installed by the kiosk setup script).
+
+`systemctl restart greetd` tends to relaunch the unit before logind releases tty1 and the DRM devices from the previous kiosk sess
+ion. Stopping, waiting a beat, and then starting avoids that race.
 
 No `display-manager.service`, login overrides, or tty autologin hacks are required—the greetd unit owns kiosk launch entirely.


### PR DESCRIPTION
## Summary
- document the stop/sleep/start sequence for restarting greetd to avoid logind timing races
- add operations SOP guidance on stopping, starting, and restarting the viewer
- update kiosk and test plan docs to use the new restart procedure

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e1f31487448323a6b049a9aa75211b