### PR TITLE
Rework iris transition to polygonal aperture

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -39,12 +39,8 @@ transition:
       flash-color: [0, 0, 0]
     iris:
       duration-ms: 520
-      style: polygon
-      edge-softness-px: 16.0
       blades: 6
-      curvature: 0.4
-      center-x: 0.5
-      center-y: 0.5
+      curvature: 0.1
       direction: open
 
 # Dwell time (ms) the current image remains fully displayed before the next transition

--- a/crates/photo-frame/src/config.rs
+++ b/crates/photo-frame/src/config.rs
@@ -2603,7 +2603,7 @@ impl TransitionOptions {
             TransitionKind::Wipe => (400, TransitionMode::Wipe(WipeTransition::default())),
             TransitionKind::Push => (400, TransitionMode::Push(PushTransition::default())),
             TransitionKind::EInk => (1600, TransitionMode::EInk(EInkTransition::default())),
-            TransitionKind::Iris => (500, TransitionMode::Iris(IrisTransition::default())),
+            TransitionKind::Iris => (520, TransitionMode::Iris(IrisTransition::default())),
         };
         Self {
             kind,
@@ -2701,14 +2701,8 @@ impl TransitionOptions {
             TransitionKind::Iris => {
                 let defaults = IrisTransition::default();
                 TransitionMode::Iris(IrisTransition {
-                    style: builder.iris_style.unwrap_or(defaults.style),
-                    edge_softness_px: builder
-                        .iris_edge_softness_px
-                        .unwrap_or(defaults.edge_softness_px),
                     blades: builder.iris_blades.unwrap_or(defaults.blades),
                     curvature: builder.iris_curvature.unwrap_or(defaults.curvature),
-                    center_x: builder.iris_center_x.unwrap_or(defaults.center_x),
-                    center_y: builder.iris_center_y.unwrap_or(defaults.center_y),
                     direction: builder.iris_direction.unwrap_or(defaults.direction),
                 })
             }
@@ -2925,19 +2919,6 @@ impl Default for EInkTransition {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum IrisStyle {
-    Circular,
-    Polygon,
-}
-
-impl Default for IrisStyle {
-    fn default() -> Self {
-        Self::Circular
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "kebab-case")]
 pub enum IrisDirection {
     Open,
     Close,
@@ -2951,24 +2932,16 @@ impl Default for IrisDirection {
 
 #[derive(Debug, Clone)]
 pub struct IrisTransition {
-    pub style: IrisStyle,
-    pub edge_softness_px: f32,
     pub blades: u32,
     pub curvature: f32,
-    pub center_x: f32,
-    pub center_y: f32,
     pub direction: IrisDirection,
 }
 
 impl Default for IrisTransition {
     fn default() -> Self {
         Self {
-            style: IrisStyle::default(),
-            edge_softness_px: 18.0,
             blades: 6,
-            curvature: 0.35,
-            center_x: 0.5,
-            center_y: 0.5,
+            curvature: 0.1,
             direction: IrisDirection::default(),
         }
     }
@@ -2976,38 +2949,17 @@ impl Default for IrisTransition {
 
 impl IrisTransition {
     fn normalize(&mut self, kind: TransitionKind) -> Result<()> {
-        ensure!(
-            self.edge_softness_px.is_finite(),
-            format!(
-                "transition option {} has non-finite iris.edge-softness-px",
-                kind
-            )
-        );
-        ensure!(
-            self.edge_softness_px >= 0.0,
-            format!(
-                "transition option {} requires iris.edge-softness-px >= 0",
-                kind
-            )
-        );
-        if self.blades == 0 {
-            self.blades = 1;
+        if self.blades < 3 {
+            self.blades = 3;
+        }
+        if self.blades > 12 {
+            self.blades = 12;
         }
         ensure!(
             self.curvature.is_finite(),
             format!("transition option {} has non-finite iris.curvature", kind)
         );
         self.curvature = self.curvature.clamp(0.0, 1.0);
-        ensure!(
-            self.center_x.is_finite(),
-            format!("transition option {} has non-finite iris.center-x", kind)
-        );
-        ensure!(
-            self.center_y.is_finite(),
-            format!("transition option {} has non-finite iris.center-y", kind)
-        );
-        self.center_x = self.center_x.clamp(0.0, 1.0);
-        self.center_y = self.center_y.clamp(0.0, 1.0);
         Ok(())
     }
 }
@@ -3291,12 +3243,8 @@ struct TransitionOptionBuilder {
     eink_reveal_portion: Option<f32>,
     eink_stripe_count: Option<u32>,
     eink_flash_color: Option<[u8; 3]>,
-    iris_style: Option<IrisStyle>,
-    iris_edge_softness_px: Option<f32>,
     iris_blades: Option<u32>,
     iris_curvature: Option<f32>,
-    iris_center_x: Option<f32>,
-    iris_center_y: Option<f32>,
     iris_direction: Option<IrisDirection>,
 }
 
@@ -3352,23 +3300,11 @@ fn apply_transition_inline_field<E: de::Error>(
         "flash-color" if matches!(kind, TransitionKind::EInk) => {
             builder.eink_flash_color = Some(inline_value_to::<[u8; 3], E>(value)?);
         }
-        "style" if matches!(kind, TransitionKind::Iris) => {
-            builder.iris_style = Some(inline_value_to::<IrisStyle, E>(value)?);
-        }
-        "edge-softness-px" if matches!(kind, TransitionKind::Iris) => {
-            builder.iris_edge_softness_px = Some(inline_value_to::<f32, E>(value)?);
-        }
         "blades" if matches!(kind, TransitionKind::Iris) => {
             builder.iris_blades = Some(inline_value_to::<u32, E>(value)?);
         }
         "curvature" if matches!(kind, TransitionKind::Iris) => {
             builder.iris_curvature = Some(inline_value_to::<f32, E>(value)?);
-        }
-        "center-x" if matches!(kind, TransitionKind::Iris) => {
-            builder.iris_center_x = Some(inline_value_to::<f32, E>(value)?);
-        }
-        "center-y" if matches!(kind, TransitionKind::Iris) => {
-            builder.iris_center_y = Some(inline_value_to::<f32, E>(value)?);
         }
         "direction" if matches!(kind, TransitionKind::Iris) => {
             builder.iris_direction = Some(inline_value_to::<IrisDirection, E>(value)?);
@@ -3387,12 +3323,8 @@ fn apply_transition_inline_field<E: de::Error>(
                     "reveal-portion",
                     "stripe-count",
                     "flash-color",
-                    "style",
-                    "edge-softness-px",
                     "blades",
                     "curvature",
-                    "center-x",
-                    "center-y",
                     "direction",
                 ],
             ));

--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -3,8 +3,8 @@ pub mod scenes;
 use self::scenes::{GreetingScene, Scene, SceneContext, SleepScene};
 
 use crate::config::{
-    IrisDirection, IrisStyle, MattingConfig, MattingMode, MattingOptions, TransitionKind,
-    TransitionMode, TransitionOptions,
+    IrisDirection, MattingConfig, MattingMode, MattingOptions, TransitionKind, TransitionMode,
+    TransitionOptions,
 };
 use crate::events::{
     Displayed, PhotoLoaded, PreparedImageCpu, ViewerCommand, ViewerState as ControlViewerState,
@@ -45,11 +45,8 @@ pub(super) enum ActiveTransition {
         noise_seed: [f32; 2],
     },
     Iris {
-        style: IrisStyle,
-        edge_softness_px: f32,
         blades: u32,
         curvature: f32,
-        center: [f32; 2],
         direction: IrisDirection,
     },
 }
@@ -124,11 +121,8 @@ impl TransitionState {
                 noise_seed: [rng.random_range(0.0..=1.0), rng.random_range(0.0..=1.0)],
             },
             TransitionMode::Iris(cfg) => ActiveTransition::Iris {
-                style: cfg.style,
-                edge_softness_px: cfg.edge_softness_px.max(0.0),
-                blades: cfg.blades.max(1),
+                blades: cfg.blades.max(3).min(12),
                 curvature: cfg.curvature.clamp(0.0, 1.0),
-                center: [cfg.center_x.clamp(0.0, 1.0), cfg.center_y.clamp(0.0, 1.0)],
                 direction: cfg.direction,
             },
         };
@@ -2027,26 +2021,20 @@ pub fn run_windowed(
                                         uniforms.params1[3] = flash_color[2].clamp(0.0, 1.0);
                                     }
                                     ActiveTransition::Iris {
-                                        style,
-                                        edge_softness_px,
                                         blades,
                                         curvature,
-                                        center,
                                         direction,
                                     } => {
-                                        uniforms.params0[0] = match style {
-                                            IrisStyle::Circular => 0.0,
-                                            IrisStyle::Polygon => 1.0,
-                                        };
-                                        uniforms.params0[1] = match direction {
+                                        uniforms.params0[0] = match direction {
                                             IrisDirection::Open => 1.0,
                                             IrisDirection::Close => -1.0,
                                         };
-                                        uniforms.params0[2] = (*edge_softness_px).max(0.0);
-                                        uniforms.params0[3] = (*curvature).clamp(0.0, 1.0);
-                                        uniforms.params1[0] = (*blades).max(1) as f32;
-                                        uniforms.params1[1] = center[0].clamp(0.0, 1.0);
-                                        uniforms.params1[2] = center[1].clamp(0.0, 1.0);
+                                        uniforms.params0[1] = (*curvature).clamp(0.0, 1.0);
+                                        uniforms.params0[2] = 0.0;
+                                        uniforms.params0[3] = 0.0;
+                                        uniforms.params1[0] = (*blades).max(3) as f32;
+                                        uniforms.params1[1] = 0.0;
+                                        uniforms.params1[2] = 0.0;
                                         uniforms.params1[3] = 0.0;
                                     }
                                 }

--- a/crates/photo-frame/tests/config_tests.rs
+++ b/crates/photo-frame/tests/config_tests.rs
@@ -1,6 +1,6 @@
 use rand::{SeedableRng, rngs::StdRng};
 use rust_photo_frame::config::{
-    ColorSelection, Configuration, FixedImagePathSelection, IrisDirection, IrisStyle, MattingKind,
+    ColorSelection, Configuration, FixedImagePathSelection, IrisDirection, MattingKind,
     MattingMode, MattingSelection, StudioMatColor, TransitionKind, TransitionSelection,
 };
 use std::path::PathBuf;
@@ -485,12 +485,8 @@ photo-library-path: "/photos"
 transition:
   types: [iris]
   duration-ms: 640
-  style: polygon
-  edge-softness-px: 14.5
   blades: 8
   curvature: 0.25
-  center-x: 0.45
-  center-y: 0.6
   direction: close
 "#;
 
@@ -506,12 +502,8 @@ transition:
     assert_eq!(iris.duration().as_millis(), 640);
     match iris.mode() {
         rust_photo_frame::config::TransitionMode::Iris(cfg) => {
-            assert_eq!(cfg.style, IrisStyle::Polygon);
-            assert!((cfg.edge_softness_px - 14.5).abs() < f32::EPSILON);
             assert_eq!(cfg.blades, 8);
             assert!((cfg.curvature - 0.25).abs() < f32::EPSILON);
-            assert!((cfg.center_x - 0.45).abs() < f32::EPSILON);
-            assert!((cfg.center_y - 0.6).abs() < f32::EPSILON);
             assert_eq!(cfg.direction, IrisDirection::Close);
         }
         _ => panic!("expected iris transition"),
@@ -716,19 +708,26 @@ transition:
 }
 
 #[test]
-fn iris_transition_rejects_negative_softness() {
+fn iris_transition_clamps_minimum_blades() {
     let yaml = r#"
 photo-library-path: "/photos"
 transition:
   types: [iris]
-  edge-softness-px: -5.0
+  blades: 1
 "#;
 
-    let err = serde_yaml::from_str::<Configuration>(yaml).unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("requires iris.edge-softness-px >= 0")
-    );
+    let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
+    let iris = cfg
+        .transition
+        .options()
+        .get(&TransitionKind::Iris)
+        .expect("expected iris transition option");
+    match iris.mode() {
+        rust_photo_frame::config::TransitionMode::Iris(cfg) => {
+            assert_eq!(cfg.blades, 3);
+        }
+        _ => panic!("expected iris transition"),
+    }
 }
 
 #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -381,12 +381,9 @@ Each transition exposes a focused set of fields:
   - **`stripe-count`** (integer ≥ 1, default `24`): How many horizontal bands sweep in; higher counts mimic a finer e-ink refresh.
   - **`flash-color`** (`[r, g, b]` array, default `[255, 255, 255]`): RGB color used for the bright flash phases before the black inversion. Channels outside `0–255` are clamped.
 - **`iris`**
-  - **`style`** (`circular` or `polygon`, default `circular`): Switches between a smooth circular reveal and a bladed polygon reminiscent of a camera iris.
-  - **`edge-softness-px`** (float ≥ 0, default `18.0`): Feather width in pixels along the aperture edge.
-  - **`blades`** (integer ≥ 1, default `6`): Number of blades to render when using the polygon style.
-  - **`curvature`** (float `0.0–1.0`, default `0.35`): Controls how rounded the polygon blades appear; higher values yield more circular arcs.
-  - **`center-x`** and **`center-y`** (floats `0.0–1.0`, defaults `0.5`): Offset the iris center relative to the frame, enabling asymmetric reveals.
-  - **`direction`** (`open` or `close`, default `open`): Whether the iris blooms outward from a closed state or collapses inward to reveal the next slide.
+  - **`blades`** (integer ≥ 3, default `6`): Number of straight-sided blades that form the aperture polygon. Values above `12` are clamped for performance.
+  - **`curvature`** (float `0.0–1.0`, default `0.1`): Blends between crisp polygon edges (`0.0`) and a nearly circular opening (`1.0`).
+  - **`direction`** (`open` or `close`, default `open`): `open` grows the aperture to reveal the next slide, while `close` shrinks it back down from full frame.
 
 ## Matting configuration
 


### PR DESCRIPTION
## Summary
- simplify the iris transition configuration to blades/curvature/direction with a 520 ms default
- update the viewer pipeline and shader to draw a polygonal aperture with curvature-controlled rounding
- refresh docs, sample config, and tests for the streamlined iris transition

## Testing
- cargo test -p rust-photo-frame config_tests

------
https://chatgpt.com/codex/tasks/task_e_68ebb99b8470832389695b567ed2009a