### PR TITLE
Document selection-based transition and matting configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ flowchart LR
 
 All configuration options—from playlist weighting and greeting screens to transition tuning—are documented in depth, including starter YAML examples and per-key reference tables. [Full details →](docs/configuration.md)
 
+> **Breaking change:** The `transition` and `matting` blocks now use a `selection` + `active` schema. Older `types`/`options` layouts no longer parse—recreate those entries with explicit `kind` fields as shown in the updated configuration guide.
+
 Need help wiring the sleep schedule to Raspberry Pi + Dell HDMI hardware? The dedicated power guide covers DPMS commands, troubleshooting, and verification steps. [Power & sleep details →](docs/power-and-sleep.md)
 
 ## Fabrication

--- a/config.yaml
+++ b/config.yaml
@@ -12,32 +12,31 @@ control-socket-path: /run/photo-frame/control.sock
 
 # Render/transition settings
 transition:
-  # List one or more transition kinds to rotate between.
-  types: [fade, wipe, push, e-ink, iris]
-  # Choose how to iterate through the transition types: random or sequential.
-  type-selection: random
-  options:
-    fade:
+  # Choose how the viewer advances through the entries below: fixed, random, or sequential.
+  selection: random
+  # Declare one or more transition entries. Repeat a kind to weight it more heavily.
+  active:
+    - kind: fade
       duration-ms: 450
       through-black: false
-    wipe:
+    - kind: wipe
       duration-ms: 600
       angle-list-degrees: [45.0, 225.0]
       angle-selection: sequential
       angle-jitter-degrees: 12.0
       softness: 0.08
-    push:
+    - kind: push
       duration-ms: 520
       angle-list-degrees: [0.0, 180.0]
       angle-selection: random
       angle-jitter-degrees: 8.0
-    e-ink:
+    - kind: e-ink
       duration-ms: 1600
       flash-count: 0
       reveal-portion: 0.55
       stripe-count: 24
       flash-color: [0, 0, 0]
-    iris:
+    - kind: iris
       duration-ms: 900
       blades: 7
       direction: open
@@ -120,23 +119,23 @@ playlist:
 
 # Matting settings
 matting:
-  types: [fixed-color, blur, studio, fixed-image]
-  # Choose how to iterate through the matting types: random or sequential.
-  type-selection: random
-  options:
-    fixed-color:
+  # Choose how the viewer advances through the mats below: fixed, random, or sequential.
+  selection: random
+  # Provide one or more mat definitions. Repeat a kind to weight or alternate variants.
+  active:
+    - kind: fixed-color
       colors:
         - [0, 0, 0]
         - [32, 32, 32]
       color-selection: sequential # or random
       minimum-mat-percentage: 0.0
       max-upscale-factor: 1.0
-    blur:
+    - kind: blur
       minimum-mat-percentage: 3.5
       sigma: 32.0
       sample-scale: 0.125 # raise toward 1.0 for sharper mats at higher cost
       backend: neon # options: cpu, neon (auto-falls back to cpu if unsupported)
-    studio:
+    - kind: studio
       colors:
         - [24, 24, 24]
         - photo-average
@@ -148,7 +147,7 @@ matting:
       texture-strength: 1.0 # 0.0 for smooth paper, 1.0 default weave
       warp-period-px: 5.6 # spacing between vertical warp threads in px
       weft-period-px: 5.2 # spacing between horizontal weft threads in px
-    fixed-image:
+    - kind: fixed-image
       minimum-mat-percentage: 6.0
       path:
         [


### PR DESCRIPTION
## Summary
- rewrite the transition and matting documentation to cover the new `selection`/`active` schema and show duplicate-kind usage
- update the sample configuration template to use the new keys for transitions and matting
- highlight the breaking configuration change for integrators in the docs and README

## Testing
- not run (documentation and configuration updates only)

------
https://chatgpt.com/codex/tasks/task_e_68ec53d2f68c832394575f5e7551a743