### PR TITLE
Ensure viewer surface readiness is restored after resume

### DIFF
--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -1550,6 +1550,7 @@ pub fn run_windowed(
                 desired_maximum_frame_latency: 2,
             };
             surface.configure(&device, &config);
+            self.update_surface_ready(size.width, size.height);
             debug!(
                 width = config.width,
                 height = config.height,


### PR DESCRIPTION
## Summary
- ensure the viewer marks the GPU surface as ready immediately after reconfiguring it on resume

## Testing
- `cargo test -p rust-photo-frame --test viewer_surface_handshake`


------
https://chatgpt.com/codex/tasks/task_e_68ec4486c4608323ac1cfda3ba1806ba