### PR TITLE
Ensure kiosk runtime directories persist across boots

### DIFF
--- a/setup/bootstrap/modules/40-kiosk-user.sh
+++ b/setup/bootstrap/modules/40-kiosk-user.sh
@@ -205,16 +205,22 @@ ensure_kiosk_user() {
 ensure_runtime_dirs() {
     local runtime_dir="/run/photo-frame"
     local tmpfiles_conf="/etc/tmpfiles.d/photo-frame.conf"
+    local kiosk_uid
+
+    kiosk_uid="$(id -u kiosk)"
 
     log "Ensuring runtime control socket directory ${runtime_dir}"
     install -d -m 0770 -o kiosk -g kiosk "${runtime_dir}"
 
     log "Writing tmpfiles.d entry ${tmpfiles_conf}"
     install -d -m 0755 "$(dirname "${tmpfiles_conf}")"
-    cat <<'TMPFILES' >"${tmpfiles_conf}"
+    cat <<TMPFILES >"${tmpfiles_conf}"
 # photo-frame runtime directories
 d /run/photo-frame 0770 kiosk kiosk -
+d /run/user/${kiosk_uid} 0700 kiosk kiosk -
 TMPFILES
+
+    install -d -m 0700 -o kiosk -g kiosk "/run/user/${kiosk_uid}"
 }
 
 install_polkit_rules() {


### PR DESCRIPTION
## Summary
- capture the kiosk user's UID when preparing runtime directories
- expand the tmpfiles.d entry so systemd recreates the kiosk runtime directory on boot
- create /run/user/<kiosk uid> immediately after writing the tmpfiles template

## Testing
- not run (requires target device)

------
https://chatgpt.com/codex/tasks/task_e_68eb3bbcb9e483238b42d2764feffd48