### PR TITLE
Switch sleep toggle to Unix control socket

### DIFF
--- a/crates/buttond/Cargo.toml
+++ b/crates/buttond/Cargo.toml
@@ -13,4 +13,4 @@ clap = { version = "4.5.48", features = ["derive"] }
 evdev = "0.12.1"
 tracing-subscriber = { version = "0.3.20", features = ["fmt", "env-filter"] }
 tracing = "0.1.41"
-nix = { version = "0.29.0", default-features = false, features = ["signal", "fs"] }
+nix = { version = "0.29.0", default-features = false, features = ["fs"] }

--- a/crates/photo-frame/Cargo.toml
+++ b/crates/photo-frame/Cargo.toml
@@ -15,13 +15,14 @@ notify = "8.2.0"
 pollster = "0.4.0"
 rand = "0.9.2"
 serde = { version = "1.0.227", features = ["derive"] }
+serde_json = "1.0.132"
 serde_yaml = "0.9.34"
 humantime-serde = "1.1.1"
 humantime = "2.3.0"
 chrono = { version = "0.4.38", features = ["serde"] }
 chrono-tz = "0.8.6"
 crossbeam-channel = "0.5.15"
-tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "signal", "sync", "time"] }
+tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "net", "io-util"] }
 tokio-util = "0.7.16"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["fmt", "env-filter"] }

--- a/developer/test-plan.md
+++ b/developer/test-plan.md
@@ -107,7 +107,7 @@ Exercise each axis at least once per release cycle.
   ```sh
   sudo evtest    # inspect for gpio-keys or power-button device
   ```
-- [ ] Short press → expect app sleep toggle (log should show SIGUSR1 or equivalent).
+- [ ] Short press → expect app sleep toggle (log should show control socket command).
 - [ ] Double-click → expect clean shutdown (`shutdown -h now` path confirmed in journal).
 - [ ] Long press → document expected behavior (hard-off). **Do not perform if risk of corruption.**
 - [ ] Evidence:
@@ -184,7 +184,7 @@ Exercise each axis at least once per release cycle.
 - [ ] Cold boot to slideshow ready in ≤ 45 seconds after login prompt appears.
 - [ ] Display locked to desired mode (4K@60 preferred) with no sustained tearing.
 - [ ] Button behaviors (short press sleep toggle, double-click shutdown) reliable.
-- [ ] Sleep schedule respects configured windows and reacts to manual SIGUSR1 trigger.
+- [ ] Sleep schedule respects configured windows and reacts to manual ToggleSleep command via control socket.
 - [ ] Wi-Fi provisioning, outage resilience, and watcher recovery all succeed without slideshow halt.
 - [ ] Library playback smooth for medium set (≤5% CPU spikes >150% overall, no OOM/IO errors).
 - [ ] Updates deploy cleanly and rollback path verified.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,7 +155,7 @@ Use the quick reference below to locate the knobs you care about, then dive into
   - `backlight-path` plus the required `sleep-value`/`wake-value` strings to write to a backlight sysfs node (intended for DSI panels or laptop-class devices). HDMI monitors typically do **not** expose `/sys/class/backlight` entries.
   - `sleep-command` and/or `wake-command` shell snippets that run when the frame transitions into or out of sleep. The defaults issue Wayland DPMS requests via `wlr-randr --output @OUTPUT@ --off|--on` with a fallback to `vcgencmd display_power 0|1`. The `@OUTPUT@` placeholder is replaced at runtime with the first connected output reported by `wlr-randr`, or `HDMI-A-1` if auto-detection fails.
 - **Effect on behavior:** Outside the configured "on" window the viewer stops advancing slides, cancels any in-flight transitions, and clears the surface to the dim color. When the schedule says to wake up, the currently loaded image is shown again and normal dwell/transition pacing resumes. The schedule is evaluated using the configured timezone on a wall-clock basis; DST transitions do not cause drift.
-- **Manual override:** Sending `SIGUSR1` to the process toggles the current state immediately—handy for a single-button GPIO input. Each press flips sleep ↔ wake regardless of the schedule. The next scheduled boundary still wins: hitting `on-hours.start` forces wake, `on-hours.end` forces sleep, and either transition clears any active manual override. Environment helpers `PHOTO_FRAME_SLEEP_OVERRIDE=sleep|wake` or `PHOTO_FRAME_SLEEP_OVERRIDE_FILE=/path/to/state` can seed the initial state at startup, but upcoming schedule boundaries will still apply. Overrides are logged with timestamps and the schedule timeline continues to update in the background.
+- **Manual override:** Writing a JSON command such as `{"command":"ToggleSleep"}` to the control socket (`/run/photo-frame/control.sock`) toggles the current state immediately—handy for a single-button GPIO input. Each press flips sleep ↔ wake regardless of the schedule. The next scheduled boundary still wins: hitting `on-hours.start` forces wake, `on-hours.end` forces sleep, and either transition clears any active manual override. Environment helpers `PHOTO_FRAME_SLEEP_OVERRIDE=sleep|wake` or `PHOTO_FRAME_SLEEP_OVERRIDE_FILE=/path/to/state` can seed the initial state at startup, but upcoming schedule boundaries will still apply. Overrides are logged with timestamps and the schedule timeline continues to update in the background.
 - **CLI helpers:**
   - `--verbose-sleep` logs the parsed schedule and the next 24 hours of transitions during startup.
   - `--sleep-test <SECONDS>` forces the configured display-power commands to sleep, waits `SECONDS`, wakes the panel (retrying once after two seconds), and exits.
@@ -201,12 +201,11 @@ The setup pipeline installs `/opt/photo-frame/bin/powerctl`, a thin wrapper arou
   --single-window-ms 250 \
   --double-window-ms 400 \
   --debounce-ms 20 \
-  --pidfile /run/photo-app.pid \
-  --procname rust-photo-frame \
+  --control-socket /run/photo-frame/control.sock \
   --shutdown /opt/photo-frame/bin/photo-safe-shutdown
 ```
 
-- **Short press:** sends `SIGUSR1` to the running app (using the pidfile when present, otherwise `pkill -USR1 -f rust-photo-frame`).
+- **Short press:** writes `{ "command": "ToggleSleep" }` to `/run/photo-frame/control.sock`.
 - **Double press:** runs `/opt/photo-frame/bin/photo-safe-shutdown`, which wraps `shutdown -h now`.
 - **Long press:** bypassed so the Pi firmware can force power-off.
 - **System integration:** The provisioning script also installs a `systemd-logind` drop-in that sets `HandlePowerKey=ignore` so the desktop stack never interprets the press as a global poweroff request; only the daemon reacts to the event.

--- a/docs/power-and-sleep.md
+++ b/docs/power-and-sleep.md
@@ -22,13 +22,13 @@ This guide focuses on powering down HDMI monitors from the Raspberry Pi 5 runnin
        sleep-command: "wlr-randr --output @OUTPUT@ --off || vcgencmd display_power 0"
        wake-command: "wlr-randr --output @OUTPUT@ --on  || vcgencmd display_power 1"
    ```
-4. Start the service. The frame wakes the moment `on-hours.start` arrives and sleeps when `on-hours.end` hits, even if a manual override was active. Pressing `SIGUSR1` (or a mapped GPIO button) still flips sleep ↔ wake immediately; the next boundary restores the scheduled state. Run a quick validation with `rust-photo-frame config.yaml --sleep-test 10`.
+4. Start the service. The frame wakes the moment `on-hours.start` arrives and sleeps when `on-hours.end` hits, even if a manual override was active. Writing `{ "command": "ToggleSleep" }` to `/run/photo-frame/control.sock` (or pressing a mapped GPIO button) still flips sleep ↔ wake immediately; the next boundary restores the scheduled state. Run a quick validation with `rust-photo-frame config.yaml --sleep-test 10`.
 
 ## Configuration essentials
 
 The `sleep-mode` block accepts wrap-past-midnight windows, per-day overrides, and optional display-power commands. Times are interpreted using the configured `timezone`; when a field omits a zone the top-level `sleep.timezone` applies. Day overrides take precedence over weekend/weekday overrides, which in turn override the default `on-hours` window.
 
-Manual overrides can be triggered by sending `SIGUSR1` to the process. Each press flips the current state (wake ↔ sleep) immediately, regardless of the schedule. Upcoming boundaries still win: `on-hours.start` forces wake, `on-hours.end` forces sleep, and either transition clears any active override. Overrides can also be seeded at startup by setting `PHOTO_FRAME_SLEEP_OVERRIDE=sleep|wake` or pointing `PHOTO_FRAME_SLEEP_OVERRIDE_FILE` at a file containing `sleep` or `wake`.
+Manual overrides can be triggered by writing `{ "command": "ToggleSleep" }` to `/run/photo-frame/control.sock`. Each press flips the current state (wake ↔ sleep) immediately, regardless of the schedule. Upcoming boundaries still win: `on-hours.start` forces wake, `on-hours.end` forces sleep, and either transition clears any active override. Overrides can also be seeded at startup by setting `PHOTO_FRAME_SLEEP_OVERRIDE=sleep|wake` or pointing `PHOTO_FRAME_SLEEP_OVERRIDE_FILE` at a file containing `sleep` or `wake`.
 
 The default `display-power` commands issue Wayland DPMS requests via:
 ```
@@ -83,6 +83,6 @@ powerctl wake HDMI-A-1 # override the connector
 
 ## Additional tips
 
-- Wrap long-running GPIO button handlers with a debouncer before sending `SIGUSR1` to avoid accidental double toggles.
+- Wrap long-running GPIO button handlers with a debouncer before writing to the control socket to avoid accidental double toggles.
 - When experimenting interactively, run the viewer with `--verbose-sleep` so you can see upcoming transitions and the detected output name in the logs.
 - Store custom power scripts alongside `powerctl` in `/opt/photo-frame/bin` and reference them via absolute paths inside `sleep-mode.display-power`.


### PR DESCRIPTION
## Summary
- replace the SIGUSR1 handler in the viewer with a UNIX domain control socket that accepts JSON commands and cleans up the socket path on shutdown
- update the photo-button daemon to write ToggleSleep commands to the control socket and make the socket path configurable
- refresh documentation, the smoke test helper, and the QA checklist to describe the new control flow

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e50d3428c083238e13655071af8e89