### PR TITLE
Fix iris tessellation shader WGSL syntax

### DIFF
--- a/crates/photo-frame/src/tasks/shaders/iris_tess.wgsl
+++ b/crates/photo-frame/src/tasks/shaders/iris_tess.wgsl
@@ -99,7 +99,7 @@ fn fs_composite(in: FullscreenOut) -> @location(0) vec4<f32> {
   let current = sample_plane(cur_tex, cur_samp, Comp.current_dest, screen_pos);
   let next = sample_plane(next_tex, next_samp, Comp.next_dest, screen_pos);
   let mask = textureSample(mask_tex, mask_samp, in.screen_uv).r;
-  let mut color = mix(next, current, mask);
+  var color = mix(next, current, mask);
   if (Comp.stage == 1u) {
     color = mix(current, next, mask);
   }


### PR DESCRIPTION
## Summary
- replace the invalid `let mut` binding in the iris tessellation WGSL shader with `var`
- keep the composite fragment shader compatible with the WGSL reserved word set

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed6ea18d408323bfb40cbd677c408b