### PR TITLE
Hide cursor in viewer window

### DIFF
--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -100,6 +100,7 @@ impl ViewerApp {
         let attrs = WindowAttributes::default().with_title("Rust Photo Frame");
         match event_loop.create_window(attrs) {
             Ok(window) => {
+                window.set_cursor_visible(false);
                 let window = Arc::new(window);
                 self.window = Some(window.clone());
                 Some(window)

--- a/docs/kiosk.md
+++ b/docs/kiosk.md
@@ -45,7 +45,7 @@ systemctl status display-manager
 journalctl -u greetd -b
 ```
 
-`systemctl status greetd` should show the unit as `active (running)` with `/usr/bin/cage -s -- /usr/local/bin/photoframe-session` in the command line. The journal contains both greetd session logs and the photo frame application output.
+`systemctl status greetd` should show the unit as `active (running)` with `/usr/bin/cage -s -- /usr/local/bin/photoframe-session` in the command line. The journal contains both greetd session logs and the photo frame application output. Note that `cage -s` merely forces every surface to match the output resolution; it does **not** touch pointer visibility. Hiding the cursor is entirely the application's responsibility (for example via `Window::set_cursor_visible(false)` in the Winit window handler), so the mouse pointer can remain visible on the greeting screen until we implement that in the renderer.
 
 ## Operations quick reference
 


### PR DESCRIPTION
## Summary
- hide the system cursor when the Winit viewer window is created so the pointer does not appear on the greeting screen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e87050906c8323bceaa41914273323