### PR TITLE
Add configurable sleep screen banner

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -49,6 +49,16 @@ greeting-screen:
     font: "#111827"
     accent: "#38bdf8"
 
+# Sleep screen displayed when the frame is entering sleep mode
+sleep-screen:
+  message: "Going to Sleep"
+  font: "Macondo"
+  stroke-width: 16
+  colors:
+    background: "#111827"
+    font: "#f8fafc"
+    accent: "#38bdf8"
+
 # Number of images to preload in the viewer (aligns with channel capacity)
 viewer-preload-count: 3
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,6 +141,19 @@ Use the quick reference below to locate the knobs you care about, then dive into
 - **Effect on behavior:** The renderer fits and centers the configured message inside a rounded double-line frame. `duration-seconds` guarantees the greeting remains on screen for at least that many seconds before the first photo appears, even when decoding finishes instantly.
 - **Notes:** Colors accept `#rgb`, `#rgba`, `#rrggbb`, or `#rrggbbaa` notation. Low-contrast combinations log a warning so you can tweak readability, and the viewer continues with sensible defaults if fonts or colors are omitted.
 
+### `sleep-screen`
+
+- **Purpose:** Styles the card shown as the frame transitions into sleep. Useful for confirming that the panel is intentionally dozing rather than frozen.
+- **Required?** Optional.
+- **Accepted values & defaults:** Mapping with optional keys
+  - `message` (string, default `Going to Sleep`),
+  - `font` (string font name; falls back to the bundled face when missing),
+  - `stroke-width` (float DIP, default `12.0`),
+  - `corner-radius` (float DIP, default `0.75 × stroke-width`),
+  - `colors.background`, `colors.font`, `colors.accent` (hex sRGB strings; default palette keeps high contrast).
+- **Effect on behavior:** Shares the same renderer as the greeting screen so your sleep banner uses identical sizing rules and readability checks. The message displays until the viewer fully enters sleep mode.
+- **Notes:** All fields mirror `greeting-screen` aside from the `duration-seconds` delay, which does not apply when sleeping.
+
 ### `sleep-mode`
 
 - **Purpose:** Defines when the frame should pause the slideshow, blank the screen to a dim level, and resume automatically.


### PR DESCRIPTION
## Summary
- introduce a reusable screen message configuration shared by greeting and sleep banners
- render the sleep banner with the shared renderer and configuration values instead of a hard-coded message
- document the new `sleep-screen` options and surface defaults in the sample configuration

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e50c0e82b08323a2adf4a8b661962a