### PR TITLE
Add GPU-driven iris transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Added
+- GPU iris transition with configurable blades, rotation, and direction parameters exposed via configuration.

--- a/config.yaml
+++ b/config.yaml
@@ -39,7 +39,8 @@ transition:
     - kind: iris
       duration-ms: 900
       blades: 7
-      blade-rgba: [0.12, 0.12, 0.12, 1.0]
+      rotate-radians: 1.05
+      direction: open
 
 # Dwell time (ms) the current image remains fully displayed before the next transition
 dwell-ms: 2000

--- a/crates/photo-frame/tests/config_tests.rs
+++ b/crates/photo-frame/tests/config_tests.rs
@@ -538,7 +538,8 @@ transition:
   types: [iris]
   duration-ms: 880
   blades: 9
-  blade-rgba: [0.2, 0.22, 0.24, 0.85]
+  rotate-radians: 1.25
+  direction: close
 "#;
 
     let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
@@ -557,7 +558,11 @@ transition:
     match selected.option.mode() {
         rust_photo_frame::config::TransitionMode::Iris(cfg) => {
             assert_eq!(cfg.blades, 9);
-            assert_eq!(cfg.blade_rgba, [0.2, 0.22, 0.24, 0.85]);
+            assert!((cfg.rotate_radians - 1.25).abs() < f32::EPSILON);
+            assert_eq!(
+                cfg.direction,
+                rust_photo_frame::config::IrisDirection::Close
+            );
         }
         _ => panic!("expected iris transition"),
     }
@@ -837,7 +842,7 @@ transition:
     assert_eq!(selected.entry.kind, TransitionKind::Iris);
     match selected.option.mode() {
         rust_photo_frame::config::TransitionMode::Iris(cfg) => {
-            assert_eq!(cfg.blades, 5);
+            assert_eq!(cfg.blades, 3);
         }
         _ => panic!("expected iris transition"),
     }


### PR DESCRIPTION
## Summary
- implement the iris shutter transition with an antialiased N-gon mask in WGSL
- extend the viewer and configuration plumbing with new iris parameters and direction handling
- refresh the sample config, tests, and changelog for the updated iris options

## Testing
- cargo test -p rust-photo-frame

------
https://chatgpt.com/codex/tasks/task_e_68ec6f0d33088323a36b52ff466bbbdd