### PR TITLE
Handle viewer surface readiness before matting

### DIFF
--- a/crates/photo-frame/src/tasks/viewer/scenes/mod.rs
+++ b/crates/photo-frame/src/tasks/viewer/scenes/mod.rs
@@ -320,6 +320,11 @@ impl WakeScene {
         self.current = current;
     }
 
+    /// Removes and returns the current image, if present.
+    pub(super) fn take_current(&mut self) -> Option<ImgTex> {
+        self.current.take()
+    }
+
     /// Returns the next staged image.
     pub(super) fn next(&self) -> Option<&ImgTex> {
         self.next.as_ref()


### PR DESCRIPTION
## Summary
- track the viewer surface readiness state so matting only starts once real dimensions arrive and reset that flag on teardown
- retain CPU copies of mats, flush outdated entries on resize, and push them back through the pipeline so textures match the new surface size
- emit debug tracing around the matting guard to make it obvious when the pipeline begins processing

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68ebcb7385dc8323ae6be353dfc00997