### PR TITLE
Simplify wake cleanup during surface resize

### DIFF
--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -1221,12 +1221,11 @@ pub fn run_windowed(
         fn on_surface_size_settled(&mut self) {
             // Drop any precomputed canvases for the previous size and flush pending queue.
             self.ready_results.clear();
-            if let Some(mut mode) = self.mode.take() {
+            if let Some(mode) = self.mode.as_mut() {
                 let wake = mode.wake_mut();
                 wake.set_next(None);
                 wake.pending_mut().clear();
                 wake.set_transition_state(None);
-                self.mode = Some(mode);
             }
             // We cannot cancel inflight matting; mismatched results will be dropped on upload.
         }


### PR DESCRIPTION
## Summary
- mutate the viewer mode in place when clearing wake state during surface resize

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eeefb326e083239bcc30a38973223f