### PR TITLE
Persist bad PSK credentials in developer Wi-Fi scripts

### DIFF
--- a/developer/suspend-wifi.sh
+++ b/developer/suspend-wifi.sh
@@ -36,8 +36,9 @@ fi
 
 SSID=$(nmcli -g 802-11-wireless.ssid connection show "$ACTIVE_CONN")
 sudo nmcli connection delete "$BAD_NAME" >/dev/null 2>&1 || true
-sudo nmcli connection add type wifi ifname "$IFACE" con-name "$BAD_NAME" ssid "$SSID" \
-  wifi-sec.key-mgmt wpa-psk wifi-sec.psk "$BAD_PSK" >/dev/null
+sudo nmcli connection add type wifi ifname "$IFACE" con-name "$BAD_NAME" ssid "$SSID" >/dev/null
+sudo nmcli connection modify "$BAD_NAME" wifi-sec.key-mgmt wpa-psk
+sudo nmcli connection modify "$BAD_NAME" wifi-sec.psk "$BAD_PSK"
 echo "Created '$BAD_NAME' for SSID '$SSID' with bad PSK"
 
 sudo nmcli connection down "$ACTIVE_CONN" || true

--- a/developer/test-bad-psk.sh
+++ b/developer/test-bad-psk.sh
@@ -58,8 +58,9 @@ fi
 
 SSID=$(nmcli -g 802-11-wireless.ssid connection show "$ACTIVE_CONN")
 nmcli connection delete "$BAD_NAME" >/dev/null 2>&1 || true
-nmcli connection add type wifi ifname "$IFACE" con-name "$BAD_NAME" ssid "$SSID" \
-  wifi-sec.key-mgmt wpa-psk wifi-sec.psk "$BAD_PSK" >/dev/null
+nmcli connection add type wifi ifname "$IFACE" con-name "$BAD_NAME" ssid "$SSID" >/dev/null
+nmcli connection modify "$BAD_NAME" wifi-sec.key-mgmt wpa-psk
+nmcli connection modify "$BAD_NAME" wifi-sec.psk "$BAD_PSK"
 log "Created '$BAD_NAME' for SSID '$SSID' with bad PSK"
 
 nmcli connection down "$ACTIVE_CONN" || true


### PR DESCRIPTION
## Summary
- ensure `developer/test-bad-psk.sh` writes the incorrect PSK to disk using `nmcli connection modify`
- mirror the explicit `nmcli connection modify` calls in `developer/suspend-wifi.sh`

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5b805dc548323a7aa49680dc974f7