### PR TITLE
Fix iris close transition mixing

### DIFF
--- a/crates/photo-frame/src/tasks/shaders/viewer_quad.wgsl
+++ b/crates/photo-frame/src/tasks/shaders/viewer_quad.wgsl
@@ -179,11 +179,7 @@ fn fs_main(in: VSOut) -> @location(0) vec4<f32> {
       let base_radius = max_radius * clamp(openness, 0.0, 1.0);
       let feather = max(softness, 1e-4);
       let mask = smoothstep(base_radius - feather, base_radius + feather, effective_dist);
-      if (direction > 0.0) {
-        color = mix(next, current, mask);
-      } else {
-        color = mix(current, next, mask);
-      }
+      color = mix(next, current, mask);
     }
     default: {
       color = current;


### PR DESCRIPTION
## Summary
- adjust the iris shader to show the incoming frame inside the closing aperture

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb3c0578a48323915e59580d41ec8a