### PR TITLE
Remove matting selection overrides

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -121,13 +121,13 @@ playlist:
 matting:
   # Choose how the viewer advances through the mats below: fixed, random, or sequential.
   selection: random
-  # Provide one or more mat definitions. Repeat a kind to weight it in the canonical slot list (sequential reuse still hits the same preset).
+  # Provide one or more mat definitions. Duplicate entries (or individual colors/paths) to weight them once expanded into the
+  # canonical list; matting.selection controls how that list is traversed.
   active:
     - kind: fixed-color
       colors:
         - [0, 0, 0]
         - [32, 32, 32]
-      color-selection: sequential # or random
       minimum-mat-percentage: 0.0
       max-upscale-factor: 1.0
     - kind: blur
@@ -140,7 +140,6 @@ matting:
         - [24, 24, 24]
         - photo-average
         - [210, 210, 210]
-      color-selection: random # or sequential
       minimum-mat-percentage: 8.0
       bevel-width-px: 4.0
       bevel-color: [255, 255, 255]
@@ -153,5 +152,4 @@ matting:
         [
           /opt/photo-frame/share/backgrounds/blue-textured-brick-wall-background.jpg,
         ]
-      path-selection: sequential # or random
       fit: cover # options: cover, contain, stretch

--- a/crates/photo-frame/tests/config_tests.rs
+++ b/crates/photo-frame/tests/config_tests.rs
@@ -1,7 +1,7 @@
 use rand::{SeedableRng, rngs::StdRng};
 use rust_photo_frame::config::{
-    ColorSelection, Configuration, FixedImagePathSelection, MattingKind, MattingMode,
-    MattingSelection, StudioMatColor, TransitionKind, TransitionSelection,
+    Configuration, MattingKind, MattingMode, MattingSelection, StudioMatColor, TransitionKind,
+    TransitionSelection,
 };
 use std::path::PathBuf;
 
@@ -151,7 +151,6 @@ matting:
       colors:
         - [10, 20, 30]
         - [5, 15, 25]
-      color-selection: random
     - kind: blur
       minimum-mat-percentage: 7.5
       sigma: 12.0
@@ -171,13 +170,10 @@ matting:
     let selected: Vec<_> = cfg.matting.iter_selected().collect();
     assert_eq!(selected.len(), 3);
     let fixed_first = &selected[0];
-    if let rust_photo_frame::config::MattingMode::FixedColor {
-        colors,
-        color_selection,
-    } = &fixed_first.option.style
+    if let rust_photo_frame::config::MattingMode::FixedColor { colors, .. } =
+        &fixed_first.option.style
     {
         assert_eq!(colors.as_slice(), &[[10, 20, 30]]);
-        assert_eq!(*color_selection, ColorSelection::Random);
     } else {
         panic!("expected fixed-color matting");
     }
@@ -234,7 +230,7 @@ matting:
 fn inline_fixed_color_array_expands_to_multiple_entries() {
     let yaml = r#"
 photo-library-path: "/photos"
-matting: { selection: random, active: [ { kind: fixed-color, colors: [[8, 16, 24], [32, 40, 48]], color-selection: random } ] }
+matting: { selection: random, active: [ { kind: fixed-color, colors: [[8, 16, 24], [32, 40, 48]] } ] }
 "#;
 
     let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
@@ -323,7 +319,6 @@ matting:
       colors:
         - [10, 20, 30]
         - [40, 50, 60]
-      color-selection: sequential
     - kind: blur
       sigma: 12.0
       minimum-mat-percentage: 7.5
@@ -331,7 +326,6 @@ matting:
       colors:
         - [10, 20, 30]
         - [40, 50, 60]
-      color-selection: sequential
 "#;
 
     let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
@@ -381,14 +375,10 @@ matting:
             MattingKind::FixedColor,
         ]
     );
-    if let rust_photo_frame::config::MattingMode::FixedColor {
-        color_selection, ..
-    } = &sequence[0].option.style
-    {
-        assert_eq!(*color_selection, ColorSelection::Sequential);
-    } else {
-        panic!("expected first matting option to be fixed-color");
-    }
+    assert!(matches!(
+        sequence[0].option.style,
+        rust_photo_frame::config::MattingMode::FixedColor { .. }
+    ));
 }
 
 #[test]
@@ -414,7 +404,6 @@ matting:
   active:
     - kind: fixed-image
       path: ["{first}", "{second}"]
-      path-selection: sequential
       fit: contain
 "#,
         first = first.display(),
@@ -426,13 +415,8 @@ matting:
     assert_eq!(selected.len(), 2);
     for (entry, path) in selected.iter().zip([&first, &second]) {
         match &entry.option.style {
-            MattingMode::FixedImage {
-                paths,
-                path_selection,
-                fit,
-            } => {
+            MattingMode::FixedImage { paths, fit } => {
                 assert_eq!(paths, &vec![path.clone()]);
-                assert_eq!(*path_selection, FixedImagePathSelection::Sequential);
                 assert!(matches!(
                     fit,
                     rust_photo_frame::config::FixedImageFit::Contain


### PR DESCRIPTION
## Summary
- drop the unused matting color/path selection enums and propagate the simplified shapes through runtime prep and canonical builder expansion
- update config parsing tests, example config, and documentation to reflect duplicate-based weighting without per-entry selection knobs

## Testing
- cargo fmt
- cargo test -p rust-photo-frame config_tests

------
https://chatgpt.com/codex/tasks/task_e_68ef0df026b48323943bffe0846f40c6