### PR TITLE
Enforce canonical control socket payloads

### DIFF
--- a/crates/buttond/src/main.rs
+++ b/crates/buttond/src/main.rs
@@ -372,9 +372,9 @@ impl ButtonTracker {
 fn perform_action(action: Action, args: &Args) {
     match action {
         Action::Single => {
-            info!("single press → ToggleState command");
+            info!("single press → toggle-state command");
             if let Err(err) = trigger_single(args) {
-                error!(?err, "failed to send ToggleState command");
+                error!(?err, "failed to send toggle-state command");
             }
         }
         Action::Double => {
@@ -395,8 +395,8 @@ fn trigger_single(args: &Args) -> Result<()> {
     })?;
 
     stream
-        .write_all(br#"{"command":"ToggleState"}"#)
-        .context("failed to send ToggleState command")?;
+        .write_all(br#"{"command":"toggle-state"}"#)
+        .context("failed to send toggle-state command")?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- enforce the `toggle-state`/`set-state` command names on the control socket and derive the control state parser
- refresh control socket tests to only accept canonical payloads
- update the button daemon to send the canonical toggle command

## Testing
- cargo test -p rust-photo-frame

------
https://chatgpt.com/codex/tasks/task_e_68e52db56f7483239fc83f8b7b246a99