### PR TITLE
Add viewer state control commands

### DIFF
--- a/crates/photo-frame/src/events.rs
+++ b/crates/photo-frame/src/events.rs
@@ -1,6 +1,12 @@
 use std::path::PathBuf;
 use std::time::SystemTime;
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ViewerState {
+    Asleep,
+    Awake,
+}
+
 #[derive(Debug)]
 pub enum InventoryEvent {
     PhotoAdded(PhotoInfo),
@@ -40,7 +46,8 @@ pub struct InvalidPhoto(pub PathBuf);
 #[derive(Debug)]
 pub struct Displayed(pub PathBuf);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ViewerCommand {
-    ToggleSleep,
+    SetState(ViewerState),
+    ToggleState,
 }

--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -2,7 +2,7 @@ use crate::config::{
     MattingConfig, MattingMode, MattingOptions, TransitionConfig, TransitionKind, TransitionMode,
     TransitionOptions,
 };
-use crate::events::{Displayed, PhotoLoaded, PreparedImageCpu, ViewerCommand};
+use crate::events::{Displayed, PhotoLoaded, PreparedImageCpu, ViewerCommand, ViewerState};
 use crate::processing::blur::apply_blur;
 use crate::processing::color::average_color;
 use crate::processing::layout::center_offset;
@@ -715,7 +715,9 @@ pub fn run_windowed(
 
         fn handle_control_command(&mut self, cmd: ViewerCommand) {
             match cmd {
-                ViewerCommand::ToggleSleep => match self.power_state {
+                ViewerCommand::SetState(ViewerState::Awake) => self.exit_sleep(),
+                ViewerCommand::SetState(ViewerState::Asleep) => self.enter_sleep(),
+                ViewerCommand::ToggleState => match self.power_state {
                     PowerState::Awake => self.enter_sleep(),
                     PowerState::Sleeping => self.exit_sleep(),
                 },


### PR DESCRIPTION
## Summary
- introduce a `ViewerState` enum and update viewer commands to support state setting and toggling
- extend the control socket handler to accept toggle/set state requests
- teach the viewer task to react to the new command variants

## Testing
- cargo check


------
https://chatgpt.com/codex/tasks/task_e_68e520b94ea8832383221f5a1ae1f240