### PR TITLE
Rework iris transition with polygonal blades

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -39,12 +39,8 @@ transition:
       flash-color: [0, 0, 0]
     iris:
       duration-ms: 520
-      style: polygon
-      edge-softness-px: 16.0
       blades: 6
-      curvature: 0.4
-      center-x: 0.5
-      center-y: 0.5
+      curvature: 0.1
       direction: open
 
 # Dwell time (ms) the current image remains fully displayed before the next transition

--- a/crates/photo-frame/src/tasks/shaders/viewer_quad.wgsl
+++ b/crates/photo-frame/src/tasks/shaders/viewer_quad.wgsl
@@ -147,39 +147,37 @@ fn fs_main(in: VSOut) -> @location(0) vec4<f32> {
       }
     }
     case 5u: {
-      let style = U.params0.x;
+      let min_shape = clamp(U.params0.x, 1e-4, 1.0);
       let direction = U.params0.y;
-      let softness_px = max(U.params0.z, 0.0);
-      let curvature = clamp(U.params0.w, 0.0, 1.0);
-      let blades = max(U.params1.x, 1.0);
-      let center = vec2<f32>(clamp(U.params1.y, 0.0, 1.0), clamp(U.params1.z, 0.0, 1.0));
-      let max_dim = max(max(U.screen_size.x, U.screen_size.y), 1.0);
-      let softness = softness_px / max_dim;
-      let rel = in.screen_uv - center;
-      let dist = length(rel);
-      var effective_dist = dist;
-      if (style > 0.5) {
-        let angle = atan2(rel.y, rel.x);
-        let wave = abs(cos(blades * angle * 0.5));
-        let scale = max(mix(wave, 1.0, curvature), 1e-3);
-        effective_dist = dist / scale;
-      }
-      let corners = array<vec2<f32>, 4>(
-        vec2<f32>(0.0, 0.0),
-        vec2<f32>(0.0, 1.0),
-        vec2<f32>(1.0, 0.0),
-        vec2<f32>(1.0, 1.0)
-      );
-      var max_radius = 0.0;
-      for (var i: i32 = 0; i < 4; i = i + 1) {
-        max_radius = max(max_radius, distance(center, corners[i]));
-      }
+      let curvature = clamp(U.params0.z, 0.0, 1.0);
+      let cos_half = clamp(U.params0.w, 1e-4, 1.0);
+      let blade_angle = max(U.params1.x, 1e-4);
+      let feather_factor = max(U.params1.y, 0.0);
       let progress = clamp(U.progress, 0.0, 1.0);
+      let aspect = U.screen_size.x / max(U.screen_size.y, 1.0);
+      let rel = vec2<f32>((in.screen_uv.x - 0.5) * aspect, in.screen_uv.y - 0.5);
+      let dist = length(rel);
+      let angle = atan2(rel.y, rel.x);
+      let inv_sector = 1.0 / blade_angle;
+      let wrapped = angle - blade_angle * floor(angle * inv_sector);
+      let offset = wrapped - blade_angle * 0.5;
+      let denom = cos(offset);
+      let polygon_norm = cos_half / max(denom, 1e-3);
+      let shape_factor = mix(polygon_norm, 1.0, curvature);
+      let max_radius = length(vec2<f32>(aspect * 0.5, 0.5));
+      let base_radius = max_radius / max(min_shape, 1e-3);
       let openness = select(1.0 - progress, progress, direction > 0.0);
-      let base_radius = max_radius * clamp(openness, 0.0, 1.0);
-      let feather = max(softness, 1e-4);
-      let mask = smoothstep(base_radius - feather, base_radius + feather, effective_dist);
-      color = mix(next, current, mask);
+      let aperture = clamp(openness, 0.0, 1.0);
+      let target_radius = base_radius * aperture * shape_factor;
+      let feather = max(max_radius * feather_factor, 1e-4);
+      var iris_cover = 1.0;
+      if (aperture > 1e-4) {
+        iris_cover = smoothstep(target_radius - feather, target_radius + feather, dist);
+      }
+      if (aperture >= 0.999) {
+        iris_cover = 0.0;
+      }
+      color = mix(next, current, iris_cover);
     }
     default: {
       color = current;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -381,12 +381,9 @@ Each transition exposes a focused set of fields:
   - **`stripe-count`** (integer ≥ 1, default `24`): How many horizontal bands sweep in; higher counts mimic a finer e-ink refresh.
   - **`flash-color`** (`[r, g, b]` array, default `[255, 255, 255]`): RGB color used for the bright flash phases before the black inversion. Channels outside `0–255` are clamped.
 - **`iris`**
-  - **`style`** (`circular` or `polygon`, default `circular`): Switches between a smooth circular reveal and a bladed polygon reminiscent of a camera iris.
-  - **`edge-softness-px`** (float ≥ 0, default `18.0`): Feather width in pixels along the aperture edge.
-  - **`blades`** (integer ≥ 1, default `6`): Number of blades to render when using the polygon style.
-  - **`curvature`** (float `0.0–1.0`, default `0.35`): Controls how rounded the polygon blades appear; higher values yield more circular arcs.
-  - **`center-x`** and **`center-y`** (floats `0.0–1.0`, defaults `0.5`): Offset the iris center relative to the frame, enabling asymmetric reveals.
-  - **`direction`** (`open` or `close`, default `open`): Whether the iris blooms outward from a closed state or collapses inward to reveal the next slide.
+  - **`blades`** (integer ≥ 1, default `6`): Number of iris blades used to form the polygonal aperture.
+  - **`curvature`** (float `0.0–1.0`, default `0.1`): Blends between sharp polygon edges (`0.0`) and a subtly rounded iris (`1.0`).
+  - **`direction`** (`open` or `close`, default `open`): Whether the iris blooms outward from a closed state or collapses inward to finish the transition.
 
 ## Matting configuration
 


### PR DESCRIPTION
## Summary
- Simplify the iris transition configuration to a centered polygonal aperture with blades/curvature controls and updated defaults
- Update the viewer pipeline and shader to render a bladed iris opening/closing efficiently on the GPU
- Refresh documentation, sample config, and tests to reflect the new iris controls

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ebb99b8470832389695b567ed2009a