### PR TITLE
Fix seatd-launch invocation in greetd session wrapper

### DIFF
--- a/setup/system/modules/50-greetd.sh
+++ b/setup/system/modules/50-greetd.sh
@@ -61,7 +61,7 @@ runner=()
 if command -v dbus-run-session >/dev/null 2>&1; then
     runner+=(dbus-run-session)
     if command -v seatd-launch >/dev/null 2>&1; then
-        runner+=(seatd-launch)
+        runner+=(seatd-launch "--")
     fi
 fi
 


### PR DESCRIPTION
## Summary
- ensure the photoframe-session wrapper includes a "--" terminator when launching sway through seatd-launch

## Testing
- PATH="/tmp/testbin:$PATH" seatd-launch -- sway -c /usr/local/share/photoframe/sway/config

------
https://chatgpt.com/codex/tasks/task_e_68ebbd0db3248323948f68417f68b0b7