### PR TITLE
Route greeting transition through dispatcher

### DIFF
--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -1389,16 +1389,21 @@ pub fn run_windowed(
             if self.mode_kind() != ViewerModeKind::Greeting {
                 info!("viewer: entering greeting");
             }
-            self.viewer_state = ViewerState::Greeting;
-            let duration = self.full_config.greeting_screen.effective_duration();
-            let duration_ms = duration.as_millis().min(u128::from(u64::MAX)) as u64;
-            debug!(duration_ms, "viewer_greeting_duration_configured");
-            self.wake.take_redraw_needed();
-            if let Some(gpu) = self.gpu.as_mut() {
-                if let Some(window) = self.window.as_ref() {
-                    let size = window.inner_size();
-                    let scale_factor = window.scale_factor();
-                    gpu.greeting.resize(size, scale_factor);
+            self.mode_mut().wake_mut().take_redraw_needed();
+            self.set_mode(ViewerModeKind::Greeting);
+            let window_dims = self
+                .window
+                .as_ref()
+                .map(|window| (window.inner_size(), window.scale_factor()));
+            let greeting_message = self
+                .full_config
+                .greeting_screen
+                .screen()
+                .message_or_default()
+                .into_owned();
+            if let Some(greeting) = self.mode_mut().greeting_mut() {
+                if let Some((size, scale_factor)) = window_dims {
+                    greeting.resize(size, scale_factor);
                 }
                 greeting.set_message(greeting_message);
                 greeting.mark_redraw_needed();


### PR DESCRIPTION
## Summary
- ensure the greeting transition uses the mode dispatcher so scene hooks fire when entering greeting
- keep existing greeting scene setup logic after the dispatcher call

## Testing
- cargo check *(fails: missing `Scene` implementations for viewer scenes)*

------
https://chatgpt.com/codex/tasks/task_e_68eaaa6d8808832399aaa0246ea986f6