### PR TITLE
Fix greeting screen rendering and layout

### DIFF
--- a/crates/photo-frame/src/tasks/greeting_screen.rs
+++ b/crates/photo-frame/src/tasks/greeting_screen.rs
@@ -1,14 +1,23 @@
+use std::num::NonZeroU64;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use bytemuck::{Pod, Zeroable};
 use fontdb::{Database, Family, Query};
 use glyphon::cosmic_text::Align;
 use glyphon::{
     Attrs, Buffer, Cache, Color, FamilyOwned, FontSystem, Metrics, Resolution, Shaping, SwashCache,
     TextArea, TextAtlas, TextBounds, TextRenderer, Viewport, Wrap,
 };
+use lyon::math::{Box2D, point};
+use lyon::path::{Path, Winding, builder::BorderRadii};
+use lyon::tessellation::{
+    BuffersBuilder, LineCap, LineJoin, StrokeOptions, StrokeTessellator, StrokeVertex,
+    StrokeVertexConstructor, TessellationError, VertexBuffers,
+};
 use palette::{LinSrgba, Srgb, Srgba};
 use tracing::warn;
+use wgpu::util::DeviceExt;
 use winit::dpi::PhysicalSize;
 
 use crate::config::ScreenMessageConfig;
@@ -18,8 +27,8 @@ use crate::config::ScreenMessageConfig;
 pub struct GreetingScreen {
     device: wgpu::Device,
     queue: wgpu::Queue,
-    format: wgpu::TextureFormat,
-    cache: Cache,
+    _format: wgpu::TextureFormat,
+    _cache: Cache,
     viewport: Viewport,
     atlas: TextAtlas,
     text_renderer: TextRenderer,
@@ -30,9 +39,47 @@ pub struct GreetingScreen {
     message: String,
     background: LinSrgba<f32>,
     font_colour: LinSrgba<f32>,
+    accent_colour: LinSrgba<f32>,
+    stroke_width_dip: f32,
+    corner_radius_dip: f32,
     size: PhysicalSize<u32>,
+    scale_factor: f64,
     text_origin: (f32, f32),
+    frame_pipeline: wgpu::RenderPipeline,
+    frame_bind_group: wgpu::BindGroup,
+    frame_uniform_buffer: wgpu::Buffer,
+    frame_vertex_buffer: wgpu::Buffer,
+    frame_index_buffer: wgpu::Buffer,
+    frame_index_count: u32,
 }
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct FrameVertex {
+    position: [f32; 2],
+}
+
+struct FrameVertexCtor;
+
+impl StrokeVertexConstructor<FrameVertex> for FrameVertexCtor {
+    fn new_vertex(&mut self, vertex: StrokeVertex) -> FrameVertex {
+        let pos = vertex.position();
+        FrameVertex {
+            position: [pos.x, pos.y],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct FrameUniforms {
+    color: [f32; 4],
+    screen_size: [f32; 2],
+    _pad: [f32; 2],
+}
+
+const MIN_FRAME_PADDING_DIP: f32 = 48.0;
+const FRAME_GAP_MULTIPLIER: f32 = 0.5;
 
 impl GreetingScreen {
     pub fn new(
@@ -58,12 +105,106 @@ impl GreetingScreen {
         let message = screen.message_or_default().into_owned();
         let background = resolve_background_colour(screen.colors.background.as_deref());
         let font_colour = resolve_font_colour(screen.colors.font.as_deref());
+        let accent_colour = resolve_accent_colour(screen.colors.accent.as_deref());
+        let stroke_width_dip = screen.effective_stroke_width_dip();
+        let corner_radius_dip = screen.effective_corner_radius_dip(stroke_width_dip);
+
+        let frame_uniforms = FrameUniforms {
+            color: to_linear_array(accent_colour),
+            screen_size: [1.0, 1.0],
+            _pad: [0.0; 2],
+        };
+        let frame_uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("greeting-frame-uniforms"),
+            contents: bytemuck::bytes_of(&frame_uniforms),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        let frame_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("greeting-frame-shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/greeting_frame.wgsl").into()),
+        });
+        let frame_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("greeting-frame-bind-group-layout"),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: NonZeroU64::new(
+                            std::mem::size_of::<FrameUniforms>() as u64
+                        ),
+                    },
+                    count: None,
+                }],
+            });
+        let frame_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("greeting-frame-pipeline-layout"),
+                bind_group_layouts: &[&frame_bind_group_layout],
+                push_constant_ranges: &[],
+            });
+        let frame_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("greeting-frame-pipeline"),
+            layout: Some(&frame_pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &frame_shader,
+                entry_point: Some("vs_main"),
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<FrameVertex>() as u64,
+                    step_mode: wgpu::VertexStepMode::Vertex,
+                    attributes: &[wgpu::VertexAttribute {
+                        format: wgpu::VertexFormat::Float32x2,
+                        offset: 0,
+                        shader_location: 0,
+                    }],
+                }],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &frame_shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+        let frame_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("greeting-frame-bind-group"),
+            layout: &frame_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: frame_uniform_buffer.as_entire_binding(),
+            }],
+        });
+        let frame_vertex_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("greeting-frame-vertices"),
+            size: 1,
+            usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let frame_index_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("greeting-frame-indices"),
+            size: 2,
+            usage: wgpu::BufferUsages::INDEX | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
 
         let instance = GreetingScreen {
             device: device.clone(),
             queue: queue.clone(),
-            format,
-            cache,
+            _format: format,
+            _cache: cache,
             viewport,
             atlas,
             text_renderer,
@@ -74,14 +215,26 @@ impl GreetingScreen {
             message,
             background,
             font_colour,
+            accent_colour,
+            stroke_width_dip,
+            corner_radius_dip,
             size: PhysicalSize::new(0, 0),
+            scale_factor: 1.0,
             text_origin: (0.0, 0.0),
+            frame_pipeline,
+            frame_bind_group,
+            frame_uniform_buffer,
+            frame_vertex_buffer,
+            frame_index_buffer,
+            frame_index_count: 0,
         };
         instance
     }
 
-    pub fn resize(&mut self, new_size: PhysicalSize<u32>, _scale_factor: f64) {
+    pub fn resize(&mut self, new_size: PhysicalSize<u32>, scale_factor: f64) {
         self.size = new_size;
+        self.scale_factor = scale_factor;
+        self.write_frame_uniforms();
     }
 
     pub fn render(
@@ -92,66 +245,75 @@ impl GreetingScreen {
         if self.size.width == 0 || self.size.height == 0 {
             return false;
         }
-            self.viewport.update(
-                &self.queue,
-                Resolution {
-                    width: self.size.width,
-                    height: self.size.height,
+
+        self.viewport.update(
+            &self.queue,
+            Resolution {
+                width: self.size.width,
+                height: self.size.height,
+            },
+        );
+
+        let text_color = to_text_color(self.font_colour);
+        if let Err(err) = self.text_renderer.prepare(
+            &self.device,
+            &self.queue,
+            &mut self.font_system,
+            &mut self.atlas,
+            &self.viewport,
+            [TextArea {
+                buffer: &self.text_buffer,
+                left: self.text_origin.0,
+                top: self.text_origin.1,
+                scale: 1.0,
+                bounds: TextBounds {
+                    left: 0,
+                    top: 0,
+                    right: self.size.width as i32,
+                    bottom: self.size.height as i32,
                 },
-            );
-
-            let text_color = to_text_color(self.font_colour);
-            if let Err(err) = self.text_renderer.prepare(
-                &self.device,
-                &self.queue,
-                &mut self.font_system,
-                &mut self.atlas,
-                &self.viewport,
-                [TextArea {
-                    buffer: &self.text_buffer,
-                    left: self.text_origin.0,
-                    top: self.text_origin.1,
-                    scale: 1.0,
-                    bounds: TextBounds {
-                        left: 0,
-                        top: 0,
-                        right: self.size.width as i32,
-                        bottom: self.size.height as i32,
-                    },
-                    default_color: text_color,
-                    custom_glyphs: &[],
-                }],
-                &mut self.swash_cache,
-            ) {
-                warn!(error = %err, "greeting_screen_prepare_failed");
-            }
-
-        {
-            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("greeting-background"),
-                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: target_view,
-                    resolve_target: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(to_wgpu_color(self.background)),
-                        store: wgpu::StoreOp::Store,
-                    },
-                })],
-                depth_stencil_attachment: None,
-                occlusion_query_set: None,
-                timestamp_writes: None,
-            });
-
-                if let Err(err) = self
-                    .text_renderer
-                    .render(&self.atlas, &self.viewport, &mut pass)
-                {
-                    warn!(error = %err, "greeting_screen_draw_failed");
-                }
+                default_color: text_color,
+                custom_glyphs: &[],
+            }],
+            &mut self.swash_cache,
+        ) {
+            warn!(error = %err, "greeting_screen_prepare_failed");
         }
 
-            self.atlas.trim();
-            true
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("greeting-background"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target_view,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(to_wgpu_color(self.background)),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            occlusion_query_set: None,
+            timestamp_writes: None,
+        });
+
+        if self.frame_index_count > 0 {
+            pass.set_pipeline(&self.frame_pipeline);
+            pass.set_bind_group(0, &self.frame_bind_group, &[]);
+            pass.set_vertex_buffer(0, self.frame_vertex_buffer.slice(..));
+            pass.set_index_buffer(self.frame_index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+            pass.draw_indexed(0..self.frame_index_count, 0, 0..1);
+        }
+
+        if let Err(err) = self
+            .text_renderer
+            .render(&self.atlas, &self.viewport, &mut pass)
+        {
+            warn!(error = %err, "greeting_screen_draw_failed");
+        }
+
+        drop(pass);
+
+        self.atlas.trim();
+        true
     }
 
     pub fn after_submit(&mut self) {
@@ -184,6 +346,115 @@ impl GreetingScreen {
             .shape_until_scroll(&mut self.font_system, false);
 
         self.text_origin = compute_text_origin(&self.text_buffer, self.size);
+        self.rebuild_frame_geometry()
+    }
+
+    fn write_frame_uniforms(&mut self) {
+        let uniforms = FrameUniforms {
+            color: to_linear_array(self.accent_colour),
+            screen_size: [
+                self.size.width.max(1) as f32,
+                self.size.height.max(1) as f32,
+            ],
+            _pad: [0.0; 2],
+        };
+        self.queue
+            .write_buffer(&self.frame_uniform_buffer, 0, bytemuck::bytes_of(&uniforms));
+    }
+
+    fn rebuild_frame_geometry(&mut self) -> bool {
+        if self.size.width == 0 || self.size.height == 0 {
+            self.frame_index_count = 0;
+            return false;
+        }
+
+        let mut geometry = VertexBuffers::<FrameVertex, u16>::new();
+        let stroke_px = (self.stroke_width_dip * self.scale_factor as f32).max(0.5);
+        let padding_px = (MIN_FRAME_PADDING_DIP * self.scale_factor as f32).max(stroke_px * 2.0);
+        let gap_px = (stroke_px * FRAME_GAP_MULTIPLIER).max(4.0 * self.scale_factor as f32);
+        let corner_radius_px = (self.corner_radius_dip * self.scale_factor as f32).max(0.0);
+
+        let layout_bounds = compute_text_bounds(&self.text_buffer, self.text_origin);
+        let (frame_width, frame_height) = if let Some(bounds) = layout_bounds {
+            let width = (bounds.right - bounds.left).max(1.0) + padding_px * 2.0;
+            let height = (bounds.bottom - bounds.top).max(stroke_px) + padding_px * 2.0;
+            (width, height)
+        } else {
+            let width = (self.size.width as f32 * 0.6).max(padding_px * 2.0 + stroke_px);
+            let height = (self.size.height as f32 * 0.25).max(padding_px * 2.0 + stroke_px);
+            (width, height)
+        };
+
+        let max_width = self.size.width as f32;
+        let max_height = self.size.height as f32;
+        let frame_width = frame_width.min(max_width);
+        let frame_height = frame_height.min(max_height);
+
+        let center_x = max_width * 0.5;
+        let center_y = max_height * 0.5;
+        let left = (center_x - frame_width * 0.5).clamp(0.0, (max_width - frame_width).max(0.0));
+        let top = (center_y - frame_height * 0.5).clamp(0.0, (max_height - frame_height).max(0.0));
+
+        let outer_rect = Box2D::new(
+            point(left, top),
+            point(left + frame_width, top + frame_height),
+        );
+        let outer_radius = corner_radius_px + stroke_px * 0.5;
+        let mut tessellator = StrokeTessellator::new();
+        if let Err(err) = tessellate_rounded_rect(
+            &mut tessellator,
+            outer_rect,
+            outer_radius,
+            stroke_px,
+            &mut geometry,
+        ) {
+            warn!(error = %err, "greeting_screen_outer_frame_tessellation_failed");
+            self.frame_index_count = 0;
+            return false;
+        }
+
+        let inner_offset = stroke_px + gap_px;
+        if frame_width > inner_offset * 2.0 && frame_height > inner_offset * 2.0 {
+            let inner_rect = Box2D::new(
+                point(left + inner_offset, top + inner_offset),
+                point(
+                    left + frame_width - inner_offset,
+                    top + frame_height - inner_offset,
+                ),
+            );
+            let inner_radius = (corner_radius_px - gap_px * 0.5).max(0.0);
+            if let Err(err) = tessellate_rounded_rect(
+                &mut tessellator,
+                inner_rect,
+                inner_radius,
+                stroke_px,
+                &mut geometry,
+            ) {
+                warn!(error = %err, "greeting_screen_inner_frame_tessellation_failed");
+            }
+        }
+
+        if geometry.indices.is_empty() || geometry.vertices.is_empty() {
+            self.frame_index_count = 0;
+            return true;
+        }
+
+        self.frame_index_count = geometry.indices.len() as u32;
+        self.frame_vertex_buffer =
+            self.device
+                .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("greeting-frame-vertices"),
+                    contents: bytemuck::cast_slice(&geometry.vertices),
+                    usage: wgpu::BufferUsages::VERTEX,
+                });
+        self.frame_index_buffer =
+            self.device
+                .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("greeting-frame-indices"),
+                    contents: bytemuck::cast_slice(&geometry.indices),
+                    usage: wgpu::BufferUsages::INDEX,
+                });
+
         true
     }
 }
@@ -217,6 +488,12 @@ fn resolve_font_colour(source: Option<&str>) -> LinSrgba<f32> {
     source
         .and_then(parse_hex_color)
         .unwrap_or_else(default_font_colour)
+}
+
+fn resolve_accent_colour(source: Option<&str>) -> LinSrgba<f32> {
+    source
+        .and_then(parse_hex_color)
+        .unwrap_or_else(default_accent_colour)
 }
 
 fn initialize_font_database(db: &mut Database) {
@@ -288,6 +565,92 @@ fn to_text_color(color: LinSrgba<f32>) -> Color {
     Color::rgba(srgb_u8.red, srgb_u8.green, srgb_u8.blue, srgb_u8.alpha)
 }
 
+fn to_linear_array(color: LinSrgba<f32>) -> [f32; 4] {
+    [color.red, color.green, color.blue, color.alpha]
+}
+
+#[derive(Clone, Copy)]
+struct LayoutBounds {
+    left: f32,
+    right: f32,
+    top: f32,
+    bottom: f32,
+}
+
+fn compute_text_bounds(buffer: &Buffer, origin: (f32, f32)) -> Option<LayoutBounds> {
+    let mut bounds = LayoutBounds {
+        left: f32::MAX,
+        right: f32::MIN,
+        top: f32::MAX,
+        bottom: f32::MIN,
+    };
+    let mut has_runs = false;
+
+    for run in buffer.layout_runs() {
+        has_runs = true;
+
+        let mut run_min_x = f32::MAX;
+        let mut run_max_x = f32::MIN;
+        for glyph in run.glyphs.iter() {
+            run_min_x = run_min_x.min(glyph.x);
+            run_max_x = run_max_x.max(glyph.x + glyph.w);
+        }
+
+        if run_min_x.is_finite() && run_max_x.is_finite() {
+            bounds.left = bounds.left.min(run_min_x + origin.0);
+            bounds.right = bounds.right.max(run_max_x + origin.0);
+        }
+
+        let line_top = run.line_top + origin.1;
+        let line_bottom = line_top + run.line_height;
+        bounds.top = bounds.top.min(line_top);
+        bounds.bottom = bounds.bottom.max(line_bottom);
+    }
+
+    if has_runs {
+        if !bounds.left.is_finite() || !bounds.right.is_finite() {
+            bounds.left = 0.0;
+            bounds.right = 0.0;
+        }
+        Some(bounds)
+    } else {
+        None
+    }
+}
+
+fn tessellate_rounded_rect(
+    tessellator: &mut StrokeTessellator,
+    rect: Box2D,
+    radius: f32,
+    stroke_width: f32,
+    geometry: &mut VertexBuffers<FrameVertex, u16>,
+) -> Result<(), TessellationError> {
+    let width = rect.width().abs();
+    let height = rect.height().abs();
+
+    if width <= 0.0 || height <= 0.0 || stroke_width <= 0.0 {
+        return Ok(());
+    }
+
+    let max_radius = 0.5 * width.min(height);
+    let clamped_radius = radius.clamp(0.0, max_radius);
+
+    let mut builder = Path::builder();
+    builder.add_rounded_rectangle(&rect, &BorderRadii::new(clamped_radius), Winding::Positive);
+    let path = builder.build();
+
+    let options = StrokeOptions::default()
+        .with_line_width(stroke_width)
+        .with_line_join(LineJoin::Round)
+        .with_line_cap(LineCap::Round);
+
+    tessellator.tessellate_path(
+        &path,
+        &options,
+        &mut BuffersBuilder::new(geometry, FrameVertexCtor),
+    )
+}
+
 fn parse_hex_color(input: &str) -> Option<LinSrgba<f32>> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
@@ -320,4 +683,8 @@ fn default_background() -> LinSrgba<f32> {
 
 fn default_font_colour() -> LinSrgba<f32> {
     parse_hex_color("#F8FAFC").unwrap()
+}
+
+fn default_accent_colour() -> LinSrgba<f32> {
+    parse_hex_color("#38BDF8").unwrap()
 }

--- a/crates/photo-frame/src/tasks/shaders/greeting_frame.wgsl
+++ b/crates/photo-frame/src/tasks/shaders/greeting_frame.wgsl
@@ -1,0 +1,29 @@
+struct FrameUniforms {
+  color: vec4<f32>;
+  screen_size: vec2<f32>;
+  _pad: vec2<f32>;
+};
+
+@group(0) @binding(0)
+var<uniform> U: FrameUniforms;
+
+struct VSOut {
+  @builtin(position) pos: vec4<f32>;
+};
+
+@vertex
+fn vs_main(@location(0) position: vec2<f32>) -> VSOut {
+  let size = max(U.screen_size, vec2<f32>(1.0, 1.0));
+  let ndc = vec2<f32>(
+    position.x / size.x * 2.0 - 1.0,
+    1.0 - position.y / size.y * 2.0,
+  );
+  var out: VSOut;
+  out.pos = vec4<f32>(ndc, 0.0, 1.0);
+  return out;
+}
+
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+  return U.color;
+}

--- a/crates/photo-frame/src/tasks/viewer/scenes/asleep.rs
+++ b/crates/photo-frame/src/tasks/viewer/scenes/asleep.rs
@@ -42,6 +42,7 @@ impl Scene for AsleepScene {
         scale_factor: f64,
     ) {
         self.resize(new_size, scale_factor);
+        let _ = self.screen.update_layout();
     }
 
     fn render(&mut self, ctx: &mut RenderCtx<'_, '_>) -> RenderResult {

--- a/crates/photo-frame/src/tasks/viewer/scenes/greeting.rs
+++ b/crates/photo-frame/src/tasks/viewer/scenes/greeting.rs
@@ -26,7 +26,7 @@ impl GreetingScene {
 
     fn resize(&mut self, new_size: PhysicalSize<u32>, scale_factor: f64) {
         self.screen.resize(new_size, scale_factor);
-        tracing::debug!("greeting_screen_resize {new_size:?} {scale_factor:?}"); 
+        tracing::debug!("greeting_screen_resize {new_size:?} {scale_factor:?}");
         self.needs_redraw = true;
     }
 }
@@ -34,7 +34,7 @@ impl GreetingScene {
 impl Scene for GreetingScene {
     fn on_enter(&mut self, ctx: &SceneContext) {
         self.resize(ctx.surface_size(), ctx.window.scale_factor());
-       tracing::debug!("greeting_screen about to call update layout");
+        tracing::debug!("greeting_screen about to call update layout");
         if self.screen.update_layout() {
             tracing::debug!(size = ?ctx.surface_size(), "greeting_scene_layout_ready");
         }
@@ -47,11 +47,13 @@ impl Scene for GreetingScene {
         scale_factor: f64,
     ) {
         self.resize(new_size, scale_factor);
+        if self.screen.update_layout() {
+            tracing::debug!("greeting_scene_layout_ready_after_resize");
+        }
     }
 
     fn render(&mut self, ctx: &mut RenderCtx<'_, '_>) -> RenderResult {
-        
-       tracing::debug!(self.needs_redraw, "greeting_screen render");
+        tracing::debug!(self.needs_redraw, "greeting_screen render");
         if self.needs_redraw {
             let drew = self.screen.render(ctx.encoder, ctx.target_view);
             self.needs_redraw = !drew;


### PR DESCRIPTION
## Summary
- render the greeting/sleep screen with a double-line frame, accent color, and responsive geometry that respects font sizing
- update layout handling so greeting and sleep scenes rebuild text metrics on resize
- add a dedicated shader and GPU pipeline for drawing the frame without relying on stale buffers

## Testing
- `cargo test -p rust-photo-frame`


------
https://chatgpt.com/codex/tasks/task_e_68e8822bd6d483238d5c5792ced56986