### PR TITLE
Fix bootstrap systemd helper path

### DIFF
--- a/setup/bootstrap/lib/systemd.sh
+++ b/setup/bootstrap/lib/systemd.sh
@@ -1,0 +1,1 @@
+../../lib/systemd.sh


### PR DESCRIPTION
## Summary
- add a bootstrap-local symlink to the shared systemd helper so bootstrap modules can source it

## Testing
- not run (system-level provisioning script)


------
https://chatgpt.com/codex/tasks/task_e_68eb32c32d848323b2906cb85303faf8