### PR TITLE
Harden kiosk bootstrap guard rails

### DIFF
--- a/setup/bootstrap/lib/systemd.sh
+++ b/setup/bootstrap/lib/systemd.sh
@@ -1,0 +1,1 @@
+../../lib/systemd.sh

--- a/setup/bootstrap/modules/40-kiosk-user.sh
+++ b/setup/bootstrap/modules/40-kiosk-user.sh
@@ -8,6 +8,12 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 # shellcheck source=../lib/systemd.sh
 source "${SCRIPT_DIR}/../lib/systemd.sh"
 
+require_root() {
+    if [[ $(id -u) -ne 0 ]]; then
+        die "This module must be run as root"
+    fi
+}
+
 log() {
     printf '[%s] %s\n' "${MODULE}" "$*"
 }
@@ -20,7 +26,7 @@ die() {
 require_commands() {
     local missing=()
     local cmd
-    for cmd in apt-get id useradd usermod groupadd install cp sed grep awk; do
+    for cmd in apt-get dpkg-query getent id useradd usermod groupadd install cp sed grep awk systemctl chown sync; do
         if ! command -v "${cmd}" >/dev/null 2>&1; then
             missing+=("${cmd}")
         fi
@@ -311,7 +317,7 @@ ensure_persistent_journald() {
 }
 
 main() {
-    require_root "$@"
+    require_root
     require_trixie
     require_commands
 


### PR DESCRIPTION
## Summary
- add an explicit root privilege guard to the kiosk bootstrap module
- expand the command prerequisite check to cover the utilities the script uses

## Testing
- not run (system-level provisioning script)

------
https://chatgpt.com/codex/tasks/task_e_68eb32c32d848323b2906cb85303faf8