### PR TITLE
Fix greeting screen rendering

### DIFF
--- a/crates/photo-frame/src/tasks/shaders/greeting_frame.wgsl
+++ b/crates/photo-frame/src/tasks/shaders/greeting_frame.wgsl
@@ -1,0 +1,81 @@
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
+    var positions = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -3.0),
+        vec2<f32>(3.0, 1.0),
+        vec2<f32>(-1.0, 1.0),
+    );
+    var uvs = array<vec2<f32>, 3>(
+        vec2<f32>(0.0, 2.0),
+        vec2<f32>(2.0, 0.0),
+        vec2<f32>(0.0, 0.0),
+    );
+
+    var out: VertexOutput;
+    out.position = vec4<f32>(positions[vertex_index], 0.0, 1.0);
+    out.uv = uvs[vertex_index];
+    return out;
+}
+
+struct FrameUniforms {
+    size_outer_inner: vec4<f32>;
+    gap_radius: vec4<f32>;
+    color: vec4<f32>;
+};
+
+@group(0) @binding(0)
+var<uniform> uniforms: FrameUniforms;
+
+fn sd_round_rect(p: vec2<f32>, size: vec2<f32>, radius: f32) -> f32 {
+    let half_size = size * 0.5;
+    let clamped_radius = min(radius, min(half_size.x, half_size.y));
+    let q = abs(p) - half_size + vec2<f32>(clamped_radius, clamped_radius);
+    return length(max(q, vec2<f32>(0.0, 0.0))) + min(max(q.x, q.y), 0.0) - clamped_radius;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let size = uniforms.size_outer_inner.xy;
+    if (size.x <= 0.0 || size.y <= 0.0) {
+        discard;
+    }
+
+    let outer_stroke = uniforms.size_outer_inner.z;
+    let inner_stroke = uniforms.size_outer_inner.w;
+    let gap = uniforms.gap_radius.x;
+    let corner_radius = uniforms.gap_radius.y;
+
+    let p = (in.uv * size) - (size * 0.5);
+
+    let d_outer = sd_round_rect(p, size, corner_radius);
+    if (d_outer > 0.0 && inner_stroke <= 0.0 && outer_stroke <= 0.0) {
+        discard;
+    }
+
+    if (d_outer > 0.0 || d_outer < -outer_stroke) {
+        // Potentially inside gap region; check inner stroke if present.
+        if (inner_stroke <= 0.0) {
+            discard;
+        }
+
+        let offset_inner = outer_stroke + gap;
+        let inner_size = size - vec2<f32>(2.0 * offset_inner, 2.0 * offset_inner);
+        if (inner_size.x <= 0.0 || inner_size.y <= 0.0) {
+            discard;
+        }
+
+        let inner_radius = max(corner_radius - offset_inner, 0.0);
+        let d_inner = sd_round_rect(p, inner_size, inner_radius);
+        if (d_inner > 0.0 || d_inner < -inner_stroke) {
+            discard;
+        }
+        return uniforms.color;
+    }
+
+    return uniforms.color;
+}

--- a/crates/photo-frame/src/tasks/viewer/scenes/greeting.rs
+++ b/crates/photo-frame/src/tasks/viewer/scenes/greeting.rs
@@ -26,7 +26,12 @@ impl GreetingScene {
 
     fn resize(&mut self, new_size: PhysicalSize<u32>, scale_factor: f64) {
         self.screen.resize(new_size, scale_factor);
-        tracing::debug!("greeting_screen_resize {new_size:?} {scale_factor:?}"); 
+        tracing::debug!("greeting_screen_resize {new_size:?} {scale_factor:?}");
+        if self.screen.update_layout() {
+            tracing::debug!(size = ?new_size, "greeting_scene_layout_ready");
+        } else {
+            tracing::debug!("greeting_scene_layout_pending");
+        }
         self.needs_redraw = true;
     }
 }
@@ -34,10 +39,6 @@ impl GreetingScene {
 impl Scene for GreetingScene {
     fn on_enter(&mut self, ctx: &SceneContext) {
         self.resize(ctx.surface_size(), ctx.window.scale_factor());
-       tracing::debug!("greeting_screen about to call update layout");
-        if self.screen.update_layout() {
-            tracing::debug!(size = ?ctx.surface_size(), "greeting_scene_layout_ready");
-        }
     }
 
     fn handle_resize(
@@ -50,8 +51,7 @@ impl Scene for GreetingScene {
     }
 
     fn render(&mut self, ctx: &mut RenderCtx<'_, '_>) -> RenderResult {
-        
-       tracing::debug!(self.needs_redraw, "greeting_screen render");
+        tracing::debug!(self.needs_redraw, "greeting_screen render");
         if self.needs_redraw {
             let drew = self.screen.render(ctx.encoder, ctx.target_view);
             self.needs_redraw = !drew;


### PR DESCRIPTION
## Summary
- add a GPU pipeline and shader so the greeting screen renders the double-line accent frame
- convert stroke and corner radius from DIP to pixels and keep the text layout in sync with resizes
- ensure viewer greeting scene re-runs layout on resize to avoid blank text

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68e8822bd6d483238d5c5792ced56986