### PR TITLE
Fix iris transition mask semantics to avoid premature next-frame reveal

### DIFF
--- a/crates/photo-frame/src/renderer/iris_tess.rs
+++ b/crates/photo-frame/src/renderer/iris_tess.rs
@@ -603,7 +603,7 @@ impl IrisRenderer {
 
         // Mask pass
         {
-            self.write_blade_uniforms(queue, params.screen_size, 0.0, [0.0; 4]);
+            self.write_blade_uniforms(queue, params.screen_size, 1.0, [0.0; 4]);
             let mask_view = &self.mask_target.as_ref().unwrap().view;
             let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("iris-mask-pass"),
@@ -612,7 +612,7 @@ impl IrisRenderer {
                     resolve_target: None,
                     depth_slice: None,
                     ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Clear(wgpu::Color::WHITE),
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
                         store: wgpu::StoreOp::Store,
                     },
                 })],

--- a/crates/photo-frame/src/tasks/shaders/iris_tess.wgsl
+++ b/crates/photo-frame/src/tasks/shaders/iris_tess.wgsl
@@ -98,10 +98,11 @@ fn fs_composite(in: FullscreenOut) -> @location(0) vec4<f32> {
   let screen_pos = in.screen_uv * Comp.screen_size;
   let current = sample_plane(cur_tex, cur_samp, Comp.current_dest, screen_pos);
   let next = sample_plane(next_tex, next_samp, Comp.next_dest, screen_pos);
-  let mask = textureSample(mask_tex, mask_samp, in.screen_uv).r;
-  var color = mix(next, current, mask);
+  let coverage = clamp(textureSample(mask_tex, mask_samp, in.screen_uv).r, 0.0, 1.0);
+  var color = current;
   if (Comp.stage == 1u) {
-    color = mix(current, next, mask);
+    let aperture = 1.0 - coverage;
+    color = mix(current, next, aperture);
   }
   let alpha = max(max(current.a, next.a), color.a);
   return vec4<f32>(color.rgb, clamp(alpha, 0.0, 1.0));


### PR DESCRIPTION
## Summary
- treat the iris mask as a coverage map and keep the closing half of the composite pass on the current frame
- drive the opening half by the inverse mask so the next frame only appears once the aperture opens
- clear the mask target to black and render blades with full opacity so both halves share the same mask semantics

## Testing
- `cargo test -p rust-photo-frame` *(fails: viewer_surface_handshake::viewer_defers_matting_until_surface_ready_event)*
- `cargo test -p rust-photo-frame --test viewer_surface_handshake` *(fails: viewer_defers_matting_until_surface_ready_event)*

------
https://chatgpt.com/codex/tasks/task_e_68edc5d540c08323a96630aa2f0ec593