### PR TITLE
Simplify wifi-manager connectivity checks

### DIFF
--- a/crates/photo-frame/tests/config_tests.rs
+++ b/crates/photo-frame/tests/config_tests.rs
@@ -1,6 +1,7 @@
 use rand::{SeedableRng, rngs::StdRng};
 use rust_photo_frame::config::{
-    Configuration, MattingKind, MattingMode, MattingSelection, PhotoEffectOptions, StudioMatColor, TransitionKind, TransitionSelection
+    Configuration, MattingKind, MattingMode, MattingSelection, PhotoEffectOptions, StudioMatColor,
+    TransitionKind, TransitionSelection,
 };
 use std::path::PathBuf;
 

--- a/crates/wifi-manager/src/watch.rs
+++ b/crates/wifi-manager/src/watch.rs
@@ -139,12 +139,7 @@ async fn start_hotspot(config: &Config, config_path: &PathBuf) -> Result<ActiveH
 }
 
 async fn check_online(config: &Config) -> Result<bool> {
-    let connected = nm::device_connected(&config.interface).await?;
-    if !connected {
-        return Ok(false);
-    }
-    let gateway = nm::gateway_reachable(&config.interface).await?;
-    Ok(gateway)
+    nm::device_connected(&config.interface).await
 }
 
 struct ActiveHotspot {

--- a/crates/wifi-manager/src/web.rs
+++ b/crates/wifi-manager/src/web.rs
@@ -144,18 +144,13 @@ async fn status_json(State(state): State<UiState>) -> Response {
 async fn monitor_connection(state: UiState, ssid: String) {
     for _ in 0..12 {
         match nm::device_connected(&state.config.interface).await {
-            Ok(true) => match nm::gateway_reachable(&state.config.interface).await {
-                Ok(true) => {
-                    let message = "Frame is back online.".to_string();
-                    if let Err(err) = write_last_attempt(&state, &ssid, "connected", &message, None)
-                    {
-                        warn!(error = ?err, "failed to mark connection as successful");
-                    }
-                    return;
+            Ok(true) => {
+                let message = "Frame is back on Wi-Fi.".to_string();
+                if let Err(err) = write_last_attempt(&state, &ssid, "connected", &message, None) {
+                    warn!(error = ?err, "failed to mark connection as successful");
                 }
-                Ok(false) => {}
-                Err(err) => warn!(error = ?err, "gateway probe failed while monitoring"),
-            },
+                return;
+            }
             Ok(false) => {}
             Err(err) => warn!(error = ?err, "device connectivity check failed while monitoring"),
         }

--- a/docs/wifi-manager.md
+++ b/docs/wifi-manager.md
@@ -4,7 +4,7 @@ The `wifi-manager` crate is the frame's single entry point for Wi-Fi monitoring,
 
 ## Capabilities at a glance
 
-- Detects connectivity loss by polling NetworkManager and verifying reachability of the default gateway.
+- Detects connectivity loss by polling NetworkManager for the interface's connection state.
 - Creates or updates an idempotent hotspot profile (`pf-hotspot`) and brings it online with a random three-word passphrase.
 - Serves a lightweight HTTP UI for submitting replacement SSID/password credentials, then provisions them via `nmcli`.
 - Renders a QR code that points to the recovery portal so phones can jump directly to the setup page.
@@ -73,7 +73,7 @@ overlay:
 | `overlay.overlay-app-id`       | Sway `app_id` that the overlay binary advertises; used for focus/teardown commands. |
 | `overlay.sway-socket`          | Optional override for the Sway IPC socket. Detected automatically from `/run/user/<uid>` when omitted. |
 
-Whenever you change the config, run `sudo systemctl restart wifi-manager` for the daemon to pick up the new settings.
+Whenever you change the config, run `sudo systemctl restart photoframe-wifi-manager.service` for the daemon to pick up the new settings.
 
 ## Runtime files
 
@@ -86,7 +86,7 @@ All mutable state lives under `/var/lib/photo-frame` and is owned by the `photo-
 
 ## Web provisioning flow
 
-1. The `watch` loop marks the frame `OFFLINE` after `offline-grace-sec` seconds without a gateway response.
+1. The `watch` loop marks the frame `OFFLINE` after `offline-grace-sec` seconds of NetworkManager reporting the interface disconnected.
 2. The hotspot profile (`pf-hotspot`) is ensured, then activated on the configured interface with WPA2-PSK security. The watcher simultaneously launches the `wifi-manager overlay` subcommand via Sway IPC and brings the web UI online so the on-device instructions, QR code, and portal stay in sync.
 3. A random three-word passphrase is selected from the bundled wordlist and written to `/var/lib/photo-frame/hotspot-password.txt`.
 4. The QR code generator produces `/var/lib/photo-frame/wifi-qr.png`, embedding the configured UI URL (default `http://192.168.4.1:8080/`).


### PR DESCRIPTION
## Summary
- treat wifi-manager's watchdog as online whenever NetworkManager reports the interface connected
- update the provisioning UI monitor and docs to reflect Wi-Fi-only detection and correct service restart guidance
- run rustfmt, updating an import in the photo-frame config tests

## Testing
- cargo check -p wifi-manager

------
https://chatgpt.com/codex/tasks/task_e_68f5a820a4908323b1722f591b115788