### PR TITLE
Document local build verification in test plan

### DIFF
--- a/developer/test-plan.md
+++ b/developer/test-plan.md
@@ -35,6 +35,13 @@ Exercise each axis at least once per release cycle.
   ```
 - [ ] Capture evidence via `tests/collect_logs.sh` (provides modes, EDID, journals).
 
+- [ ] **Local build verification:** ensure the binaries and tests compile cleanly before touching hardware.
+  ```sh
+  cargo check --workspace
+  cargo test --workspace
+  ```
+  Both commands should finish without warnings or failures. This validates the `photo-frame`, `buttond`, and `wifi-manager` crates prior to deploying to a Raspberry Pi.
+
 ## Phase 1 – Blank-Pi Install
 - [ ] Flash the latest Raspberry Pi OS (Trixie, 64-bit) onto a reliable microSD using Raspberry Pi Imager (preload hostname, user, Wi-Fi, SSH key).
 - [ ] On first boot, sign in as the deployment user (default `frame`) and confirm network connectivity.


### PR DESCRIPTION
## Summary
- add a pre-flight checklist item to the developer test plan that documents running `cargo check` and `cargo test` so local builds are verified before hardware work

## Testing
- cargo check
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ead1c157d0832398becf2f305121da