### PR TITLE
Update GPU and font dependencies for wgpu 27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ edition = "2024"
 
 [workspace.metadata]
 # Workspace-level metadata placeholder for future shared settings.
+
+[patch.crates-io]
+cosmic-text = { git = "https://github.com/pop-os/cosmic-text.git", rev = "646e04389e1c2e03a85e61946ace06d8fada1fa1" }

--- a/crates/photo-frame/Cargo.toml
+++ b/crates/photo-frame/Cargo.toml
@@ -20,17 +20,17 @@ serde_yaml = "0.9.34"
 humantime-serde = "1.1.1"
 humantime = "2.3.0"
 chrono = { version = "0.4.38", features = ["serde"] }
-chrono-tz = { version = "0.8.6", features = ["serde"] }
+chrono-tz = { version = "0.10.0", features = ["serde"] }
 crossbeam-channel = "0.5.15"
 tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "net", "io-util"] }
 tokio-util = "0.7.16"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["fmt", "env-filter"] }
 walkdir = "2.5.0"
-wgpu = { version = "25.0.2", features = ["wgsl"] }
+wgpu = { version = "27.0.0", features = ["wgsl"] }
 winit = "0.30.12"
-glyphon = "0.9.0"
-fontdb = "0.16.2"
+glyphon = { git = "https://github.com/grovesNL/glyphon.git", rev = "de4b5b8d4e52310be8df56d82a759593920acc04" }
+fontdb = "0.23.0"
 lyon = "1.0.1"
 palette = "0.7.6"
 

--- a/crates/photo-frame/src/gpu/debug_overlay.rs
+++ b/crates/photo-frame/src/gpu/debug_overlay.rs
@@ -17,6 +17,7 @@ pub fn render<F>(
         label: Some(label),
         color_attachments: &[Some(wgpu::RenderPassColorAttachment {
             view: target,
+            depth_slice: None,
             resolve_target: None,
             ops: wgpu::Operations {
                 load: wgpu::LoadOp::Clear(clear_color),

--- a/crates/photo-frame/src/tasks/greeting_screen.rs
+++ b/crates/photo-frame/src/tasks/greeting_screen.rs
@@ -139,6 +139,7 @@ impl GreetingScreen {
                 label: Some("greeting-background"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: target_view,
+                    depth_slice: None,
                     resolve_target: None,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Clear(to_wgpu_color(self.background)),
@@ -163,7 +164,7 @@ impl GreetingScreen {
     }
 
     pub fn after_submit(&mut self) {
-        let _ = self.device.poll(wgpu::PollType::Wait);
+        let _ = self.device.poll(wgpu::PollType::wait_indefinitely());
     }
 
     pub fn update_layout(&mut self) -> bool {
@@ -186,6 +187,7 @@ impl GreetingScreen {
             &self.message,
             &attrs,
             Shaping::Advanced,
+            None,
         );
         apply_center_alignment(&mut self.text_buffer);
         self.text_buffer

--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -1146,6 +1146,7 @@ pub fn run_windowed(
                     label: Some("viewer-device"),
                     required_features: wgpu::Features::empty(),
                     required_limits: limits.clone(),
+                    experimental_features: wgpu::ExperimentalFeatures::default(),
                     memory_hints: wgpu::MemoryHints::default(),
                     trace: wgpu::Trace::default(),
                 })) {
@@ -1646,6 +1647,7 @@ pub fn run_windowed(
                                     label: Some("draw-pass"),
                                     color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                                         view: &view,
+                                        depth_slice: None,
                                         resolve_target: None,
                                         ops: wgpu::Operations {
                                             load: wgpu::LoadOp::Clear(self.clear_color),


### PR DESCRIPTION
## Summary
- bump the photo-frame crate to wgpu 27, fontdb 0.23, chrono-tz 0.10, and track the matching glyphon/cosmic-text git revisions
- adjust render pass descriptors and device creation for the wgpu 27 API
- update greeting text rendering to the latest cosmic-text signatures

## Testing
- cargo build -p rust-photo-frame
- cargo test -p rust-photo-frame

------
https://chatgpt.com/codex/tasks/task_e_68e9d9f6a5f883239d32650a5a7a1544