### PR TITLE
Reapply Raspberry Pi 4K boot tweaks during kiosk provisioning

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -14,6 +14,7 @@ The script performs the following actions:
 
 - verifies the OS is Raspberry Pi OS Trixie,
 - installs `greetd`, `cage`, `mesa-vulkan-drivers`, `vulkan-tools`, `wlr-randr`, and `wayland-protocols`,
+- programs the Raspberry Pi boot configuration for HDMI 4K60 output and enables the Pi 5 active cooling overlay (set `ENABLE_4K_BOOT=0` before running if you need different firmware settings),
 - ensures the `kiosk` user exists with `/usr/sbin/nologin` and belongs to the `render`, `video`, and `input` groups,
 - writes `/etc/greetd/config.toml` to launch `cage -s -- systemd-cat --identifier=rust-photo-frame env RUST_LOG=info /opt/photo-frame/bin/rust-photo-frame /var/lib/photo-frame/config/config.yaml` on virtual terminal 1,
 - disables conflicting display managers (`gdm3`, `sddm`, `lightdm`), enables `greetd.service` as the system `display-manager.service`, sets the default boot target to `graphical.target`, and masks `getty@tty1.service` to avoid VT races, and

--- a/setup/kiosk-trixie.sh
+++ b/setup/kiosk-trixie.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# shellcheck source=setup/lib/raspi_boot.sh
+. "${SCRIPT_DIR}/lib/raspi_boot.sh"
+
 log() {
     printf '[kiosk-setup] %s\n' "$*"
 }
@@ -161,6 +164,8 @@ main() {
     require_root "$@"
     require_trixie
     require_commands
+
+    ensure_boot_config_4k
 
     ensure_packages
     ensure_kiosk_user

--- a/setup/lib/raspi_boot.sh
+++ b/setup/lib/raspi_boot.sh
@@ -49,3 +49,109 @@ update_initramfs_if_available() {
         update-initramfs -u
     fi
 }
+
+ensure_boot_config_4k() {
+    local module="raspi_boot:4k" dry_run="${DRY_RUN:-0}" enable_4k="${ENABLE_4K_BOOT:-1}" config_path="${1:-}" backup_taken=0
+    local changes_needed=0 backup_path=""
+
+    if [[ "${enable_4k}" != "1" ]]; then
+        printf '[%s] INFO: 4K boot configuration disabled via ENABLE_4K_BOOT=%s. Skipping.\n' "${module}" "${enable_4k}"
+        return 0
+    fi
+
+    if [[ -z "${config_path}" ]]; then
+        if [[ -f /boot/firmware/config.txt ]]; then
+            config_path="/boot/firmware/config.txt"
+        elif [[ -f /boot/config.txt ]]; then
+            config_path="/boot/config.txt"
+        else
+            printf '[%s] WARN: Unable to locate config.txt (looked in /boot/firmware and /boot).\n' "${module}"
+            return 0
+        fi
+    fi
+
+    printf '[%s] INFO: Using configuration file %s\n' "${module}" "${config_path}"
+
+    declare -A settings=(
+        ["hdmi_force_hotplug:1"]="1"
+        ["hdmi_group:1"]="2"
+        ["hdmi_mode:1"]="97"
+        ["hdmi_drive:1"]="2"
+    )
+    local overlays=("pi5-fan,temp0=55000,level0=50,temp1=65000,level1=150,temp2=75000,level2=255")
+
+    local key value current overlay overlay_line
+    for key in "${!settings[@]}"; do
+        value="${settings[${key}]}"
+        current=$(sudo awk -F'=' -v key="${key}" '$1==key {print $2}' "${config_path}" 2>/dev/null || true)
+        if [[ "${current}" == "${value}" ]]; then
+            printf '[%s] INFO: %s already set to %s\n' "${module}" "${key}" "${value}"
+            continue
+        fi
+
+        changes_needed=1
+        if [[ "${dry_run}" == "1" ]]; then
+            if [[ -n "${current}" ]]; then
+                printf '[%s] INFO: DRY_RUN: would update %s=%s\n' "${module}" "${key}" "${value}"
+            else
+                printf '[%s] INFO: DRY_RUN: would append %s=%s\n' "${module}" "${key}" "${value}"
+            fi
+            continue
+        fi
+
+        if [[ ${backup_taken} -eq 0 ]]; then
+            backup_path="${config_path}.bak.$(date +%Y%m%d-%H%M%S)"
+            sudo cp -a "${config_path}" "${backup_path}"
+            printf '[%s] INFO: Backup written to %s\n' "${module}" "${backup_path}"
+            backup_taken=1
+        fi
+
+        if [[ -n "${current}" ]]; then
+            sudo sed -i "s|^${key}=.*$|${key}=${value}|" "${config_path}"
+        else
+            printf '\n%s=%s\n' "${key}" "${value}" | sudo tee -a "${config_path}" >/dev/null
+        fi
+        printf '[%s] INFO: Set %s=%s\n' "${module}" "${key}" "${value}"
+    done
+
+    for overlay in "${overlays[@]}"; do
+        overlay_line="dtoverlay=${overlay}"
+        if sudo grep -qxF "${overlay_line}" "${config_path}" 2>/dev/null; then
+            printf '[%s] INFO: %s already present\n' "${module}" "${overlay_line}"
+            continue
+        fi
+
+        changes_needed=1
+        if [[ "${dry_run}" == "1" ]]; then
+            printf '[%s] INFO: DRY_RUN: would append %s\n' "${module}" "${overlay_line}"
+            continue
+        fi
+
+        if [[ ${backup_taken} -eq 0 ]]; then
+            backup_path="${config_path}.bak.$(date +%Y%m%d-%H%M%S)"
+            sudo cp -a "${config_path}" "${backup_path}"
+            printf '[%s] INFO: Backup written to %s\n' "${module}" "${backup_path}"
+            backup_taken=1
+        fi
+
+        printf '\n%s\n' "${overlay_line}" | sudo tee -a "${config_path}" >/dev/null
+        printf '[%s] INFO: Added %s\n' "${module}" "${overlay_line}"
+    done
+
+    if [[ "${dry_run}" == "1" ]]; then
+        if [[ ${changes_needed} -eq 0 ]]; then
+            printf '[%s] INFO: DRY_RUN: configuration already matches requirements\n' "${module}"
+        else
+            printf '[%s] INFO: DRY_RUN: configuration changes summarized above\n' "${module}"
+        fi
+        return 0
+    fi
+
+    if [[ ${backup_taken} -eq 0 ]]; then
+        printf '[%s] INFO: Boot configuration already satisfied\n' "${module}"
+        return 0
+    fi
+
+    sudo sync
+    printf '[%s] INFO: 4K boot configuration ensured\n' "${module}"
+}


### PR DESCRIPTION
## Summary
- port the previous boot configuration enforcement into setup/lib/raspi_boot.sh and expose ensure_boot_config_4k
- source the helper from kiosk-trixie.sh so kiosk provisioning reapplies 4K HDMI and Pi 5 fan settings
- document the new behavior and how to disable it via ENABLE_4K_BOOT in setup/README.md

## Testing
- not run (bash scripts)


------
https://chatgpt.com/codex/tasks/task_e_68e320e6712083239052a38fa2297212