### PR TITLE
Avoid blank sleep overlay when layout is not ready

### DIFF
--- a/crates/photo-frame/src/gpu/debug_overlay.rs
+++ b/crates/photo-frame/src/gpu/debug_overlay.rs
@@ -1,5 +1,6 @@
 //! Minimal overlay helpers for isolating clear/draw paths during debugging.
 
+#[allow(dead_code)]
 /// Clears the target view with `clear_color` and optionally executes `draw_fn`
 /// inside the render pass. The helper makes it easy to rule out pipeline state
 /// issues by swapping the closure for a no-op draw.

--- a/crates/photo-frame/src/tasks/greeting_screen.rs
+++ b/crates/photo-frame/src/tasks/greeting_screen.rs
@@ -153,9 +153,13 @@ impl GreetingScreen {
         }
     }
 
-    pub fn render(&mut self, encoder: &mut wgpu::CommandEncoder, target_view: &wgpu::TextureView) {
+    pub fn render(
+        &mut self,
+        encoder: &mut wgpu::CommandEncoder,
+        target_view: &wgpu::TextureView,
+    ) -> bool {
         if self.size.width == 0 || self.size.height == 0 {
-            return;
+            return false;
         }
         let layout = match self.layout {
             Some(layout) => layout,
@@ -163,7 +167,7 @@ impl GreetingScreen {
                 self.update_text_layout();
                 match self.layout {
                     Some(layout) => layout,
-                    None => return,
+                    None => return false,
                 }
             }
         };
@@ -203,6 +207,7 @@ impl GreetingScreen {
             warn!(error = %err, "greeting_screen_draw_failed");
         }
         self.staging_belt.finish();
+        true
     }
 
     pub fn after_submit(&mut self) {
@@ -214,9 +219,20 @@ impl GreetingScreen {
         screen: &ScreenMessageConfig,
         encoder: &mut wgpu::CommandEncoder,
         target_view: &wgpu::TextureView,
-    ) {
+    ) -> bool {
         self.update_screen(screen);
-        self.render(encoder, target_view);
+        self.render(encoder, target_view)
+    }
+
+    /// Ensure layout information is available for the current window size.
+    pub fn ensure_layout_ready(&mut self) -> bool {
+        if self.size.width == 0 || self.size.height == 0 {
+            return false;
+        }
+        if self.layout.is_none() {
+            self.update_text_layout();
+        }
+        self.layout.is_some()
     }
 
     fn ensure_font_loaded(&mut self) {


### PR DESCRIPTION
## Summary
- guard sleep/greeting redraws until the greeting screen has a usable layout
- make the greeting screen renderer report whether it produced commands and expose a helper to ensure layout readiness
- leave the debug overlay helper available while suppressing dead code warnings

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e65433c3f0832398c91ef80ad279f4