### PR TITLE
Ensure sleep overlay draws on first entry

### DIFF
--- a/crates/buttond/src/main.rs
+++ b/crates/buttond/src/main.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use evdev::{Device, EventSummary, KeyCode};
-use nix::fcntl::{fcntl, FcntlArg, OFlag};
+use nix::fcntl::{FcntlArg, OFlag, fcntl};
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::EnvFilter;
 

--- a/crates/photo-frame/src/tasks/viewer/scenes/mod.rs
+++ b/crates/photo-frame/src/tasks/viewer/scenes/mod.rs
@@ -30,7 +30,7 @@ impl OverlayScene {
         Self {
             screen,
             layout_dirty: true,
-            redraw_pending: false,
+            redraw_pending: true,
             size: PhysicalSize::new(0, 0),
             scale_factor: 1.0,
         }

--- a/crates/photo-frame/tests/config_tests.rs
+++ b/crates/photo-frame/tests/config_tests.rs
@@ -224,7 +224,10 @@ matting:
     let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
     match cfg.matting.selection() {
         MattingSelection::Sequential { kinds, .. } => {
-            assert_eq!(kinds.as_slice(), &[MattingKind::FixedColor, MattingKind::Blur]);
+            assert_eq!(
+                kinds.as_slice(),
+                &[MattingKind::FixedColor, MattingKind::Blur]
+            );
         }
         other => panic!("expected sequential matting selection, got {other:?}"),
     }
@@ -556,7 +559,10 @@ transition:
     let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
     match cfg.transition.selection() {
         TransitionSelection::Sequential { kinds, .. } => {
-            assert_eq!(kinds.as_slice(), &[TransitionKind::Push, TransitionKind::Wipe]);
+            assert_eq!(
+                kinds.as_slice(),
+                &[TransitionKind::Push, TransitionKind::Wipe]
+            );
         }
         other => panic!("expected sequential transition selection, got {other:?}"),
     }


### PR DESCRIPTION
## Summary
- mark overlay scenes as needing a redraw as soon as they are created so the sleep banner renders on its first frame even if we enter sleep before the overlay is fully initialised
- run rustfmt while touching the tree, which updated import ordering in a couple of files

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68eb0ec46f188323bc97bfbc8963c4b4