### PR TITLE
Fix greeting screen layout updates

### DIFF
--- a/crates/photo-frame/src/tasks/greeting_screen.rs
+++ b/crates/photo-frame/src/tasks/greeting_screen.rs
@@ -92,39 +92,39 @@ impl GreetingScreen {
         if self.size.width == 0 || self.size.height == 0 {
             return false;
         }
-            self.viewport.update(
-                &self.queue,
-                Resolution {
-                    width: self.size.width,
-                    height: self.size.height,
-                },
-            );
+        self.viewport.update(
+            &self.queue,
+            Resolution {
+                width: self.size.width,
+                height: self.size.height,
+            },
+        );
 
-            let text_color = to_text_color(self.font_colour);
-            if let Err(err) = self.text_renderer.prepare(
-                &self.device,
-                &self.queue,
-                &mut self.font_system,
-                &mut self.atlas,
-                &self.viewport,
-                [TextArea {
-                    buffer: &self.text_buffer,
-                    left: self.text_origin.0,
-                    top: self.text_origin.1,
-                    scale: 1.0,
-                    bounds: TextBounds {
-                        left: 0,
-                        top: 0,
-                        right: self.size.width as i32,
-                        bottom: self.size.height as i32,
-                    },
-                    default_color: text_color,
-                    custom_glyphs: &[],
-                }],
-                &mut self.swash_cache,
-            ) {
-                warn!(error = %err, "greeting_screen_prepare_failed");
-            }
+        let text_color = to_text_color(self.font_colour);
+        if let Err(err) = self.text_renderer.prepare(
+            &self.device,
+            &self.queue,
+            &mut self.font_system,
+            &mut self.atlas,
+            &self.viewport,
+            [TextArea {
+                buffer: &self.text_buffer,
+                left: self.text_origin.0,
+                top: self.text_origin.1,
+                scale: 1.0,
+                bounds: TextBounds {
+                    left: 0,
+                    top: 0,
+                    right: self.size.width as i32,
+                    bottom: self.size.height as i32,
+                },
+                default_color: text_color,
+                custom_glyphs: &[],
+            }],
+            &mut self.swash_cache,
+        ) {
+            warn!(error = %err, "greeting_screen_prepare_failed");
+        }
 
         {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -142,16 +142,16 @@ impl GreetingScreen {
                 timestamp_writes: None,
             });
 
-                if let Err(err) = self
-                    .text_renderer
-                    .render(&self.atlas, &self.viewport, &mut pass)
-                {
-                    warn!(error = %err, "greeting_screen_draw_failed");
-                }
+            if let Err(err) = self
+                .text_renderer
+                .render(&self.atlas, &self.viewport, &mut pass)
+            {
+                warn!(error = %err, "greeting_screen_draw_failed");
+            }
         }
 
-            self.atlas.trim();
-            true
+        self.atlas.trim();
+        true
     }
 
     pub fn after_submit(&mut self) {

--- a/crates/photo-frame/src/tasks/viewer/scenes/greeting.rs
+++ b/crates/photo-frame/src/tasks/viewer/scenes/greeting.rs
@@ -7,6 +7,7 @@ use crate::tasks::greeting_screen::GreetingScreen;
 pub struct GreetingScene {
     screen: GreetingScreen,
     needs_redraw: bool,
+    layout_dirty: bool,
 }
 
 impl GreetingScene {
@@ -21,23 +22,22 @@ impl GreetingScene {
         Self {
             screen,
             needs_redraw: true,
+            layout_dirty: true,
         }
     }
 
     fn resize(&mut self, new_size: PhysicalSize<u32>, scale_factor: f64) {
         self.screen.resize(new_size, scale_factor);
-        tracing::debug!("greeting_screen_resize {new_size:?} {scale_factor:?}"); 
+        tracing::debug!("greeting_screen_resize {new_size:?} {scale_factor:?}");
         self.needs_redraw = true;
+        self.layout_dirty = true;
     }
 }
 
 impl Scene for GreetingScene {
     fn on_enter(&mut self, ctx: &SceneContext) {
         self.resize(ctx.surface_size(), ctx.window.scale_factor());
-       tracing::debug!("greeting_screen about to call update layout");
-        if self.screen.update_layout() {
-            tracing::debug!(size = ?ctx.surface_size(), "greeting_scene_layout_ready");
-        }
+        tracing::debug!("greeting_screen_marked_dirty_on_enter");
     }
 
     fn handle_resize(
@@ -50,8 +50,18 @@ impl Scene for GreetingScene {
     }
 
     fn render(&mut self, ctx: &mut RenderCtx<'_, '_>) -> RenderResult {
-        
-       tracing::debug!(self.needs_redraw, "greeting_screen render");
+        if self.layout_dirty {
+            tracing::debug!("greeting_scene_layout_dirty");
+            if !self.screen.update_layout() {
+                tracing::debug!("greeting_scene_layout_pending");
+                return RenderResult::NeedsRedraw;
+            }
+            tracing::debug!("greeting_scene_layout_ready");
+            self.layout_dirty = false;
+            self.needs_redraw = true;
+        }
+
+        tracing::debug!(self.needs_redraw, "greeting_screen render");
         if self.needs_redraw {
             let drew = self.screen.render(ctx.encoder, ctx.target_view);
             self.needs_redraw = !drew;


### PR DESCRIPTION
## Summary
- track when the greeting layout is stale so we can recompute it after window resizes or re-entry
- request another draw until layout succeeds before rendering the greeting frame

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e882ac481483238aba2c6e91b10570