### PR TITLE
Fix greeting screen staging belt recall ordering

### DIFF
--- a/crates/photo-frame/src/tasks/greeting_screen.rs
+++ b/crates/photo-frame/src/tasks/greeting_screen.rs
@@ -168,8 +168,6 @@ impl GreetingScreen {
                 }
             }
         };
-        self.staging_belt.recall();
-
         let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: Some("greeting-frame"),
             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
@@ -206,6 +204,10 @@ impl GreetingScreen {
             warn!(error = %err, "greeting_screen_draw_failed");
         }
         self.staging_belt.finish();
+    }
+
+    pub fn after_submit(&mut self) {
+        self.staging_belt.recall();
     }
 
     pub fn screen_message(

--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -1324,6 +1324,7 @@ pub fn run_windowed(
                         }
                         gpu.queue.submit(Some(encoder.finish()));
                         frame.present();
+                        gpu.greeting.after_submit();
                         return;
                     }
 
@@ -1337,6 +1338,7 @@ pub fn run_windowed(
                         );
                         gpu.queue.submit(Some(encoder.finish()));
                         frame.present();
+                        gpu.greeting.after_submit();
                         return;
                     }
                     let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {


### PR DESCRIPTION
## Summary
- stop returning staging buffers to the belt at the start of greeting screen renders
- add an explicit `after_submit` hook that is invoked once the frame is submitted so glyph uploads are not reused too early

## Testing
- cargo check -p rust-photo-frame

------
https://chatgpt.com/codex/tasks/task_e_68e5b1b70c08832384fc2c70affaed7e