### PR TITLE
Fix wake scene frame submission

### DIFF
--- a/crates/photo-frame/src/tasks/viewer/scenes/mod.rs
+++ b/crates/photo-frame/src/tasks/viewer/scenes/mod.rs
@@ -361,6 +361,11 @@ impl WakeScene {
         std::mem::take(&mut self.pending_redraw)
     }
 
+    /// Clears any serviced redraw request after the frame has been presented.
+    pub(super) fn after_present(&mut self) {
+        let _ = self.take_redraw_needed();
+    }
+
     /// Returns the timestamp when the current image started displaying.
     pub(super) fn displayed_at(&self) -> Option<Instant> {
         self.displayed_at


### PR DESCRIPTION
## Summary
- submit wake-scene command buffers before recording frame presentation
- add a wake-scene post-present hook to clear pending redraw requests after presenting

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68edc038308c8323a0f4df2c9310ebdb