### PR TITLE
Fix viewer shutdown join handling

### DIFF
--- a/crates/photo-frame/Cargo.toml
+++ b/crates/photo-frame/Cargo.toml
@@ -23,6 +23,7 @@ chrono = { version = "0.4.38", features = ["serde"] }
 chrono-tz = { version = "0.10.0", features = ["serde"] }
 crossbeam-channel = "0.5.15"
 tokio = { version = "1.47.1", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "net", "io-util"] }
+futures = "0.3.31"
 tokio-util = "0.7.16"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["fmt", "env-filter"] }


### PR DESCRIPTION
## Summary
- add `futures` as a dependency so the viewer shutdown path can block on async joins without `Handle::block_on`
- wrap the control driver and command forwarder joins in `tokio::task::block_in_place` to avoid nested runtime usage and keep abort semantics intact
- log non-cancelled join errors during shutdown for better visibility

## Testing
- cargo fmt
- cargo check -p rust-photo-frame

------
https://chatgpt.com/codex/tasks/task_e_68ebbd0f683883239e966e539557a1f9