### PR TITLE
Ensure seatd is managed alongside greetd provisioning

### DIFF
--- a/setup/app/modules/50-postcheck.sh
+++ b/setup/app/modules/50-postcheck.sh
@@ -13,6 +13,7 @@ KIOSK_SERVICE="${KIOSK_SERVICE:-greetd.service}"
 WIFI_SERVICE="${WIFI_SERVICE:-photoframe-wifi-manager.service}"
 SYNC_TIMER="${SYNC_TIMER:-photoframe-sync.timer}"
 BUTTON_SERVICE="${BUTTON_SERVICE:-photoframe-buttond.service}"
+SEATD_SERVICE="${SEATD_SERVICE:-seatd.service}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../lib/systemd.sh
 source "${SCRIPT_DIR}/../../lib/systemd.sh"
@@ -124,9 +125,13 @@ if systemd_available; then
     }
 
     kiosk_hint="run 'sudo ./setup/bootstrap/run.sh' to provision kiosk services"
+    seatd_hint="install seatd and rerun bootstrap provisioning"
 
     check_service "${KIOSK_SERVICE}" "ERROR" "${kiosk_hint}"
     check_enabled "${KIOSK_SERVICE}" "${kiosk_hint}"
+
+    check_service "${SEATD_SERVICE}" "ERROR" "${seatd_hint}"
+    check_enabled "${SEATD_SERVICE}" "${seatd_hint}"
 
     check_service "${WIFI_SERVICE}" "ERROR" "${kiosk_hint}"
     check_enabled "${WIFI_SERVICE}" "${kiosk_hint}"
@@ -145,11 +150,13 @@ if systemd_available; then
     wifi_service_status=$(systemd_unit_property "${WIFI_SERVICE}" ActiveState 2>/dev/null || echo "not-found")
     button_status=$(systemd_unit_property "${BUTTON_SERVICE}" ActiveState 2>/dev/null || echo "not-found")
     sync_status=$(systemd_unit_property "${SYNC_TIMER}" ActiveState 2>/dev/null || echo "not-found")
+    seatd_status=$(systemd_unit_property "${SEATD_SERVICE}" ActiveState 2>/dev/null || echo "not-found")
 else
     service_status="not checked (systemctl unavailable)"
     wifi_service_status="not checked (systemctl unavailable)"
     button_status="not checked (systemctl unavailable)"
     sync_status="not checked (systemctl unavailable)"
+    seatd_status="not checked (systemctl unavailable)"
 fi
 
 log INFO "Deployment summary:"
@@ -170,6 +177,7 @@ ${KIOSK_SERVICE} : ${service_status}
 ${WIFI_SERVICE}: ${wifi_service_status}
 ${BUTTON_SERVICE}: ${button_status}
 ${SYNC_TIMER}: ${sync_status}
+${SEATD_SERVICE}: ${seatd_status}
 Next steps:
   - Customize ${VAR_CONFIG} for your site.
   - Review journal logs with 'journalctl -u ${KIOSK_SERVICE} -f'.

--- a/setup/bootstrap/modules/60-systemd.sh
+++ b/setup/bootstrap/modules/60-systemd.sh
@@ -77,6 +77,17 @@ enable_systemd_units() {
     local session_bin="/opt/photo-frame/bin/rust-photo-frame"
     local greetd_started=0
 
+    local seatd_units=(seatd.service seatd.socket)
+    local seatd_unit
+    for seatd_unit in "${seatd_units[@]}"; do
+        if systemctl list-unit-files "${seatd_unit}" >/dev/null 2>&1; then
+            log "Enabling ${seatd_unit}"
+            systemctl enable "${seatd_unit}" >/dev/null 2>&1 || true
+            log "Starting ${seatd_unit}"
+            systemctl start "${seatd_unit}" >/dev/null 2>&1 || true
+        fi
+    done
+
     log "Setting greetd as the system display manager"
     if [[ -x "${session_bin}" ]]; then
         systemctl enable --now greetd.service >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- enable seatd.service and seatd.socket during bootstrap provisioning so seatd is ready before greetd starts
- extend post-install checks to confirm seatd is installed, enabled, and active alongside other kiosk services

## Testing
- not run (systemd not available in containerized environment)


------
https://chatgpt.com/codex/tasks/task_e_68eb37d65db083238afa34f48a0e6e4d