### PR TITLE
Fix systemd shim path in setup scripts

### DIFF
--- a/setup/system/lib/systemd.sh
+++ b/setup/system/lib/systemd.sh
@@ -1,1 +1,7 @@
-../../lib/systemd.sh
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+_system_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../lib/systemd.sh
+source "${_system_lib_dir}/../../lib/systemd.sh"
+unset _system_lib_dir


### PR DESCRIPTION
## Summary
- replace the placeholder systemd shim in `setup/system/lib/systemd.sh` with a wrapper that re-sources the shared library
- ensure modules can source the shared systemd helpers without failing on missing relative paths

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebb080e6e08323bb07f855e0789c7f