### PR TITLE
Reorganize kiosk setup scripts for consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: diag-kiosk
+.PHONY: kiosk-diagnostics diag-kiosk
 
-diag-kiosk:
-	@./setup/diag-kiosk.sh
+kiosk-diagnostics:
+@./setup/kiosk/diagnostics.sh
+
+diag-kiosk: kiosk-diagnostics

--- a/assets/systemd/photoframe-buttond.service
+++ b/assets/systemd/photoframe-buttond.service
@@ -1,4 +1,4 @@
-# Managed by setup/kiosk-trixie.sh
+# Managed by setup/kiosk/provision-trixie.sh
 [Unit]
 Description=Photo Frame Power Button Monitor
 After=multi-user.target

--- a/assets/systemd/photoframe-sync.service
+++ b/assets/systemd/photoframe-sync.service
@@ -1,4 +1,4 @@
-# Managed by setup/kiosk-trixie.sh
+# Managed by setup/kiosk/provision-trixie.sh
 [Unit]
 Description=Photo Frame Library Sync
 After=network-online.target

--- a/assets/systemd/photoframe-sync.timer
+++ b/assets/systemd/photoframe-sync.timer
@@ -1,4 +1,4 @@
-# Managed by setup/kiosk-trixie.sh
+# Managed by setup/kiosk/provision-trixie.sh
 [Unit]
 Description=Run Photo Frame Library Sync hourly
 

--- a/assets/systemd/photoframe-wifi-manager.service
+++ b/assets/systemd/photoframe-wifi-manager.service
@@ -1,4 +1,4 @@
-# Managed by setup/kiosk-trixie.sh
+# Managed by setup/kiosk/provision-trixie.sh
 [Unit]
 Description=Photo Frame Wi-Fi Manager
 After=network-online.target

--- a/developer/test-plan.md
+++ b/developer/test-plan.md
@@ -49,7 +49,7 @@ Exercise each axis at least once per release cycle.
   ```
 - [ ] Run the kiosk bootstrapper (installs greetd/cage, creates the kiosk user, installs helper units, and enables greetd on tty1):
   ```sh
-  sudo ./setup/kiosk-trixie.sh
+  sudo ./setup/kiosk/provision-trixie.sh
   ```
   Note: reconnect your SSH session afterwards so refreshed group memberships apply.
 - [ ] After reconnecting, rerun the repo checkout if necessary and execute the app deploy stage (build + install + systemd wiring). Expect 5–7 minutes for the release build on a Pi 5 with active cooling:

--- a/docs/kiosk.md
+++ b/docs/kiosk.md
@@ -7,7 +7,7 @@ The photo frame boots straight into the Wayland app using a greetd-managed sessi
 Run the kiosk installer on a fresh Debian 13 (or Raspberry Pi OS trixie) image:
 
 ```bash
-sudo ./setup/kiosk-trixie.sh
+sudo ./setup/kiosk/provision-trixie.sh
 ```
 
 The script performs the following actions:

--- a/docs/software.md
+++ b/docs/software.md
@@ -134,7 +134,7 @@ Use the following environment variables to customize an installation:
 ### 3. Provision the kiosk session
 
 ```bash
-sudo ./setup/kiosk-trixie.sh
+sudo ./setup/kiosk/provision-trixie.sh
 ```
 
 Run the greetd installer with root privileges. The script:

--- a/docs/wifi-manager.md
+++ b/docs/wifi-manager.md
@@ -90,12 +90,12 @@ All mutable state lives under `/var/lib/photo-frame` and is owned by the `photo-
 
 The Wi-Fi manager is wired into the refreshed setup pipeline:
 
-- `setup/kiosk-trixie.sh` provisions the kiosk user, installs the Cage session units, and enables seat management.
+- `setup/kiosk/provision-trixie.sh` provisions the kiosk user, installs the Cage session units, and enables seat management.
 - `setup/packages/install-apt-packages.sh` pulls in NetworkManager, Cage, GPU drivers, and build prerequisites.
 - `setup/app/modules/10-build.sh` compiles `wifi-manager` in release mode as the invoking user (never root).
 - `setup/app/modules/20-stage.sh` stages the binary, config template, wordlist, and docs.
 - `setup/app/modules/30-install.sh` installs artifacts into `/opt/photo-frame` and seeds `/var/lib/photo-frame/config/config.yaml` if missing.
-- `setup/kiosk-trixie.sh` installs and enables `/etc/systemd/system/photoframe-wifi-manager.service` alongside the other kiosk units.
+- `setup/kiosk/provision-trixie.sh` installs and enables `/etc/systemd/system/photoframe-wifi-manager.service` alongside the other kiosk units.
 
 Re-running the scripts is idempotent: binaries are replaced in place, configs are preserved, ACLs stay intact, and systemd units reload cleanly.
 

--- a/scripts/legacy_sweep/all-files.txt
+++ b/scripts/legacy_sweep/all-files.txt
@@ -37,8 +37,8 @@ maker/cleat-spacers.scad
 maker/cleat-spacers.stl
 maker/maker.md
 setup-AUDIT-RESULTS.md
-setup/diag-kiosk.sh
-setup/kiosk-trixie.sh
+setup/kiosk/diagnostics.sh
+setup/kiosk/provision-trixie.sh
 setup/README.md
 setup/app/modules/10-build.sh
 setup/app/modules/20-stage.sh

--- a/setup/README.md
+++ b/setup/README.md
@@ -7,7 +7,7 @@ This directory houses idempotent provisioning scripts for Raspberry Pi photo fra
 Provision a Raspberry Pi OS Trixie kiosk with the greetd + cage workflow:
 
 ```bash
-sudo ./setup/kiosk-trixie.sh
+sudo ./setup/kiosk/provision-trixie.sh
 ```
 
 The script performs the following actions:
@@ -21,6 +21,16 @@ The script performs the following actions:
 - deploys and enables the supporting `photoframe-*` helper units.
 
 Re-run the script after OS updates to reapply package dependencies or repair systemd state; it is safe and idempotent.
+
+## Diagnose kiosk health
+
+Inspect the greetd session, kiosk user, and display-manager wiring:
+
+```bash
+sudo ./setup/kiosk/diagnostics.sh
+```
+
+Run this from the device when display login fails or the kiosk session will not start; it flags missing packages, disabled units, and other common misconfigurations.
 
 ## Replace the legacy swapfile with zram
 

--- a/setup/app/modules/50-postcheck.sh
+++ b/setup/app/modules/50-postcheck.sh
@@ -125,7 +125,7 @@ if command -v systemctl >/dev/null 2>&1; then
         fi
     }
 
-    kiosk_hint="run setup/kiosk-trixie.sh to provision kiosk services"
+    kiosk_hint="run setup/kiosk/provision-trixie.sh to provision kiosk services"
 
     check_service "${KIOSK_SERVICE}" "ERROR" "${kiosk_hint}"
     check_enabled "${KIOSK_SERVICE}" "${kiosk_hint}"

--- a/setup/kiosk/diagnostics.sh
+++ b/setup/kiosk/diagnostics.sh
@@ -8,20 +8,20 @@ fi
 FAIL=0
 
 title() {
-    printf '[diag-kiosk] %s\n' "$1"
+    printf '[kiosk-diagnostics] %s\n' "$1"
 }
 
 ok() {
-    printf '[diag-kiosk] OK: %s\n' "$1"
+    printf '[kiosk-diagnostics] OK: %s\n' "$1"
 }
 
 err() {
-    printf '[diag-kiosk] ERROR: %s\n' "$1" >&2
+    printf '[kiosk-diagnostics] ERROR: %s\n' "$1" >&2
     FAIL=1
 }
 
 warn() {
-    printf '[diag-kiosk] WARN: %s\n' "$1"
+    printf '[kiosk-diagnostics] WARN: %s\n' "$1"
 }
 
 check_greetd_unit() {

--- a/setup/kiosk/provision-trixie.sh
+++ b/setup/kiosk/provision-trixie.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 # shellcheck source=setup/lib/raspi_boot.sh
-. "${SCRIPT_DIR}/lib/raspi_boot.sh"
+. "${SCRIPT_DIR}/../lib/raspi_boot.sh"
 
 log() {
     printf '[kiosk-setup] %s\n' "$*"


### PR DESCRIPTION
## Summary
- move the kiosk provisioning and diagnostic scripts under setup/kiosk/ and rename them for clarity
- update documentation, helper messaging, and systemd unit headers to reference the new script paths
- add a kiosk diagnostics make target while keeping the legacy alias for compatibility

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e53378b6f88323bba7c250dd437d03