### PR TITLE
Avoid seatd-launch when seatd service is active

### DIFF
--- a/setup/system/modules/50-greetd.sh
+++ b/setup/system/modules/50-greetd.sh
@@ -60,10 +60,10 @@ runner=()
 
 if command -v dbus-run-session >/dev/null 2>&1; then
     runner+=(dbus-run-session)
-    if command -v seatd-launch >/dev/null 2>&1; then
-        runner+=(seatd-launch "--")
-    fi
 fi
+
+# seatd.service already provides the compositor with a socket, so avoid
+# wrapping sway in seatd-launch (which would fail when seatd is active).
 
 if [[ ${#runner[@]} -eq 0 ]]; then
     exec systemd-cat -t rust-photo-frame -- "${CMD[@]}"


### PR DESCRIPTION
## Summary
- keep the greetd session wrapper calling sway directly when dbus-run-session is available
- document why seatd-launch is intentionally skipped while seatd.service is running

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ebc2e99eec8323b11f3f7204808c4a