### PR TITLE
Preserve runtime config during setup reruns

### DIFF
--- a/setup/app/modules/30-install.sh
+++ b/setup/app/modules/30-install.sh
@@ -72,9 +72,13 @@ bootstrap_runtime() {
             run_sudo install -d -m 770 -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" "${path}"
         fi
     done
-    if [[ -f "${STAGE_DIR}/etc/config.yaml" && ! -f "${CONFIG_DEST}" ]]; then
-        run_sudo install -m 660 -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" "${STAGE_DIR}/etc/config.yaml" "${CONFIG_DEST}"
-        log INFO "Seeded default config at ${CONFIG_DEST}"
+    if [[ -f "${STAGE_DIR}/etc/config.yaml" ]]; then
+        if run_sudo test -f "${CONFIG_DEST}"; then
+            log INFO "Preserving existing runtime config at ${CONFIG_DEST}"
+        else
+            run_sudo install -m 660 -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" "${STAGE_DIR}/etc/config.yaml" "${CONFIG_DEST}"
+            log INFO "Seeded default config at ${CONFIG_DEST}"
+        fi
     fi
 }
 


### PR DESCRIPTION
## Summary
- teach the install module to check for the runtime config with sudo so we skip reseeding when it already exists
- continue seeding the staged config when the runtime file is missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2008daf84832383e0f02586b16b04