### PR TITLE
Make control socket path configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,9 @@
 #   local/ — manual imports (USB, scp) that should persist across syncs.
 photo-library-path: /var/lib/photo-frame/photos
 
+# Unix domain socket path for runtime control commands
+control-socket-path: /run/photo-frame/control.sock
+
 # Render/transition settings
 transition:
   # List one or more transition kinds to rotate between.


### PR DESCRIPTION
## Summary
- add a `control-socket-path` configuration field with a default matching the legacy location
- use the configured socket path at runtime and emit clearer diagnostics when directory creation fails
- document the new option and surface it in the sample `config.yaml`

## Testing
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68e59cb686788323b1167114a7dbb410