### PR TITLE
Provide Sway IPC socket discovery for wifi overlay

### DIFF
--- a/crates/wifi-manager/src/config.rs
+++ b/crates/wifi-manager/src/config.rs
@@ -54,6 +54,8 @@ pub struct OverlayConfig {
     pub photo_app_id: String,
     #[serde(default = "default_overlay_app_id")]
     pub overlay_app_id: String,
+    #[serde(default)]
+    pub sway_socket: Option<PathBuf>,
 }
 
 impl Config {
@@ -91,6 +93,7 @@ impl Default for OverlayConfig {
             command: default_overlay_command(),
             photo_app_id: default_photo_app_id(),
             overlay_app_id: default_overlay_app_id(),
+            sway_socket: None,
         }
     }
 }

--- a/crates/wifi-manager/src/overlay/mod.rs
+++ b/crates/wifi-manager/src/overlay/mod.rs
@@ -2,14 +2,17 @@ pub mod ui;
 
 use crate::config::{Config, OverlayConfig};
 use crate::hotspot;
-use anyhow::{Context, Result};
-use std::path::PathBuf;
+use anyhow::{bail, Context, Result};
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 use swayipc::{Connection, Error as SwayError, Node};
 use tokio::process::{Child, Command};
 use tokio::time::sleep;
 use tracing::{debug, info, warn};
+use users::get_current_uid;
 
 #[derive(Clone, Debug)]
 pub struct OverlayRequest {
@@ -64,6 +67,9 @@ impl OverlayController {
             command.arg("--title").arg(title);
         }
         command.env("WINIT_APP_ID", &self.config.overlay_app_id);
+        if let Ok(socket) = self.ensure_sway_socket_env() {
+            command.env("SWAYSOCK", socket);
+        }
         command.stdout(Stdio::null());
         command.stderr(Stdio::null());
 
@@ -135,6 +141,9 @@ impl OverlayController {
 
     async fn run_commands(&self, commands: Vec<String>) -> Result<()> {
         let overlay_app = self.config.overlay_app_id.clone();
+        self.ensure_sway_socket_env()
+            .context("failed to configure sway IPC environment")?;
+
         tokio::task::spawn_blocking(move || {
             let mut conn = Connection::new().context("failed to connect to sway IPC")?;
             for command in commands {
@@ -163,12 +172,58 @@ impl OverlayController {
 
     async fn overlay_present(&self) -> Result<bool> {
         let app_id = self.config.overlay_app_id.clone();
+        self.ensure_sway_socket_env()
+            .context("failed to configure sway IPC environment")?;
         Ok(tokio::task::spawn_blocking(move || -> Result<bool> {
             let mut conn = Connection::new().context("failed to connect to sway IPC")?;
             let tree = conn.get_tree().context("failed to query sway tree")?;
             Ok(find_app(&tree, &app_id))
         })
         .await??)
+    }
+}
+
+impl OverlayController {
+    fn ensure_sway_socket_env(&self) -> Result<PathBuf> {
+        let socket = self.locate_sway_socket()?;
+        let current = std::env::var_os("SWAYSOCK");
+        let needs_update = current
+            .as_ref()
+            .map(|value| Path::new(value) != socket.as_path())
+            .unwrap_or(true);
+        if needs_update {
+            debug!(path = %socket.display(), "configuring sway IPC socket");
+            set_env_path("SWAYSOCK", &socket);
+        }
+        Ok(socket)
+    }
+
+    fn locate_sway_socket(&self) -> Result<PathBuf> {
+        if let Some(path) = &self.config.sway_socket {
+            return Ok(path.clone());
+        }
+
+        if let Some(path) = std::env::var_os("SWAYSOCK") {
+            return Ok(PathBuf::from(path));
+        }
+
+        for dir in self.runtime_dirs() {
+            if let Some(socket) = find_socket_in_dir(&dir)? {
+                return Ok(socket);
+            }
+        }
+
+        bail!("failed to locate sway IPC socket; set overlay.sway-socket or export SWAYSOCK");
+    }
+
+    fn runtime_dirs(&self) -> Vec<PathBuf> {
+        let mut dirs = Vec::new();
+        if let Some(dir) = std::env::var_os("XDG_RUNTIME_DIR") {
+            dirs.push(PathBuf::from(dir));
+        }
+        let uid = get_current_uid();
+        dirs.push(PathBuf::from(format!("/run/user/{uid}")));
+        dirs
     }
 }
 
@@ -195,6 +250,48 @@ fn find_app(node: &Node, app_id: &str) -> bool {
             .floating_nodes
             .iter()
             .any(|child| find_app(child, app_id))
+}
+
+fn find_socket_in_dir(dir: &Path) -> Result<Option<PathBuf>> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            return Ok(None);
+        }
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("failed to read sway runtime dir at {}", dir.display()));
+        }
+    };
+
+    for entry in entries {
+        let entry = entry.with_context(|| {
+            format!(
+                "failed to inspect sway runtime dir entry in {}",
+                dir.display()
+            )
+        })?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if name.starts_with("sway-ipc.") && name.ends_with(".sock") {
+            return Ok(Some(path));
+        }
+    }
+
+    Ok(None)
+}
+
+fn set_env_path(key: &str, value: &Path) {
+    // SAFETY: `key` has no interior nulls, and `value` comes from filesystem paths,
+    // which likewise cannot contain interior null bytes on Unix platforms.
+    unsafe {
+        std::env::set_var(key, value);
+    }
 }
 
 pub fn overlay_request(config: &Config) -> OverlayRequest {

--- a/docs/wifi-manager.md
+++ b/docs/wifi-manager.md
@@ -53,6 +53,7 @@ overlay:
     - overlay
   photo-app-id: rust-photo-frame
   overlay-app-id: wifi-overlay
+  # sway-socket: /run/user/1000/sway-ipc.1000.123.sock
 ```
 
 | Key                            | Description                                                                                      |
@@ -70,6 +71,7 @@ overlay:
 | `overlay.command`              | Executable invoked to render the on-device hotspot instructions (default `wifi-manager overlay`). |
 | `overlay.photo-app-id`         | Sway `app_id` assigned to the photo frame window so it can be re-focused after recovery. |
 | `overlay.overlay-app-id`       | Sway `app_id` that the overlay binary advertises; used for focus/teardown commands. |
+| `overlay.sway-socket`          | Optional override for the Sway IPC socket. Detected automatically from `/run/user/<uid>` when omitted. |
 
 Whenever you change the config, run `sudo systemctl restart wifi-manager` for the daemon to pick up the new settings.
 

--- a/setup/assets/app/etc/wifi-manager.yaml
+++ b/setup/assets/app/etc/wifi-manager.yaml
@@ -17,3 +17,4 @@ overlay:
     - overlay
   photo-app-id: rust-photo-frame
   overlay-app-id: wifi-overlay
+  # sway-socket: /run/user/1000/sway-ipc.1000.123.sock


### PR DESCRIPTION
## Summary
- add an optional `overlay.sway-socket` config field and auto-discover the compositor socket when absent
- configure the overlay controller to export `SWAYSOCK` for spawned UI and IPC commands so focus/fullscreen succeed
- document the new config surface in the wifi-manager reference and template

## Testing
- cargo check -p wifi-manager

------
https://chatgpt.com/codex/tasks/task_e_68eb3c244bfc8323b92a169fcb418c72