### PR TITLE
Handle request_adapter failure in viewer startup

### DIFF
--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -962,9 +962,9 @@ pub fn run_windowed(
                     compatible_surface: Some(&surface),
                     force_fallback_adapter: false,
                 })) {
-                    Some(adapter) => adapter,
-                    None => {
-                        warn!("failed to acquire GPU adapter; exiting viewer");
+                    Ok(adapter) => adapter,
+                    Err(err) => {
+                        warn!(error = %err, "failed to acquire GPU adapter; exiting viewer");
                         event_loop.exit();
                         return;
                     }


### PR DESCRIPTION
## Summary
- update the viewer startup flow to handle the Result returned by `request_adapter`

## Testing
- cargo check -p rust-photo-frame

------
https://chatgpt.com/codex/tasks/task_e_68e48a3efc908323bc965effbf8f0885