### PR TITLE
Guard viewer event loop logging behind debug level check

### DIFF
--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -21,7 +21,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::time::{MissedTickBehavior, interval};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{Level, debug, info, warn};
 
 //
 // Viewer state machine overview
@@ -701,6 +701,9 @@ pub fn run_windowed(
         }
 
         fn log_event_loop_state(&self, context: &str) {
+            if !tracing::level_enabled!(Level::DEBUG) {
+                return;
+            }
             let now = Instant::now();
             let current_path = self
                 .current


### PR DESCRIPTION
## Summary
- guard viewer log_event_loop_state so debug instrumentation only runs when the debug level is enabled

## Testing
- `cargo fmt`


------
https://chatgpt.com/codex/tasks/task_e_68e5e6c3b4408323a23f555d838ebc7b