### PR TITLE
Document photo library cloud/local layout

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,10 @@
 # Example configuration for rust-photo-frame
 # Adjust values to match your hardware, library layout, and visual preferences.
 
-# Root directory for images (scanned recursively)
+# Root directory for images. Keep media in the managed subdirectories to
+# separate synced libraries from ad-hoc drops:
+#   cloud/ — populated by rclone or other sync jobs; safe to wipe/reseed.
+#   local/ — manual imports (USB, scp) that should persist across syncs.
 photo-library-path: /var/lib/photo-frame/photos
 
 # Render/transition settings

--- a/developer/fake-btime.sh
+++ b/developer/fake-btime.sh
@@ -11,7 +11,7 @@
 #
 # Example
 #   find ~/photo-library-test -regex ".*\(jpeg\|png\)" \
-#   -exec bash -c 'tools/fake-btime.sh "$1" "/var/lib/photo-frame/photos/$(basename "$1")" "2020-01-01 12:00:00"' _ {} \;
+#   -exec bash -c 'tools/fake-btime.sh "$1" "/var/lib/photo-frame/photos/local/$(basename "$1")" "2020-01-01 12:00:00"' _ {} \;
 
 set -euo pipefail
 

--- a/developer/test-plan.md
+++ b/developer/test-plan.md
@@ -61,6 +61,8 @@ Exercise each axis at least once per release cycle.
 - [ ] Customize the writable config at `/var/lib/photo-frame/config.yaml`. Minimal example:
   ```yaml
   photo-library-path: /var/lib/photo-frame/photos
+  # ├── cloud/  # sync target (rclone, Nextcloud, etc.)
+  # └── local/  # manual USB/SSH drops kept outside sync
   greeting-screen:
     message: "Welcome home!"
     font: "Macondo"
@@ -73,7 +75,7 @@ Exercise each axis at least once per release cycle.
       sleep-command: "wlr-randr --output @OUTPUT@ --off || vcgencmd display_power 0"
       wake-command: "wlr-randr --output @OUTPUT@ --on  || vcgencmd display_power 1"
   ```
-- [ ] Populate `/var/lib/photo-frame/photos` (or configured library path) according to the test matrix scenario.
+- [ ] Populate `/var/lib/photo-frame/photos/cloud` via your sync pipeline for mirrored libraries and `/var/lib/photo-frame/photos/local` for ad-hoc media (or the equivalent subdirectories under the configured library path) according to the test matrix scenario.
 
 ## Phase 3 – Kiosk Autostart & Services
 - [ ] Confirm the setup script enabled expected units:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,8 @@ The example below targets a Pi driving a 4K portrait display backed by a NAS-mou
 
 ```yaml
 photo-library-path: /var/lib/photo-frame/photos
+# ├── cloud/  # managed by sync jobs; safe to resync or replace wholesale
+# └── local/  # manual drops (USB, scp) that should survive sync resets
 
 # Render/transition settings
 transition:
@@ -45,7 +47,7 @@ matting:
       backend: neon
 ```
 
-If the frame launches to a black screen, double-check that `photo-library-path` points to a directory the runtime can read and that the user account has permission to access mounted network shares. You can validate a YAML edit quickly with `cargo run -p rust-photo-frame -- --playlist-dry-run 1`, which parses the config without opening the render window.
+If the frame launches to a black screen, double-check that `photo-library-path` points to a directory the runtime can read and that the user account has permission to access mounted network shares. The directory should contain `cloud` and `local` subdirectories—the runtime merges both so that cloud syncs can refresh `cloud/` while USB or ad-hoc transfers live under `local/`. You can validate a YAML edit quickly with `cargo run -p rust-photo-frame -- --playlist-dry-run 1`, which parses the config without opening the render window.
 
 ## Top-level keys
 
@@ -67,9 +69,9 @@ Use the quick reference below to locate the knobs you care about, then dive into
 
 - **Purpose:** Sets the root directory that will be scanned recursively for supported photo formats.
 - **Required?** Yes. Leave it unset and the application has no images to display.
-- **Accepted values & defaults:** Any absolute or relative filesystem path. The setup pipeline provisions `/var/lib/photo-frame/photos` and points the default configuration there so both the runtime and any cloud sync job start from a known location.
+- **Accepted values & defaults:** Any absolute or relative filesystem path. The setup pipeline provisions `/var/lib/photo-frame/photos` with `cloud/` and `local/` subdirectories and points the default configuration there so both the runtime and any cloud sync job start from a known location.
 - **Effect on behavior:** Switching the path changes the library the watcher monitors; the viewer reloads the playlist when the directory contents change.
-- **Notes:** After the installer seeds `/var/lib/photo-frame/config.yaml`, edit that writable copy to move the library elsewhere (for example, to an attached drive or network share) if you do not want to keep photos under `/var/lib/photo-frame/photos`.
+- **Notes:** Keep the `cloud/` and `local/` folders under the configured root so the runtime can merge them. Use `cloud/` for content that will be overwritten by sync jobs (e.g., rclone, Nextcloud), and reserve `local/` for manual imports you do not want the sync job to prune. After the installer seeds `/var/lib/photo-frame/config.yaml`, edit that writable copy to move the library elsewhere (for example, to an attached drive or network share) if you do not want to keep photos under `/var/lib/photo-frame/photos`.
 
 ### `transition`
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -62,6 +62,7 @@ The app stage compiles the workspace, stages binaries and documentation under `s
 - Inspect the running session: `sudo systemctl status greetd`
 - Restart helpers: `sudo systemctl restart photoframe-wifi-manager.service`
 - Tail kiosk logs: `sudo journalctl -u greetd -f`
-- Upload new media: copy into `/var/lib/photo-frame/photos`
+- Upload new media: copy manual additions into `/var/lib/photo-frame/photos/local`.
+- Configure sync tooling (e.g., rclone) to manage `/var/lib/photo-frame/photos/cloud` when mirroring from remote storage.
 
 The kiosk account is unprivileged; use the `frame` operator account (see `docs/configuration.md`) for maintenance commands.


### PR DESCRIPTION
## Summary
- describe the expected `cloud`/`local` subdirectories under `photo-library-path` in the sample config and configuration guide
- update setup and developer documentation, including the test plan and helper script examples, to reference the split library layout

## Testing
- not run (docs-only)


------
https://chatgpt.com/codex/tasks/task_e_68e533c24e208323bc81931facc35b53