### PR TITLE
Enable persistent journald storage during kiosk provisioning

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -20,7 +20,8 @@ The script performs the following actions:
 - creates `/run/photo-frame` with mode `0770`, ownership `kiosk:kiosk`, and drops an `/etc/tmpfiles.d/photo-frame.conf` entry so the control socket directory is recreated on boot,
 - writes `/etc/greetd/config.toml` to launch `cage -s -- /usr/local/bin/photoframe-session` on virtual terminal 1,
 - disables conflicting display managers (`gdm3`, `sddm`, `lightdm`), enables `greetd.service` as the system `display-manager.service`, sets the default boot target to `graphical.target`, and masks `getty@tty1.service` to avoid VT races, and
-- deploys and enables the supporting `photoframe-*` helper units.
+- deploys and enables the supporting `photoframe-*` helper units, and
+- enables persistent systemd journaling with a 200 MB cap for `/var/log/journal` to preserve kiosk diagnostics across reboots.
 
 Re-run the script after OS updates to reapply package dependencies or repair systemd state; it is safe and idempotent.
 


### PR DESCRIPTION
## Summary
- ensure the kiosk provisioning script enables persistent systemd-journald storage capped at 200 MB
- document the new journaling behavior in the setup README so operators know the logs persist across boots

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5b0ffaab88323bf19df7add7ff811