### PR TITLE
Update photo effect pipeline configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -100,18 +100,19 @@ loader-max-concurrent-decodes: 4
 startup-shuffle-seed: null
 
 photo-effect:
-  # List zero or more effect types; set to [] to disable the stage entirely.
-  types: []
-  # Choose how to iterate through effects when multiple are configured.
-  type-selection: random
-  options:
-    print-simulation:
-      light-angle-degrees: 135.0
-      relief-strength: 0.35
-      ink-spread: 0.18
-      sheen-strength: 0.22
-      paper-color: [245, 244, 240]
-      debug: false # Set true to only treat the left half for side-by-side comparison
+  # Choose how the viewer advances through the entries below when enabled.
+  selection: random
+  # Provide zero or more effect entries; leave empty to disable the stage.
+  active: []
+  # Example configuration:
+  # active:
+  #   - kind: print-simulation
+  #     light-angle-degrees: 135.0
+  #     relief-strength: 0.35
+  #     ink-spread: 0.18
+  #     sheen-strength: 0.22
+  #     paper-color: [245, 244, 240]
+  #     debug: false # Set true to only treat the left half for side-by-side comparison
 
 playlist:
   new-multiplicity: 3

--- a/crates/photo-frame/src/tasks/photo_effect.rs
+++ b/crates/photo-frame/src/tasks/photo_effect.rs
@@ -154,9 +154,9 @@ mod tests {
     #[tokio::test]
     async fn applies_print_simulation_when_enabled() {
         let yaml = r#"
-types: [print-simulation]
-options:
-  print-simulation:
+selection: random
+active:
+  - kind: print-simulation
     relief-strength: 1.0
     sheen-strength: 0.5
 "#;


### PR DESCRIPTION
## Summary
- align the photo-effect parser with the matting/transition pipeline format using selection entries and inline options
- adjust the sample configuration and tests to showcase the new photo-effect `selection`/`active` style
- silence dead-code warnings on matting and transition helpers that remain available for integration tests

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ec5b383d108323871b8e73a7cf3459