### PR TITLE
Add dbus packages to bootstrap apt dependencies

### DIFF
--- a/docs/kiosk.md
+++ b/docs/kiosk.md
@@ -13,7 +13,7 @@ sudo ./setup/bootstrap/run.sh
 The script performs the following actions:
 
 - verifies `/etc/os-release` reports `VERSION_CODENAME=trixie` and applies Raspberry Pi 5 boot tweaks (set `ENABLE_4K_BOOT=0` to skip the 4K60 profile),
-- installs the Wayland stack required for kiosk mode (`greetd`, `sway`, `swaybg`, `swayidle`, `swaylock`, `mesa-vulkan-drivers`, `vulkan-tools`, `wayland-protocols`, and `socat` for control-socket tooling) alongside general dependencies,
+- installs the Wayland stack required for kiosk mode (`greetd`, `sway`, `swaybg`, `swayidle`, `swaylock`, `mesa-vulkan-drivers`, `vulkan-tools`, `wayland-protocols`, and `socat` for control-socket tooling) alongside general dependencies, including `dbus`/`dbus-user-session` so `dbus-run-session` is present for the kiosk launch wrapper,
 - creates the `kiosk` account with a locked shell and ensures it belongs to the `video`, `render`, and `input` groups,
 - provisions `/run/photo-frame` (owned by `kiosk:kiosk`, mode `0770`) and drops an `/etc/tmpfiles.d/photo-frame.conf` entry so the control socket directory exists on every boot,
 - installs `/usr/local/bin/photoframe-session` and writes `/etc/greetd/config.toml` so virtual terminal 1 runs `/usr/local/bin/photoframe-session` as the `kiosk` user,

--- a/setup/bootstrap/modules/10-apt-packages.sh
+++ b/setup/bootstrap/modules/10-apt-packages.sh
@@ -15,6 +15,8 @@ PACKAGES=(
     libdrm2
     mesa-vulkan-drivers
     seatd
+    dbus
+    dbus-user-session
     network-manager
     build-essential
     pkg-config


### PR DESCRIPTION
## Summary
- ensure the bootstrap apt module installs both `dbus` and `dbus-user-session` so the kiosk wrapper can rely on `dbus-run-session`
- note the new dependency in the kiosk provisioning guide

## Testing
- sudo ./setup/bootstrap/modules/10-apt-packages.sh
- which dbus-run-session

------
https://chatgpt.com/codex/tasks/task_e_68eb3bbe3da88323946cb6b70c547d66