### PR TITLE
Defer scheduled wake until greeting completes

### DIFF
--- a/crates/photo-frame/src/lib.rs
+++ b/crates/photo-frame/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod events;
 pub mod gpu;
 pub mod processing;
+pub mod schedule;
 pub mod tasks {
     pub mod files;
     pub mod greeting_screen;

--- a/crates/photo-frame/src/schedule.rs
+++ b/crates/photo-frame/src/schedule.rs
@@ -1,8 +1,10 @@
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
+use chrono_tz::Tz;
 use tokio::sync::mpsc;
+use tokio::time::{Instant, sleep};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
@@ -13,80 +15,204 @@ pub async fn run(
     schedule: AwakeScheduleConfig,
     cancel: CancellationToken,
     control: mpsc::Sender<ViewerCommand>,
+    greeting_delay: Duration,
 ) -> Result<()> {
     let tz = schedule.timezone();
     let mut last_state: Option<bool> = None;
+    let mut initial_awake_deadline: Option<Instant> = None;
+
+    enum NextEvent {
+        Idle,
+        InitialAwake,
+        Transition { at: DateTime<Tz>, awake_after: bool },
+    }
 
     loop {
         let now_local = Utc::now().with_timezone(&tz);
         let awake_now = schedule.is_awake_at(now_local);
+
         if last_state != Some(awake_now) {
-            let state = if awake_now {
-                ViewerState::Awake
+            if awake_now {
+                if last_state.is_none() {
+                    if greeting_delay.is_zero() {
+                        let state = ViewerState::Awake;
+                        info!(
+                            %now_local,
+                            state = ?state,
+                            "schedule enforcing viewer state"
+                        );
+                        control
+                            .send(ViewerCommand::SetState(state))
+                            .await
+                            .context("failed to send scheduled viewer command")?;
+                        last_state = Some(true);
+                        continue;
+                    }
+                    if initial_awake_deadline.is_none() {
+                        let deadline = Instant::now() + greeting_delay;
+                        let delay_ms = greeting_delay.as_millis().min(u128::from(u64::MAX)) as u64;
+                        debug!(delay_ms, "schedule deferring initial wake");
+                        initial_awake_deadline = Some(deadline);
+                    }
+                } else {
+                    let state = ViewerState::Awake;
+                    info!(
+                        %now_local,
+                        state = ?state,
+                        "schedule enforcing viewer state"
+                    );
+                    control
+                        .send(ViewerCommand::SetState(state))
+                        .await
+                        .context("failed to send scheduled viewer command")?;
+                    last_state = Some(true);
+                    continue;
+                }
             } else {
-                ViewerState::Asleep
-            };
-            info!(
-                %now_local,
-                state = ?state,
-                "schedule enforcing viewer state"
-            );
-            control
-                .send(ViewerCommand::SetState(state))
-                .await
-                .context("failed to send scheduled viewer command")?;
-            last_state = Some(awake_now);
-        }
-
-        let Some((transition_at, awake_after)) = schedule.next_transition_after(now_local) else {
-            tokio::select! {
-                _ = cancel.cancelled() => break,
-                _ = tokio::time::sleep(Duration::from_secs(60)) => continue,
-            };
-        };
-
-        let desired_state = if awake_after {
-            ViewerState::Awake
-        } else {
-            ViewerState::Asleep
-        };
-        let now_utc = now_local.with_timezone(&Utc);
-        let transition_utc = transition_at.with_timezone(&Utc);
-        let delta = transition_utc.signed_duration_since(now_utc);
-        let wait = match delta.to_std() {
-            Ok(duration) => duration,
-            Err(_) => Duration::from_secs(0),
-        };
-
-        if wait.is_zero() {
-            debug!(
-                %transition_at,
-                state = ?desired_state,
-                "schedule executing immediate transition"
-            );
-            control
-                .send(ViewerCommand::SetState(desired_state))
-                .await
-                .context("failed to send scheduled viewer command")?;
-            last_state = Some(awake_after);
-            continue;
-        }
-
-        debug!(
-            %transition_at,
-            state = ?desired_state,
-            wait_secs = wait.as_secs_f64(),
-            "schedule awaiting transition"
-        );
-
-        tokio::select! {
-            _ = cancel.cancelled() => break,
-            _ = tokio::time::sleep(wait) => {
+                initial_awake_deadline = None;
+                let state = ViewerState::Asleep;
+                info!(
+                    %now_local,
+                    state = ?state,
+                    "schedule enforcing viewer state"
+                );
                 control
-                    .send(ViewerCommand::SetState(desired_state))
+                    .send(ViewerCommand::SetState(state))
                     .await
                     .context("failed to send scheduled viewer command")?;
-                last_state = Some(awake_after);
+                last_state = Some(false);
+                continue;
+            }
+        }
+
+        let mut wait = Duration::from_secs(60);
+        let mut next_event = NextEvent::Idle;
+
+        if let Some(deadline) = initial_awake_deadline {
+            let now_instant = Instant::now();
+            let until = deadline
+                .checked_duration_since(now_instant)
+                .unwrap_or_else(|| Duration::from_secs(0));
+            wait = until;
+            next_event = NextEvent::InitialAwake;
+        }
+
+        if let Some((transition_at, awake_after)) = schedule.next_transition_after(now_local) {
+            let now_utc = now_local.with_timezone(&Utc);
+            let transition_utc = transition_at.with_timezone(&Utc);
+            let delta = transition_utc.signed_duration_since(now_utc);
+            let transition_wait = match delta.to_std() {
+                Ok(duration) => duration,
+                Err(_) => Duration::from_secs(0),
+            };
+
+            if matches!(next_event, NextEvent::Idle) || transition_wait < wait {
+                wait = transition_wait;
+                next_event = NextEvent::Transition {
+                    at: transition_at,
+                    awake_after,
+                };
+            }
+        }
+
+        match next_event {
+            NextEvent::Idle => {
+                tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    _ = sleep(wait) => {}
+                }
+            }
+            NextEvent::InitialAwake => {
+                if wait.is_zero() {
+                    initial_awake_deadline = None;
+                    let now_local = Utc::now().with_timezone(&tz);
+                    let awake = schedule.is_awake_at(now_local);
+                    let state = if awake {
+                        ViewerState::Awake
+                    } else {
+                        ViewerState::Asleep
+                    };
+                    info!(
+                        %now_local,
+                        state = ?state,
+                        "schedule enforcing viewer state"
+                    );
+                    control
+                        .send(ViewerCommand::SetState(state))
+                        .await
+                        .context("failed to send scheduled viewer command")?;
+                    last_state = Some(awake);
+                    continue;
+                }
+
+                tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    _ = sleep(wait) => {
+                        initial_awake_deadline = None;
+                        let now_local = Utc::now().with_timezone(&tz);
+                        let awake = schedule.is_awake_at(now_local);
+                        let state = if awake {
+                            ViewerState::Awake
+                        } else {
+                            ViewerState::Asleep
+                        };
+                        info!(
+                            %now_local,
+                            state = ?state,
+                            "schedule enforcing viewer state"
+                        );
+                        control
+                            .send(ViewerCommand::SetState(state))
+                            .await
+                            .context("failed to send scheduled viewer command")?;
+                        last_state = Some(awake);
+                    }
+                }
+            }
+            NextEvent::Transition { at, awake_after } => {
+                let desired_state = if awake_after {
+                    ViewerState::Awake
+                } else {
+                    ViewerState::Asleep
+                };
+
+                if wait.is_zero() {
+                    debug!(
+                        %at,
+                        state = ?desired_state,
+                        "schedule executing immediate transition"
+                    );
+                    control
+                        .send(ViewerCommand::SetState(desired_state))
+                        .await
+                        .context("failed to send scheduled viewer command")?;
+                    last_state = Some(awake_after);
+                    if !awake_after {
+                        initial_awake_deadline = None;
+                    }
+                    continue;
+                }
+
+                debug!(
+                    %at,
+                    state = ?desired_state,
+                    wait_secs = wait.as_secs_f64(),
+                    "schedule awaiting transition"
+                );
+
+                tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    _ = sleep(wait) => {
+                        control
+                            .send(ViewerCommand::SetState(desired_state))
+                            .await
+                            .context("failed to send scheduled viewer command")?;
+                        last_state = Some(awake_after);
+                        if !awake_after {
+                            initial_awake_deadline = None;
+                        }
+                    }
+                }
             }
         }
     }

--- a/crates/photo-frame/tests/schedule_startup.rs
+++ b/crates/photo-frame/tests/schedule_startup.rs
@@ -1,0 +1,104 @@
+use std::time::{Duration, Instant};
+
+use rust_photo_frame::config::AwakeScheduleConfig;
+use rust_photo_frame::events::{ViewerCommand, ViewerState};
+use rust_photo_frame::schedule;
+use serde_yaml::from_str;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+fn schedule_from_yaml(input: &str) -> AwakeScheduleConfig {
+    let mut schedule: AwakeScheduleConfig = from_str(input).expect("valid schedule yaml");
+    schedule.validate().expect("valid schedule");
+    schedule
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn schedule_defers_initial_wake_for_greeting() {
+    let schedule = schedule_from_yaml(
+        r#"
+timezone: "UTC"
+awake-scheduled:
+  daily:
+    - ["00:00:00", "23:59:59"]
+"#,
+    );
+
+    let (tx, mut rx) = mpsc::channel::<ViewerCommand>(4);
+    let cancel = CancellationToken::new();
+    let greeting_delay = Duration::from_millis(250);
+
+    let start = Instant::now();
+    let handle = tokio::spawn(schedule::run(schedule, cancel.clone(), tx, greeting_delay));
+
+    let early = tokio::time::timeout(Duration::from_millis(150), rx.recv()).await;
+    assert!(
+        early.is_err(),
+        "command should not arrive before greeting delay elapses"
+    );
+
+    let command = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("expected wake command after greeting delay")
+        .expect("schedule channel closed unexpectedly");
+
+    let elapsed = start.elapsed();
+    match command {
+        ViewerCommand::SetState(ViewerState::Awake) => {
+            assert!(
+                elapsed >= greeting_delay,
+                "awake command sent too early: {:?} < {:?}",
+                elapsed,
+                greeting_delay
+            );
+        }
+        other => panic!("unexpected command: {:?}", other),
+    }
+
+    cancel.cancel();
+    let _ = handle.await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn schedule_does_not_auto_wake_during_sleep_interval() {
+    let schedule = schedule_from_yaml(
+        r#"
+timezone: "UTC"
+"#,
+    );
+
+    let (tx, mut rx) = mpsc::channel::<ViewerCommand>(4);
+    let cancel = CancellationToken::new();
+    let greeting_delay = Duration::from_millis(250);
+
+    let handle = tokio::spawn(schedule::run(schedule, cancel.clone(), tx, greeting_delay));
+
+    let first_command = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+        .await
+        .expect("expected immediate sleep command")
+        .expect("schedule channel closed unexpectedly");
+
+    assert_eq!(
+        first_command,
+        ViewerCommand::SetState(ViewerState::Asleep),
+        "schedule should enforce sleep state immediately"
+    );
+
+    let stray_wake = tokio::time::timeout(Duration::from_millis(400), async {
+        while let Some(cmd) = rx.recv().await {
+            if matches!(cmd, ViewerCommand::SetState(ViewerState::Awake)) {
+                return Some(cmd);
+            }
+        }
+        None
+    })
+    .await;
+
+    assert!(
+        stray_wake.is_err() || stray_wake.unwrap().is_none(),
+        "sleep interval was interrupted by an unexpected wake command"
+    );
+
+    cancel.cancel();
+    let _ = handle.await;
+}


### PR DESCRIPTION
## Summary
- only arm the auto-wake timer when no awake schedule is configured and pass the greeting delay into the scheduler
- defer the initial wake transition inside the schedule task while keeping immediate sleep enforcement and maintaining state tracking
- add async integration tests to ensure the greeting duration is respected and that awake schedules do not emit stray wake commands during sleep intervals

## Testing
- cargo fmt
- cargo test -p rust-photo-frame schedule *(fails: viewer module in the crate does not currently compile)*

------
https://chatgpt.com/codex/tasks/task_e_68eaaa8394248323a52b994829864a82