### PR TITLE
Fix greeting screen background during text layout preparation

### DIFF
--- a/crates/photo-frame/src/tasks/greeting_screen.rs
+++ b/crates/photo-frame/src/tasks/greeting_screen.rs
@@ -103,11 +103,12 @@ impl GreetingScreen {
         }
 
         let has_text = !self.message.trim().is_empty();
-        if has_text && !self.update_layout_if_needed() {
-            return false;
+        let mut text_ready = true;
+        if has_text {
+            text_ready = self.update_layout_if_needed();
         }
 
-        if has_text {
+        if has_text && text_ready {
             self.viewport.update(
                 &self.queue,
                 Resolution {
@@ -159,7 +160,7 @@ impl GreetingScreen {
                 timestamp_writes: None,
             });
 
-            if has_text {
+            if has_text && text_ready {
                 if let Err(err) = self
                     .text_renderer
                     .render(&self.atlas, &self.viewport, &mut pass)
@@ -169,11 +170,11 @@ impl GreetingScreen {
             }
         }
 
-        if has_text {
+        if has_text && text_ready {
             self.atlas.trim();
         }
 
-        true
+        if has_text { text_ready } else { true }
     }
 
     pub fn after_submit(&mut self) {


### PR DESCRIPTION
## Summary
- guard greeting screen rendering so the background always clears even if the text layout is still being prepared
- delay text rendering until layout data is ready while keeping another redraw scheduled

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e8606dd49083239bd702259199897d