### PR TITLE
Use palette for greeting screen colors

### DIFF
--- a/crates/photo-frame/Cargo.toml
+++ b/crates/photo-frame/Cargo.toml
@@ -32,6 +32,7 @@ winit = "0.30.12"
 glyphon = "0.9.0"
 fontdb = "0.16.2"
 lyon = "1.0.1"
+palette = "0.7.6"
 
 [dev-dependencies]
 tempfile = "3.23.0"


### PR DESCRIPTION
## Summary
- add the `palette` crate to handle greeting screen color parsing and conversions
- update `GreetingScreen` to build its message and colors at construction and drop runtime config updates
- replace the bespoke hex/linear color helpers with palette-powered utilities

## Testing
- cargo fmt
- cargo check -p rust-photo-frame

------
https://chatgpt.com/codex/tasks/task_e_68e86cba8e988323a0f10e767a8c62b3