### PR TITLE
Add iris transition support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,7 +13,7 @@ control-socket-path: /run/photo-frame/control.sock
 # Render/transition settings
 transition:
   # List one or more transition kinds to rotate between.
-  types: [fade, wipe, push, e-ink]
+  types: [fade, wipe, push, e-ink, iris]
   # Choose how to iterate through the transition types: random or sequential.
   type-selection: random
   options:
@@ -37,6 +37,15 @@ transition:
       reveal-portion: 0.55
       stripe-count: 24
       flash-color: [0, 0, 0]
+    iris:
+      duration-ms: 520
+      style: polygon
+      edge-softness-px: 16.0
+      blades: 6
+      curvature: 0.4
+      center-x: 0.5
+      center-y: 0.5
+      direction: open
 
 # Dwell time (ms) the current image remains fully displayed before the next transition
 dwell-ms: 2000

--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -3,7 +3,8 @@ pub mod scenes;
 use self::scenes::{GreetingScene, Scene, SceneContext, SleepScene};
 
 use crate::config::{
-    MattingConfig, MattingMode, MattingOptions, TransitionKind, TransitionMode, TransitionOptions,
+    IrisDirection, IrisStyle, MattingConfig, MattingMode, MattingOptions, TransitionKind,
+    TransitionMode, TransitionOptions,
 };
 use crate::events::{
     Displayed, PhotoLoaded, PreparedImageCpu, ViewerCommand, ViewerState as ControlViewerState,
@@ -42,6 +43,14 @@ pub(super) enum ActiveTransition {
         stripe_count: u32,
         flash_color: [f32; 3],
         noise_seed: [f32; 2],
+    },
+    Iris {
+        style: IrisStyle,
+        edge_softness_px: f32,
+        blades: u32,
+        curvature: f32,
+        center: [f32; 2],
+        direction: IrisDirection,
     },
 }
 
@@ -113,6 +122,14 @@ impl TransitionState {
                     .flash_color
                     .map(|channel| (channel as f32 / 255.0).clamp(0.0, 1.0)),
                 noise_seed: [rng.random_range(0.0..=1.0), rng.random_range(0.0..=1.0)],
+            },
+            TransitionMode::Iris(cfg) => ActiveTransition::Iris {
+                style: cfg.style,
+                edge_softness_px: cfg.edge_softness_px.max(0.0),
+                blades: cfg.blades.max(1),
+                curvature: cfg.curvature.clamp(0.0, 1.0),
+                center: [cfg.center_x.clamp(0.0, 1.0), cfg.center_y.clamp(0.0, 1.0)],
+                direction: cfg.direction,
             },
         };
 
@@ -2008,6 +2025,29 @@ pub fn run_windowed(
                                         uniforms.params1[1] = flash_color[0].clamp(0.0, 1.0);
                                         uniforms.params1[2] = flash_color[1].clamp(0.0, 1.0);
                                         uniforms.params1[3] = flash_color[2].clamp(0.0, 1.0);
+                                    }
+                                    ActiveTransition::Iris {
+                                        style,
+                                        edge_softness_px,
+                                        blades,
+                                        curvature,
+                                        center,
+                                        direction,
+                                    } => {
+                                        uniforms.params0[0] = match style {
+                                            IrisStyle::Circular => 0.0,
+                                            IrisStyle::Polygon => 1.0,
+                                        };
+                                        uniforms.params0[1] = match direction {
+                                            IrisDirection::Open => 1.0,
+                                            IrisDirection::Close => -1.0,
+                                        };
+                                        uniforms.params0[2] = (*edge_softness_px).max(0.0);
+                                        uniforms.params0[3] = (*curvature).clamp(0.0, 1.0);
+                                        uniforms.params1[0] = (*blades).max(1) as f32;
+                                        uniforms.params1[1] = center[0].clamp(0.0, 1.0);
+                                        uniforms.params1[2] = center[1].clamp(0.0, 1.0);
+                                        uniforms.params1[3] = 0.0;
                                     }
                                 }
                             } else if let Some(cur) = wake.current() {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -316,7 +316,7 @@ The `transition` block controls how the viewer blends between photos. List one o
 
 | Key              | Required?                                                       | Default                        | Accepted values                                                 | Effect                                                                                                                                                              |
 | ---------------- | --------------------------------------------------------------- | ------------------------------ | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `types`          | Yes                                                             | `['fade']`                     | Array containing one or more of `fade`, `wipe`, `push`, `e-ink` | Determines which transition families are in play. Duplicates are ignored; at least one entry must be supplied.                                                      |
+| `types`          | Yes                                                             | `['fade']`                     | Array containing one or more of `fade`, `wipe`, `push`, `e-ink`, `iris` | Determines which transition families are in play. Duplicates are ignored; at least one entry must be supplied.                                                      |
 | `type-selection` | Optional (only valid when `types` has multiple entries)         | `random`                       | `random` or `sequential`                                        | Picks whether the app draws a new type randomly each slide or cycles through the list in order. Ignored when only one type is listed.                               |
 | `options`        | Required when `types` has multiple entries (optional otherwise) | Defaults per transition family | Mapping keyed by transition kind                                | Provides per-type overrides for duration and mode-specific fields. When only one type is listed you can specify the same fields inline instead of creating the map. |
 
@@ -377,6 +377,13 @@ Each transition exposes a focused set of fields:
   - **`reveal-portion`** (float, default `0.55`, clamped to `0.05–0.95`): Fraction of the timeline spent flashing before the stripes start uncovering the next slide.
   - **`stripe-count`** (integer ≥ 1, default `24`): How many horizontal bands sweep in; higher counts mimic a finer e-ink refresh.
   - **`flash-color`** (`[r, g, b]` array, default `[255, 255, 255]`): RGB color used for the bright flash phases before the black inversion. Channels outside `0–255` are clamped.
+- **`iris`**
+  - **`style`** (`circular` or `polygon`, default `circular`): Switches between a smooth circular reveal and a bladed polygon reminiscent of a camera iris.
+  - **`edge-softness-px`** (float ≥ 0, default `18.0`): Feather width in pixels along the aperture edge.
+  - **`blades`** (integer ≥ 1, default `6`): Number of blades to render when using the polygon style.
+  - **`curvature`** (float `0.0–1.0`, default `0.35`): Controls how rounded the polygon blades appear; higher values yield more circular arcs.
+  - **`center-x`** and **`center-y`** (floats `0.0–1.0`, defaults `0.5`): Offset the iris center relative to the frame, enabling asymmetric reveals.
+  - **`direction`** (`open` or `close`, default `open`): Whether the iris blooms outward from a closed state or collapses inward to reveal the next slide.
 
 ## Matting configuration
 


### PR DESCRIPTION
## Summary
- add the iris transition family to the configuration surface, validation, and option builder
- render iris transitions by extending the viewer state handling and WGSL shader
- document the new knobs, seed the sample config, and cover happy/error paths in config tests

## Testing
- cargo test config_tests

------
https://chatgpt.com/codex/tasks/task_e_68eb2e83e9f083239298278d063e0a8f