### PR TITLE
Refactor setup scripts to share systemd helpers

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -70,6 +70,24 @@ Build and install release artifacts from an unprivileged shell:
 
 The app stage compiles the workspace, stages binaries and documentation under `setup/app/build/stage`, ensures the kiosk service user exists, and installs the artifacts into `/opt/photo-frame`.
 
+## systemd helper library
+
+Provisioning and diagnostics scripts reuse a shared wrapper library at `setup/lib/systemd.sh`. Source it from modules using the canonical pattern:
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/systemd.sh
+source "${SCRIPT_DIR}/../lib/systemd.sh"
+```
+
+The library exposes helpers to keep systemd orchestration consistent:
+
+- `systemd_available` – detect whether `systemctl` can be used without aborting the caller.
+- `systemd_daemon_reload`, `systemd_enable_unit`, `systemd_start_unit`, `systemd_restart_unit`, `systemd_stop_unit` – manage unit lifecycle.
+- `systemd_enable_now_unit`, `systemd_disable_unit`, `systemd_disable_now_unit`, `systemd_mask_unit`, `systemd_unmask_unit`, `systemd_set_default_target` – configure unit state and boot targets.
+- `systemd_unit_exists`, `systemd_is_active`, `systemd_is_enabled`, `systemd_status`, `systemd_unit_property` – inspect unit presence and health.
+- `systemd_install_unit_file`, `systemd_install_dropin`, `systemd_remove_dropins` – install or prune unit definitions and drop-ins.
+
 ## Operator quick reference
 
 - Inspect the running session: `sudo systemctl status greetd`

--- a/setup/lib/systemd.sh
+++ b/setup/lib/systemd.sh
@@ -10,8 +10,19 @@ if [[ -z "${SYSTEMDCTL:-}" ]]; then
 fi
 SYSTEMD_DIR=${SYSTEMD_DIR:-/etc/systemd/system}
 
+systemd_available() {
+    if [[ -x "${SYSTEMDCTL}" ]]; then
+        return 0
+    fi
+    if command -v systemctl >/dev/null 2>&1; then
+        SYSTEMDCTL="$(command -v systemctl)"
+        return 0
+    fi
+    return 1
+}
+
 _systemd_require() {
-    if [[ ! -x "${SYSTEMDCTL}" ]]; then
+    if ! systemd_available; then
         echo "systemctl not found at ${SYSTEMDCTL}" >&2
         exit 1
     fi
@@ -54,6 +65,60 @@ systemd_start_unit() {
     _systemd_require
     local unit="$1"
     "${SYSTEMDCTL}" start "${unit}"
+}
+
+systemd_enable_now_unit() {
+    _systemd_require
+    local unit="$1"
+    "${SYSTEMDCTL}" enable --now "${unit}"
+}
+
+systemd_disable_now_unit() {
+    _systemd_require
+    local unit="$1"
+    "${SYSTEMDCTL}" disable --now "${unit}"
+}
+
+systemd_is_active() {
+    _systemd_require
+    local unit="$1"
+    "${SYSTEMDCTL}" is-active --quiet "${unit}"
+}
+
+systemd_is_enabled() {
+    _systemd_require
+    local unit="$1"
+    "${SYSTEMDCTL}" is-enabled --quiet "${unit}"
+}
+
+systemd_status() {
+    _systemd_require
+    local unit="$1"
+    "${SYSTEMDCTL}" status "${unit}" --no-pager
+}
+
+systemd_set_default_target() {
+    _systemd_require
+    local target="$1"
+    "${SYSTEMDCTL}" set-default "${target}"
+}
+
+systemd_mask_unit() {
+    _systemd_require
+    local unit="$1"
+    "${SYSTEMDCTL}" mask "${unit}"
+}
+
+systemd_unmask_unit() {
+    _systemd_require
+    local unit="$1"
+    "${SYSTEMDCTL}" unmask "${unit}"
+}
+
+systemd_unit_property() {
+    _systemd_require
+    local unit="$1" property="$2"
+    "${SYSTEMDCTL}" show -p "${property}" --value "${unit}"
 }
 
 systemd_unit_exists() {


### PR DESCRIPTION
## Summary
- add shared wrappers for common systemd operations and expose an availability check
- update provisioning and postcheck scripts to source the shared helpers via a canonical pattern
- document the systemd helper library so future modules reuse the same interface

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5d624ee0083238912773635fb3fb5