### PR TITLE
Improve iris transition with animated shutter outlines

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -38,10 +38,15 @@ transition:
       stripe-count: 24
       flash-color: [0, 0, 0]
     iris:
-      duration-ms: 520
-      blades: 6
-      curvature: 0.1
+      duration-ms: 900
+      blades: 7
       direction: open
+      line-rgba: [0.95, 0.95, 0.95, 0.35]
+      arc-rgba: [0.95, 0.95, 0.95, 0.20]
+      line-thickness-px: 2.0
+      taper: 0.6
+      vignette: 0.2
+      easing: cubic
 
 # Dwell time (ms) the current image remains fully displayed before the next transition
 dwell-ms: 2000

--- a/crates/photo-frame/tests/config_tests.rs
+++ b/crates/photo-frame/tests/config_tests.rs
@@ -1,6 +1,6 @@
 use rand::{SeedableRng, rngs::StdRng};
 use rust_photo_frame::config::{
-    ColorSelection, Configuration, FixedImagePathSelection, IrisDirection, MattingKind,
+    ColorSelection, Configuration, FixedImagePathSelection, IrisDirection, IrisEasing, MattingKind,
     MattingMode, MattingSelection, StudioMatColor, TransitionKind, TransitionSelection,
 };
 use std::path::PathBuf;
@@ -484,10 +484,15 @@ fn parse_inline_iris_transition() {
 photo-library-path: "/photos"
 transition:
   types: [iris]
-  duration-ms: 640
-  blades: 7
-  curvature: 0.25
+  duration-ms: 880
+  blades: 9
   direction: close
+  line-rgba: [0.8, 0.7, 0.6, 0.5]
+  arc-rgba: [0.2, 0.3, 0.4, 0.25]
+  line-thickness-px: 3.5
+  taper: 0.4
+  vignette: 0.15
+  easing: linear
 "#;
 
     let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
@@ -499,12 +504,17 @@ transition:
     let iris = options
         .get(&TransitionKind::Iris)
         .expect("expected iris transition option");
-    assert_eq!(iris.duration().as_millis(), 640);
+    assert_eq!(iris.duration().as_millis(), 880);
     match iris.mode() {
         rust_photo_frame::config::TransitionMode::Iris(cfg) => {
-            assert_eq!(cfg.blades, 7);
-            assert!((cfg.curvature - 0.25).abs() < f32::EPSILON);
+            assert_eq!(cfg.blades, 9);
             assert_eq!(cfg.direction, IrisDirection::Close);
+            assert_eq!(cfg.line_rgba, [0.8, 0.7, 0.6, 0.5]);
+            assert_eq!(cfg.arc_rgba, [0.2, 0.3, 0.4, 0.25]);
+            assert!((cfg.line_thickness_px - 3.5).abs() < f32::EPSILON);
+            assert!((cfg.taper - 0.4).abs() < f32::EPSILON);
+            assert!((cfg.vignette - 0.15).abs() < f32::EPSILON);
+            assert_eq!(cfg.easing, IrisEasing::Linear);
         }
         _ => panic!("expected iris transition"),
     }
@@ -724,7 +734,7 @@ transition:
         .expect("expected iris transition option");
     match iris.mode() {
         rust_photo_frame::config::TransitionMode::Iris(cfg) => {
-            assert_eq!(cfg.blades, 1);
+            assert_eq!(cfg.blades, 5);
         }
         _ => panic!("expected iris transition"),
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -381,9 +381,14 @@ Each transition exposes a focused set of fields:
   - **`stripe-count`** (integer ≥ 1, default `24`): How many horizontal bands sweep in; higher counts mimic a finer e-ink refresh.
   - **`flash-color`** (`[r, g, b]` array, default `[255, 255, 255]`): RGB color used for the bright flash phases before the black inversion. Channels outside `0–255` are clamped.
 - **`iris`**
-  - **`blades`** (integer ≥ 1, default `6`): Number of iris blades used to form the polygonal aperture.
-  - **`curvature`** (float `0.0–1.0`, default `0.1`): Blends between sharp polygon edges (`0.0`) and a subtly rounded iris (`1.0`).
-  - **`direction`** (`open` or `close`, default `open`): Whether the iris blooms outward from a closed state or collapses inward to finish the transition.
+  - **`blades`** (integer, default `7`, clamped to `5–18`): Number of shutter spokes sketched around the aperture.
+  - **`direction`** (`open` or `close`, default `open`): Choose whether the aperture grows (`open`) or shrinks (`close`) as the next image is revealed. Rotation direction mirrors the choice.
+  - **`line-rgba`** (`[r, g, b, a]` float array, default `[0.95, 0.95, 0.95, 0.35]`): Stroke color for the animated shutter spokes. Channels outside `0–1` are clamped.
+  - **`arc-rgba`** (`[r, g, b, a]` float array, default `[0.95, 0.95, 0.95, 0.20]`): Accent color for the short arc hints drawn along the aperture edge.
+  - **`line-thickness-px`** (float ≥ 0, default `2.0`): Approximate thickness of the spoke outlines in screen pixels.
+  - **`taper`** (float `0.0–1.0`, default `0.6`): Controls how aggressively the spokes taper as they extend outward; `0` keeps a uniform width.
+  - **`vignette`** (float `0.0–1.0`, default `0.2`): Strength of the subtle darkening toward the screen corners to emphasize the circular aperture.
+  - **`easing`** (`linear` or `cubic`, default `cubic`): Selects the easing curve applied to the shutter progress. `cubic` matches the default smooth ease-in-out, while `linear` sticks to the raw transition timeline.
 
 ## Matting configuration
 


### PR DESCRIPTION
## Summary
- replace the iris transition shader with a circular aperture that reveals the incoming photo and overlays rotating shutter spokes and arc hints
- extend the iris configuration surface with styling controls, easing selection, and refreshed defaults
- document the new options, update the sample configuration, and expand config parsing tests

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ebcb541fbc8323ab7312b1d59ba917