### PR TITLE
Eliminate dead code allowances and surface configuration usage

### DIFF
--- a/crates/photo-frame/src/gpu/debug_overlay.rs
+++ b/crates/photo-frame/src/gpu/debug_overlay.rs
@@ -1,6 +1,5 @@
 //! Minimal overlay helpers for isolating clear/draw paths during debugging.
 
-#[allow(dead_code)]
 /// Clears the target view with `clear_color` and optionally executes `draw_fn`
 /// inside the render pass. The helper makes it easy to rule out pipeline state
 /// issues by swapping the closure for a no-op draw.

--- a/crates/photo-frame/src/processing/blur.rs
+++ b/crates/photo-frame/src/processing/blur.rs
@@ -17,7 +17,7 @@ fn blur_cpu(image: &RgbaImage, sigma: f32) -> RgbaImage {
     imageops::blur(image, sigma)
 }
 
-#[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
+#[cfg(target_arch = "aarch64")]
 fn gaussian_kernel(sigma: f32) -> (Vec<f32>, u32) {
     let sigma = sigma.max(0.01);
     let radius = (sigma * 3.0).ceil() as i32;
@@ -44,7 +44,7 @@ fn gaussian_kernel(sigma: f32) -> (Vec<f32>, u32) {
     (weights, radius as u32)
 }
 
-#[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
+#[cfg(target_arch = "aarch64")]
 fn rgba_to_f32(image: &RgbaImage) -> Vec<f32> {
     image
         .pixels()
@@ -52,7 +52,7 @@ fn rgba_to_f32(image: &RgbaImage) -> Vec<f32> {
         .collect()
 }
 
-#[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
+#[cfg(target_arch = "aarch64")]
 fn f32_to_rgba(width: u32, height: u32, data: &[f32]) -> RgbaImage {
     let mut out = RgbaImage::new(width, height);
     for (i, pixel) in out.pixels_mut().enumerate() {

--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -1,6 +1,6 @@
 pub mod scenes;
 
-use self::scenes::{GreetingScene, Scene, SleepScene};
+use self::scenes::{GreetingScene, SleepScene};
 
 use crate::config::{
     MattingConfig, MattingMode, MattingOptions, TransitionKind, TransitionMode, TransitionOptions,


### PR DESCRIPTION
## Summary
- gate NEON blur helpers behind aarch64-only builds instead of allowing dead code
- reuse the GPU debug overlay clear helper and apply greeting screen configuration when laying out text
- expose matting and transition getters without allows and log the active transition in the wake scene

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68e9d98b16d08323a8f99438e1e763c1