### PR TITLE
Rework iris transition with shutter blades

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -40,13 +40,7 @@ transition:
     iris:
       duration-ms: 900
       blades: 7
-      direction: open
-      line-rgba: [0.95, 0.95, 0.95, 0.35]
-      arc-rgba: [0.95, 0.95, 0.95, 0.20]
-      line-thickness-px: 2.0
-      taper: 0.6
-      vignette: 0.2
-      easing: cubic
+      blade-rgba: [0.12, 0.12, 0.12, 1.0]
 
 # Dwell time (ms) the current image remains fully displayed before the next transition
 dwell-ms: 2000

--- a/crates/photo-frame/src/tasks/shaders/viewer_quad.wgsl
+++ b/crates/photo-frame/src/tasks/shaders/viewer_quad.wgsl
@@ -149,84 +149,53 @@ fn fs_main(in: VSOut) -> @location(0) vec4<f32> {
       }
     }
     case 5u: {
-      let blades = max(U.params0.x, 1.0);
-      let direction_sign = U.params0.y;
-      let line_thickness_px = max(U.params0.z, 0.0);
-      let taper = clamp(U.params0.w, 0.0, 1.0);
-      let rotation_amp = U.params1.x;
-      let feather_factor = max(U.params1.y, 0.0);
-      let vignette_strength = clamp(U.params1.z, 0.0, 1.0);
-      let noise_amount = clamp(U.params1.w, 0.0, 1.0);
-      let line_color = U.params2;
-      let arc_color = U.params3;
-      let base_progress = clamp(U.progress, 0.0, 1.0);
-      var aperture_progress = base_progress;
-      if (direction_sign < 0.0) {
-        aperture_progress = 1.0 - base_progress;
-      }
+      let blades = max(U.params0.x, 3.0);
+      let blade_rgb_base = clamp(U.params1.xyz, vec3<f32>(0.0), vec3<f32>(1.0));
+      let blade_alpha = clamp(U.params1.w, 0.0, 1.0);
       let aspect = U.screen_size.x / max(U.screen_size.y, 1.0);
       let rel = vec2<f32>((in.screen_uv.x - 0.5) * aspect, in.screen_uv.y - 0.5);
       let dist = length(rel);
       let angle = atan2(rel.y, rel.x);
       let max_radius = length(vec2<f32>(aspect * 0.5, 0.5));
-      let aperture_radius = max_radius * aperture_progress;
-      let feather = max(max_radius * feather_factor, 1e-4);
-      var cover = 1.0;
-      if (aperture_progress > 1e-4) {
-        cover = smoothstep(aperture_radius - feather, aperture_radius + feather, dist);
+      let clamped_progress = clamp(U.progress, 0.0, 1.0);
+      let phase = clamped_progress * 2.0;
+      let close_phase = clamp(phase, 0.0, 1.0);
+      let open_phase = clamp(phase - 1.0, 0.0, 1.0);
+      let close_curve = close_phase * close_phase * (3.0 - 2.0 * close_phase);
+      let open_curve = open_phase * open_phase * (3.0 - 2.0 * open_phase);
+      let is_opening = step(1.0, phase);
+      let aperture_ratio = (1.0 - is_opening) * (1.0 - close_curve) + is_opening * open_curve;
+      let rotation = (phase - 1.0) * 0.75;
+      let two_pi = 6.28318530718;
+      let sector = two_pi / blades;
+      let half_sector = 0.5 * sector;
+      let wrapped = (angle + rotation + half_sector) / sector;
+      let local_angle = (fract(wrapped) - 0.5) * sector;
+      let cos_local = max(cos(local_angle), 0.0005);
+      let inscribed = max_radius * aperture_ratio;
+      let boundary = min(inscribed / cos_local, max_radius);
+      let edge_softness = max(max_radius * 0.02, 0.001);
+      let mask = 1.0 - smoothstep(-edge_softness, 0.0, dist - boundary);
+      var stage_color = current;
+      if (phase >= 1.0) {
+        stage_color = next;
       }
-      if (aperture_progress >= 0.9995) {
-        cover = 0.0;
-      }
-      let next_weight = clamp(1.0 - cover, 0.0, 1.0);
-      color = mix(current, next, next_weight);
-
-      let rotation = rotation_amp * base_progress * direction_sign;
-      let rotated_angle = angle + rotation;
-      let blades_clamped = max(blades, 1.0);
-      let sin_term = abs(sin(rotated_angle * blades_clamped));
-      let delta_angle = sin_term / blades_clamped;
-      let line_range = max(max_radius - aperture_radius, 1e-4);
-      let outward = max(dist - aperture_radius, 0.0);
-      var line_presence = 0.0;
-      if (line_range > 1e-3) {
-        let entry = smoothstep(0.0, feather * 4.0 + 1e-4, outward);
-        let exit = smoothstep(line_range * 0.85, line_range, outward);
-        line_presence = entry * (1.0 - exit);
-      }
-      let radius_px = max(dist * U.screen_size.y, 1.0);
-      let outward_ratio = clamp(outward / line_range, 0.0, 1.0);
-      let taper_scale = mix(1.0, 1.0 - outward_ratio, taper);
-      let thickness_angle = max(line_thickness_px / radius_px * taper_scale, 1e-4);
-      let angle_ratio = delta_angle / thickness_angle;
-      let line_body = exp(-0.5 * angle_ratio * angle_ratio);
+      let blade_center = clamp(1.0 - abs(local_angle) / half_sector, 0.0, 1.0);
+      let radial = clamp(dist / max_radius, 0.0, 1.0);
+      let highlight = pow(blade_center, 2.4) * 0.28;
+      let radial_shadow = mix(1.05, 0.55, radial);
+      let edge_highlight = smoothstep(-edge_softness * 5.0, 0.0, boundary - dist) * 0.32;
       let noise = fract(
         sin(dot(screen_pos, vec2<f32>(12.9898, 78.233))) * 43758.5453
       );
-      let jitter = (noise - 0.5) * noise_amount;
-      let line_alpha = clamp(line_color.w + jitter, 0.0, 1.0) * line_body * line_presence;
-      color = vec4<f32>(
-        mix(color.rgb, line_color.rgb, clamp(line_alpha, 0.0, 1.0)),
-        color.a,
-      );
-
-      let arc_phase = abs(cos(rotated_angle * blades_clamped));
-      let arc_delta = 1.0 - arc_phase;
-      let arc_body = exp(-arc_delta * 12.0);
-      let arc_inner = smoothstep(-feather * 2.0, feather * 2.0, dist - aperture_radius);
-      let arc_outer = 1.0 - smoothstep(feather * 4.0, feather * 4.0 + 1e-3, dist - aperture_radius);
-      let arc_presence = arc_inner * arc_outer;
-      let arc_alpha = clamp(arc_color.w + jitter * 0.5, 0.0, 1.0) * arc_body * arc_presence;
-      color = vec4<f32>(
-        mix(color.rgb, arc_color.rgb, clamp(arc_alpha, 0.0, 1.0)),
-        color.a,
-      );
-
-      if (vignette_strength > 0.0) {
-        let radius_norm = clamp(dist / max_radius, 0.0, 1.0);
-        let vignette = 1.0 - vignette_strength * smoothstep(0.55, 1.0, radius_norm);
-        color = vec4<f32>(color.rgb * vignette, color.a);
-      }
+      let noise_term = (noise - 0.5) * 0.05;
+      var blade_rgb = blade_rgb_base * radial_shadow + highlight + edge_highlight + noise_term;
+      blade_rgb = clamp(blade_rgb, vec3<f32>(0.0), vec3<f32>(1.0));
+      let blade_strength = clamp(blade_alpha, 0.0, 1.0);
+      blade_rgb = mix(vec3<f32>(0.0), blade_rgb, blade_strength);
+      let blade_color = vec4<f32>(blade_rgb, 1.0);
+      color = mix(blade_color, stage_color, mask);
+      color.a = mix(blade_color.a, stage_color.a, mask);
     }
     default: {
       color = current;

--- a/crates/photo-frame/tests/config_tests.rs
+++ b/crates/photo-frame/tests/config_tests.rs
@@ -1,7 +1,7 @@
 use rand::{SeedableRng, rngs::StdRng};
 use rust_photo_frame::config::{
-    ColorSelection, Configuration, FixedImagePathSelection, IrisDirection, IrisEasing, MattingKind,
-    MattingMode, MattingSelection, StudioMatColor, TransitionKind, TransitionSelection,
+    ColorSelection, Configuration, FixedImagePathSelection, MattingKind, MattingMode,
+    MattingSelection, StudioMatColor, TransitionKind, TransitionSelection,
 };
 use std::path::PathBuf;
 
@@ -486,13 +486,7 @@ transition:
   types: [iris]
   duration-ms: 880
   blades: 9
-  direction: close
-  line-rgba: [0.8, 0.7, 0.6, 0.5]
-  arc-rgba: [0.2, 0.3, 0.4, 0.25]
-  line-thickness-px: 3.5
-  taper: 0.4
-  vignette: 0.15
-  easing: linear
+  blade-rgba: [0.2, 0.22, 0.24, 0.85]
 "#;
 
     let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
@@ -508,13 +502,7 @@ transition:
     match iris.mode() {
         rust_photo_frame::config::TransitionMode::Iris(cfg) => {
             assert_eq!(cfg.blades, 9);
-            assert_eq!(cfg.direction, IrisDirection::Close);
-            assert_eq!(cfg.line_rgba, [0.8, 0.7, 0.6, 0.5]);
-            assert_eq!(cfg.arc_rgba, [0.2, 0.3, 0.4, 0.25]);
-            assert!((cfg.line_thickness_px - 3.5).abs() < f32::EPSILON);
-            assert!((cfg.taper - 0.4).abs() < f32::EPSILON);
-            assert!((cfg.vignette - 0.15).abs() < f32::EPSILON);
-            assert_eq!(cfg.easing, IrisEasing::Linear);
+            assert_eq!(cfg.blade_rgba, [0.2, 0.22, 0.24, 0.85]);
         }
         _ => panic!("expected iris transition"),
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -382,13 +382,9 @@ Each transition exposes a focused set of fields:
   - **`flash-color`** (`[r, g, b]` array, default `[255, 255, 255]`): RGB color used for the bright flash phases before the black inversion. Channels outside `0–255` are clamped.
 - **`iris`**
   - **`blades`** (integer, default `7`, clamped to `5–18`): Number of shutter spokes sketched around the aperture.
-  - **`direction`** (`open` or `close`, default `open`): Choose whether the aperture grows (`open`) or shrinks (`close`) as the next image is revealed. Rotation direction mirrors the choice.
-  - **`line-rgba`** (`[r, g, b, a]` float array, default `[0.95, 0.95, 0.95, 0.35]`): Stroke color for the animated shutter spokes. Channels outside `0–1` are clamped.
-  - **`arc-rgba`** (`[r, g, b, a]` float array, default `[0.95, 0.95, 0.95, 0.20]`): Accent color for the short arc hints drawn along the aperture edge.
-  - **`line-thickness-px`** (float ≥ 0, default `2.0`): Approximate thickness of the spoke outlines in screen pixels.
-  - **`taper`** (float `0.0–1.0`, default `0.6`): Controls how aggressively the spokes taper as they extend outward; `0` keeps a uniform width.
-  - **`vignette`** (float `0.0–1.0`, default `0.2`): Strength of the subtle darkening toward the screen corners to emphasize the circular aperture.
-  - **`easing`** (`linear` or `cubic`, default `cubic`): Selects the easing curve applied to the shutter progress. `cubic` matches the default smooth ease-in-out, while `linear` sticks to the raw transition timeline.
+  - **`blade-rgba`** (`[r, g, b, a]` float array, default `[0.12, 0.12, 0.12, 1.0]`): Base color for the iris blades. Channels outside `0–1` are clamped; the alpha component scales how dark the rendered blades appear.
+
+  The iris transition renders shaded SLR-style blades that first close over the current photo, then reopen to reveal the next one. Each half of the timeline is dedicated to one of those motions, producing a mechanical shutter feel.
 
 ## Matting configuration
 


### PR DESCRIPTION
## Summary
- replace the old configurable iris parameters with a minimal blades + blade color surface and update the docs/sample config
- render an SLR-style iris shader that closes over the current image and reopens to reveal the next photo

## Testing
- `cargo test --workspace --exclude buttond --exclude wifi-manager` *(fails once on `manager_rotates_actual_sent_item`; reran below)*
- `cargo test -p rust-photo-frame --test manager_integration`


------
https://chatgpt.com/codex/tasks/task_e_68ebff47ce94832399f5c57773d741dc