### PR TITLE
Fix iris mask sampling and blend logic

### DIFF
--- a/crates/photo-frame/src/renderer/iris_tess.rs
+++ b/crates/photo-frame/src/renderer/iris_tess.rs
@@ -188,8 +188,8 @@ impl IrisRenderer {
             address_mode_u: wgpu::AddressMode::ClampToEdge,
             address_mode_v: wgpu::AddressMode::ClampToEdge,
             address_mode_w: wgpu::AddressMode::ClampToEdge,
-            mag_filter: wgpu::FilterMode::Linear,
-            min_filter: wgpu::FilterMode::Linear,
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Nearest,
             mipmap_filter: wgpu::FilterMode::Nearest,
             ..Default::default()
         });
@@ -328,7 +328,7 @@ impl IrisRenderer {
                 entry_point: Some("fs_composite"),
                 targets: &[Some(wgpu::ColorTargetState {
                     format: surface_format,
-                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    blend: None,
                     write_mask: wgpu::ColorWrites::ALL,
                 })],
                 compilation_options: wgpu::PipelineCompilationOptions::default(),
@@ -603,7 +603,7 @@ impl IrisRenderer {
 
         // Mask pass
         {
-            self.write_blade_uniforms(queue, params.screen_size, 1.0, [0.0; 4]);
+            self.write_blade_uniforms(queue, params.screen_size, 1.0, [1.0; 4]);
             let mask_view = &self.mask_target.as_ref().unwrap().view;
             let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("iris-mask-pass"),

--- a/crates/photo-frame/src/tasks/shaders/iris_tess.wgsl
+++ b/crates/photo-frame/src/tasks/shaders/iris_tess.wgsl
@@ -99,11 +99,7 @@ fn fs_composite(in: FullscreenOut) -> @location(0) vec4<f32> {
   let current = sample_plane(cur_tex, cur_samp, Comp.current_dest, screen_pos);
   let next = sample_plane(next_tex, next_samp, Comp.next_dest, screen_pos);
   let coverage = clamp(textureSample(mask_tex, mask_samp, in.screen_uv).r, 0.0, 1.0);
-  var color = current;
-  if (Comp.stage == 1u) {
-    let aperture = 1.0 - coverage;
-    color = mix(current, next, aperture);
-  }
+  let color = mix(current, next, coverage);
   let alpha = max(max(current.a, next.a), color.a);
   return vec4<f32>(color.rgb, clamp(alpha, 0.0, 1.0));
 }

--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -2370,9 +2370,7 @@ pub fn run_windowed(
                                                 closeness,
                                                 tolerance,
                                                 stroke_width,
-                                                rotation: rotate_radians
-                                                    * base_progress
-                                                    * rotation_sign,
+                                                rotation: rotate_radians * timeline * rotation_sign,
                                                 fill_color: fill_rgba,
                                                 stroke_color: stroke_rgba,
                                                 stage,


### PR DESCRIPTION
## Summary
- switch the iris mask sampler to nearest filtering and disable blending on the composite pass to avoid halos and double blending
- normalize mask polarity so the composite shader always mixes current to next with the mask and remove the stage-dependent branch
- drive iris rotation from the same timeline as closeness to keep motion continuous through the midpoint

## Testing
- cargo test *(fails: viewer_surface_handshake::viewer_defers_matting_until_surface_ready_event)*

------
https://chatgpt.com/codex/tasks/task_e_68edc9f280588323869aa97a71432435