### PR TITLE
Implement viewer scene trait hooks

### DIFF
--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -986,7 +986,6 @@ pub fn run_windowed(
             self.ready_results.clear();
             self.deferred_images.clear();
             if self.mode_kind() == ViewerModeKind::Sleep {
-                self.mode_mut().wake_mut().take_redraw_needed();
                 let message = self
                     .full_config
                     .sleep_screen
@@ -1352,7 +1351,6 @@ pub fn run_windowed(
                 return;
             }
             info!("viewer: entering sleep");
-            self.mode_mut().wake_mut().take_redraw_needed();
             self.set_mode(ViewerModeKind::Sleep);
             let window_dims = self
                 .window
@@ -1371,7 +1369,6 @@ pub fn run_windowed(
                 sleep.set_message(sleep_message);
                 sleep.mark_redraw_needed();
             }
-            self.request_redraw();
             self.log_event_loop_state("enter_sleep");
         }
 
@@ -1381,7 +1378,6 @@ pub fn run_windowed(
             }
             info!("viewer: entering wake");
             self.set_mode(ViewerModeKind::Wake);
-            self.request_redraw();
             self.log_event_loop_state("enter_wake");
         }
 
@@ -1389,7 +1385,6 @@ pub fn run_windowed(
             if self.mode_kind() != ViewerModeKind::Greeting {
                 info!("viewer: entering greeting");
             }
-            self.mode_mut().wake_mut().take_redraw_needed();
             self.set_mode(ViewerModeKind::Greeting);
             let window_dims = self
                 .window
@@ -1408,7 +1403,6 @@ pub fn run_windowed(
                 greeting.set_message(greeting_message);
                 greeting.mark_redraw_needed();
             }
-            self.request_redraw();
             self.log_event_loop_state("enter_greeting");
         }
     }

--- a/crates/photo-frame/src/tasks/viewer/scenes/mod.rs
+++ b/crates/photo-frame/src/tasks/viewer/scenes/mod.rs
@@ -433,3 +433,46 @@ pub(super) trait Scene {
     /// Called when the viewer wants the scene to ensure any redraw requests are queued.
     fn request_redraw(&mut self, _ctx: SceneContext<'_>) {}
 }
+
+impl Scene for GreetingScene {
+    fn enter(&mut self, mut ctx: SceneContext<'_>) {
+        self.mark_redraw_needed();
+        ctx.request_redraw();
+    }
+
+    fn request_redraw(&mut self, mut ctx: SceneContext<'_>) {
+        if self.needs_redraw() {
+            ctx.request_redraw();
+        }
+    }
+}
+
+impl Scene for SleepScene {
+    fn enter(&mut self, mut ctx: SceneContext<'_>) {
+        self.mark_redraw_needed();
+        ctx.request_redraw();
+    }
+
+    fn request_redraw(&mut self, mut ctx: SceneContext<'_>) {
+        if self.needs_redraw() {
+            ctx.request_redraw();
+        }
+    }
+}
+
+impl Scene for WakeScene {
+    fn enter(&mut self, mut ctx: SceneContext<'_>) {
+        self.enter_wake();
+        ctx.request_redraw();
+    }
+
+    fn exit(&mut self, _ctx: SceneContext<'_>) {
+        self.take_redraw_needed();
+    }
+
+    fn request_redraw(&mut self, mut ctx: SceneContext<'_>) {
+        if self.needs_redraw() || self.transition_state().is_some() {
+            ctx.request_redraw();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement the `Scene` trait for the greeting, sleep, and wake viewer scenes so they request redraws through the shared context
- rely on the wake scene's exit hook to clear pending redraws and drop redundant manual redraw calls when switching modes

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68eab42440088323bdadaa9666483d47