### PR TITLE
Update buttond to load config and manage display power

### DIFF
--- a/assets/systemd/buttond.service
+++ b/assets/systemd/buttond.service
@@ -1,6 +1,6 @@
 # Managed by setup/system/modules/60-systemd.sh
 [Unit]
-Description=Photo Frame Power Button Monitor
+Description=Photo Frame Button Daemon
 After=multi-user.target
 Wants=multi-user.target
 
@@ -9,8 +9,7 @@ Type=simple
 User=kiosk
 Group=kiosk
 WorkingDirectory=/var/lib/photo-frame
-ExecStart=/opt/photo-frame/bin/photo-buttond --single-window-ms 250 --double-window-ms 400 --debounce-ms 20 \
-  --pidfile /run/photoframe/app.pid --procname rust-photo-frame --shutdown /opt/photo-frame/bin/photo-safe-shutdown
+ExecStart=/opt/photo-frame/bin/photo-buttond --config /var/lib/photo-frame/config/config.yaml --log-level info
 Restart=always
 RestartSec=1s
 CapabilityBoundingSet=CAP_KILL CAP_SYS_BOOT

--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,27 @@ photo-library-path: /var/lib/photo-frame/photos
 # Unix domain socket path for runtime control commands
 control-socket-path: /run/photo-frame/control.sock
 
+# Hardware button daemon configuration
+buttond:
+  # Optional override for the evdev device path that emits KEY_POWER. Leave null to auto-detect.
+  device: null
+  # Timing windows (milliseconds) that classify button interactions.
+  single-window-ms: 250
+  double-window-ms: 400
+  debounce-ms: 20
+  # Executable that performs a clean shutdown when the button is double-pressed.
+  shutdown-command: /opt/photo-frame/bin/photo-safe-shutdown
+  # Uncomment to require a specific kiosk process to be active before forwarding toggle commands.
+  # pidfile: /run/photo-frame/app.pid
+  # procname: rust-photo-frame
+  screen:
+    # Connector name reported by `wlr-randr`. Leave null to auto-select the first connected external output.
+    output: null
+    # Delay (milliseconds) to wait before powering the display off so the sleep screen can render.
+    off-delay-ms: 3500
+    # Wayland display to target when invoking `wlr-randr`.
+    wayland-display: wayland-1
+
 # Render/transition settings
 transition:
   # Choose how the viewer advances through the entries below: fixed, random, or sequential.

--- a/crates/buttond/Cargo.toml
+++ b/crates/buttond/Cargo.toml
@@ -14,6 +14,8 @@ evdev = "0.13"
 tracing-subscriber = { version = "0.3.20", features = ["fmt", "env-filter"] }
 tracing = "0.1.41"
 nix = { version = "0.30.0", default-features = false, features = ["fs"] }
+serde = { version = "1.0.214", features = ["derive"] }
+serde_yaml = "0.9.34"
 
 [dev-dependencies]
 tempfile = "3.13.0"

--- a/crates/photo-frame/tests/config_tests.rs
+++ b/crates/photo-frame/tests/config_tests.rs
@@ -1,6 +1,7 @@
 use rand::{SeedableRng, rngs::StdRng};
 use rust_photo_frame::config::{
-    Configuration, MattingKind, MattingMode, MattingSelection, PhotoEffectOptions, StudioMatColor, TransitionKind, TransitionSelection
+    Configuration, MattingKind, MattingMode, MattingSelection, PhotoEffectOptions, StudioMatColor,
+    TransitionKind, TransitionSelection,
 };
 use std::path::PathBuf;
 

--- a/setup/application/modules/50-postcheck.sh
+++ b/setup/application/modules/50-postcheck.sh
@@ -12,7 +12,7 @@ fi
 KIOSK_SERVICE="${KIOSK_SERVICE:-greetd.service}"
 WIFI_SERVICE="${WIFI_SERVICE:-photoframe-wifi-manager.service}"
 SYNC_TIMER="${SYNC_TIMER:-photoframe-sync.timer}"
-BUTTON_SERVICE="${BUTTON_SERVICE:-photoframe-buttond.service}"
+BUTTON_SERVICE="${BUTTON_SERVICE:-buttond.service}"
 SEATD_SERVICE="${SEATD_SERVICE:-seatd.service}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../lib/systemd.sh

--- a/setup/assets/app/bin/photo-safe-shutdown
+++ b/setup/assets/app/bin/photo-safe-shutdown
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-exec /sbin/shutdown -h now
+exec /bin/systemctl poweroff --no-wall

--- a/setup/assets/kiosk/polkit-1/rules.d/95-photoframe-power.rules
+++ b/setup/assets/kiosk/polkit-1/rules.d/95-photoframe-power.rules
@@ -1,0 +1,13 @@
+polkit.addRule(function(action, subject) {
+    if (!subject.isInGroup("kiosk")) {
+        return polkit.Result.NOT_HANDLED;
+    }
+
+    switch (action.id) {
+        case "org.freedesktop.login1.power-off":
+        case "org.freedesktop.login1.power-off-multiple-sessions":
+            return polkit.Result.YES;
+        default:
+            return polkit.Result.NOT_HANDLED;
+    }
+});

--- a/setup/system/modules/60-systemd.sh
+++ b/setup/system/modules/60-systemd.sh
@@ -8,9 +8,9 @@ log() {
 }
 
 install_auxiliary_units() {
-    log "Installing photoframe systemd units"
+    log "Installing systemd units"
     local unit
-    for unit in "${REPO_ROOT}"/assets/systemd/photoframe-*; do
+    for unit in "${REPO_ROOT}"/assets/systemd/*.service "${REPO_ROOT}"/assets/systemd/*.timer; do
         [ -f "${unit}" ] || continue
         install -D -m 0644 "${unit}" "/etc/systemd/system/$(basename "${unit}")"
     done
@@ -51,6 +51,33 @@ ensure_persistent_journald() {
 
     log "[${module}] Restarting systemd-journald to apply configuration"
     systemctl restart systemd-journald
+}
+
+configure_logind_power_key() {
+    local module="logind"
+    local config="/etc/systemd/logind.conf"
+
+    log "[${module}] Forcing HandlePowerKey=ignore"
+    if [[ ! -f "${config}" ]]; then
+        install -m 0644 /dev/null "${config}"
+    fi
+
+    if grep -Eq '^[#[:space:]]*HandlePowerKey=ignore' "${config}"; then
+        log "[${module}] HandlePowerKey already set to ignore"
+    elif grep -Eq '^[#[:space:]]*HandlePowerKey=' "${config}"; then
+        sed -i 's/^[#[:space:]]*HandlePowerKey=.*/HandlePowerKey=ignore/' "${config}"
+        log "[${module}] Updated HandlePowerKey=ignore"
+    else
+        printf '\nHandlePowerKey=ignore\n' >>"${config}"
+        log "[${module}] Appended HandlePowerKey=ignore"
+    fi
+
+    if systemctl list-unit-files systemd-logind.service >/dev/null 2>&1; then
+        log "[${module}] Restarting systemd-logind"
+        systemctl restart systemd-logind || log "[${module}] WARN: Failed to restart systemd-logind"
+    else
+        log "[${module}] systemd-logind.service not installed; restart manually if required"
+    fi
 }
 
 enable_systemd_units() {
@@ -107,7 +134,7 @@ enable_systemd_units() {
     local wifi_bin="/opt/photo-frame/bin/wifi-manager"
     local button_bin="/opt/photo-frame/bin/photo-buttond"
     local unit
-    for unit in photoframe-wifi-manager.service photoframe-buttond.service; do
+    for unit in photoframe-wifi-manager.service buttond.service; do
         if systemctl list-unit-files "${unit}" >/dev/null 2>&1; then
             systemctl enable "${unit}"
             case "${unit}" in
@@ -118,7 +145,7 @@ enable_systemd_units() {
                         log "Deferring start of ${unit}; ${wifi_bin} missing"
                     fi
                     ;;
-                photoframe-buttond.service)
+                buttond.service)
                     if [[ -x "${button_bin}" ]]; then
                         systemctl start "${unit}" || true
                     else
@@ -137,6 +164,7 @@ enable_systemd_units() {
 
 install_auxiliary_units
 ensure_persistent_journald
+configure_logind_power_key
 enable_systemd_units
 
 log "systemd provisioning complete"


### PR DESCRIPTION
## Summary
- add config-driven CLI for buttond and implement display toggling with wlr-randr
- add a buttond section to the default config and refresh the docs
- rename the buttond systemd unit, configure logind/polkit, and update the shutdown helper

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f5a56077cc8323bca3038135b59ce4