### PR TITLE
Clarify matting canonical selection behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ All configuration options—from playlist weighting and greeting screens to tran
 
 > **Breaking change:** The `transition` and `matting` blocks now use a `selection` + `active` schema. Older `types`/`options` layouts no longer parse—recreate those entries with explicit `kind` fields as shown in the updated configuration guide.
 
+> **Matting at a glance:** The viewer walks `matting.active` from top to bottom, expanding inline palettes (such as `colors` arrays) into a canonical list of presets. Random and sequential selection both operate on that expanded list, so weighting or rotation happens after the inline swatches unfold. See the [full matting documentation](docs/configuration.md#matting-configuration) for details and examples.
+
 Need help wiring the sleep schedule to Raspberry Pi + Dell HDMI hardware? The dedicated power guide covers DPMS commands, troubleshooting, and verification steps. [Power & sleep details →](docs/power-and-sleep.md)
 
 ## Fabrication

--- a/config.yaml
+++ b/config.yaml
@@ -121,7 +121,7 @@ playlist:
 matting:
   # Choose how the viewer advances through the mats below: fixed, random, or sequential.
   selection: random
-  # Provide one or more mat definitions. Repeat a kind to weight or alternate variants.
+  # Provide one or more mat definitions. Repeat a kind to weight it in the canonical slot list (sequential reuse still hits the same preset).
   active:
     - kind: fixed-color
       colors:


### PR DESCRIPTION
## Summary
- add a README "Matting at a glance" callout that describes the canonical list expansion
- rewrite the matting configuration docs to explain canonical slots, random vs. sequential draws, and refresh the weighted example
- update the sample config comment to point out canonical weighting instead of unsupported alternation

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68eef7b320108323b7f1cb20eb265ef1