### PR TITLE
Add configurable awake schedule

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -62,6 +62,22 @@ sleep-screen:
     font: "#f8fafc"
     accent: "#38bdf8"
 
+# Optional awake schedule (viewer sleeps outside these intervals)
+awake-schedule:
+  timezone: "America/New_York"
+  awake-scheduled:
+    daily:
+      - ["07:15", "22:00"]
+    weekdays:
+      - ["06:45", "23:00"]
+    weekend:
+      - ["07:15", "12:00"]
+      - ["15:00", "23:30"]
+    friday: []
+    saturday:
+      - ["08:00", "12:00"]
+      - ["16:00", "23:00"]
+
 # Number of images to preload in the viewer (aligns with channel capacity)
 viewer-preload-count: 3
 

--- a/crates/photo-frame/Cargo.toml
+++ b/crates/photo-frame/Cargo.toml
@@ -20,7 +20,7 @@ serde_yaml = "0.9.34"
 humantime-serde = "1.1.1"
 humantime = "2.3.0"
 chrono = { version = "0.4.38", features = ["serde"] }
-chrono-tz = "0.8.6"
+chrono-tz = { version = "0.8.6", features = ["serde"] }
 crossbeam-channel = "0.5.15"
 tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "net", "io-util"] }
 tokio-util = "0.7.16"

--- a/crates/photo-frame/src/main.rs
+++ b/crates/photo-frame/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod events;
 mod processing;
+mod schedule;
 mod tasks {
     pub mod files;
     pub mod greeting_screen;
@@ -139,6 +140,16 @@ async fn main() -> Result<()> {
         tokio::spawn(async move {
             if let Err(err) = run_control_socket(cancel, control).await {
                 tracing::warn!("control socket failed: {err}");
+            }
+        });
+    }
+
+    if let Some(schedule_cfg) = cfg.awake_schedule.clone() {
+        let cancel = cancel.clone();
+        let control = viewer_control_tx.clone();
+        tokio::spawn(async move {
+            if let Err(err) = schedule::run(schedule_cfg, cancel, control).await {
+                tracing::warn!("awake schedule task failed: {err:?}");
             }
         });
     }

--- a/crates/photo-frame/src/schedule.rs
+++ b/crates/photo-frame/src/schedule.rs
@@ -1,0 +1,95 @@
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info};
+
+use crate::config::AwakeScheduleConfig;
+use crate::events::{ViewerCommand, ViewerState};
+
+pub async fn run(
+    schedule: AwakeScheduleConfig,
+    cancel: CancellationToken,
+    control: mpsc::Sender<ViewerCommand>,
+) -> Result<()> {
+    let tz = schedule.timezone();
+    let mut last_state: Option<bool> = None;
+
+    loop {
+        let now_local = Utc::now().with_timezone(&tz);
+        let awake_now = schedule.is_awake_at(now_local);
+        if last_state != Some(awake_now) {
+            let state = if awake_now {
+                ViewerState::Awake
+            } else {
+                ViewerState::Asleep
+            };
+            info!(
+                %now_local,
+                state = ?state,
+                "schedule enforcing viewer state"
+            );
+            control
+                .send(ViewerCommand::SetState(state))
+                .await
+                .context("failed to send scheduled viewer command")?;
+            last_state = Some(awake_now);
+        }
+
+        let Some((transition_at, awake_after)) = schedule.next_transition_after(now_local) else {
+            tokio::select! {
+                _ = cancel.cancelled() => break,
+                _ = tokio::time::sleep(Duration::from_secs(60)) => continue,
+            };
+        };
+
+        let desired_state = if awake_after {
+            ViewerState::Awake
+        } else {
+            ViewerState::Asleep
+        };
+        let now_utc = now_local.with_timezone(&Utc);
+        let transition_utc = transition_at.with_timezone(&Utc);
+        let delta = transition_utc.signed_duration_since(now_utc);
+        let wait = match delta.to_std() {
+            Ok(duration) => duration,
+            Err(_) => Duration::from_secs(0),
+        };
+
+        if wait.is_zero() {
+            debug!(
+                %transition_at,
+                state = ?desired_state,
+                "schedule executing immediate transition"
+            );
+            control
+                .send(ViewerCommand::SetState(desired_state))
+                .await
+                .context("failed to send scheduled viewer command")?;
+            last_state = Some(awake_after);
+            continue;
+        }
+
+        debug!(
+            %transition_at,
+            state = ?desired_state,
+            wait_secs = wait.as_secs_f64(),
+            "schedule awaiting transition"
+        );
+
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            _ = tokio::time::sleep(wait) => {
+                control
+                    .send(ViewerCommand::SetState(desired_state))
+                    .await
+                    .context("failed to send scheduled viewer command")?;
+                last_state = Some(awake_after);
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add an `awake-schedule` section to the configuration with timezone-aware daily and per-day intervals
- drive a new schedule task that toggles the viewer state according to the configured awake windows
- cover schedule parsing and daylight-saving behaviour with targeted unit tests

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e595f07f3c8323af0682776822d524