### PR TITLE
Ensure greeting scene shows configured message

### DIFF
--- a/crates/photo-frame/src/tasks/greeting_screen.rs
+++ b/crates/photo-frame/src/tasks/greeting_screen.rs
@@ -55,7 +55,6 @@ impl GreetingScreen {
             TextRenderer::new(&mut atlas, device, wgpu::MultisampleState::default(), None);
         let swash_cache = SwashCache::new();
 
-        let message = screen.message_or_default().into_owned();
         let background = resolve_background_colour(screen.colors.background.as_deref());
         let font_colour = resolve_font_colour(screen.colors.font.as_deref());
 
@@ -71,13 +70,22 @@ impl GreetingScreen {
             font_system,
             swash_cache,
             font_family,
-            message,
+            message: String::new(),
             background,
             font_colour,
             size: PhysicalSize::new(0, 0),
             text_origin: (0.0, 0.0),
         };
         instance
+    }
+
+    pub fn set_message(&mut self, message: impl Into<String>) -> bool {
+        let message = message.into();
+        if self.message == message {
+            return false;
+        }
+        self.message = message;
+        true
     }
 
     pub fn resize(&mut self, new_size: PhysicalSize<u32>, _scale_factor: f64) {

--- a/crates/photo-frame/src/tasks/viewer/scenes/asleep.rs
+++ b/crates/photo-frame/src/tasks/viewer/scenes/asleep.rs
@@ -16,7 +16,9 @@ impl AsleepScene {
         format: wgpu::TextureFormat,
         config: &SleepScreenConfig,
     ) -> Self {
-        let screen = GreetingScreen::new(device, queue, format, config.screen());
+        let mut screen = GreetingScreen::new(device, queue, format, config.screen());
+        let message = config.screen().message_or_default().into_owned();
+        let _ = screen.set_message(message);
         Self {
             screen,
             needs_redraw: true,

--- a/crates/photo-frame/src/tasks/viewer/scenes/greeting.rs
+++ b/crates/photo-frame/src/tasks/viewer/scenes/greeting.rs
@@ -17,7 +17,9 @@ impl GreetingScene {
         format: wgpu::TextureFormat,
         config: &GreetingScreenConfig,
     ) -> Self {
-        let screen = GreetingScreen::new(device, queue, format, config.screen());
+        let mut screen = GreetingScreen::new(device, queue, format, config.screen());
+        let message = config.screen().message_or_default().into_owned();
+        let _ = screen.set_message(message);
         tracing::debug!("greeting_screen_new completed {config:?}");
         Self {
             screen,


### PR DESCRIPTION
## Summary
- add a setter on the greeting screen renderer so the message text can be injected
- initialize both the greeting and sleep scenes with the message pulled from the configuration

## Testing
- cargo check -q

------
https://chatgpt.com/codex/tasks/task_e_68e9aeb2d6f88323a0e39ec69e4dfef3