### PR TITLE
Refactor viewer sleep scheduling and state machine

### DIFF
--- a/crates/photo-frame/src/events.rs
+++ b/crates/photo-frame/src/events.rs
@@ -40,7 +40,15 @@ pub struct InvalidPhoto(pub PathBuf);
 #[derive(Debug)]
 pub struct Displayed(pub PathBuf);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SleepCommandSource {
+    Manual,
+    Schedule,
+}
+
 #[derive(Debug, Clone)]
 pub enum ViewerCommand {
     ToggleSleep,
+    GoToSleep(SleepCommandSource),
+    AwakeNow(SleepCommandSource),
 }


### PR DESCRIPTION
## Summary
- extend viewer commands to capture manual versus schedule sleep sources for downstream handling
- rework the viewer sleep controller and tick loop around explicit awake/sleep modes while honoring manual overrides
- add a background schedule driver and command fan-in so configuration wake/sleep transitions dispatch without blocking the UI thread

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e27c41c3048323a0b3f3f75c1904db