### PR TITLE
Treat hotspot connection as offline

### DIFF
--- a/crates/wifi-manager/src/watch.rs
+++ b/crates/wifi-manager/src/watch.rs
@@ -139,7 +139,8 @@ async fn start_hotspot(config: &Config, config_path: &PathBuf) -> Result<ActiveH
 }
 
 async fn check_online(config: &Config) -> Result<bool> {
-    let connected = nm::device_connected(&config.interface).await?;
+    let connected =
+        nm::connected_to_infrastructure(&config.interface, &config.hotspot.connection_id).await?;
     if !connected {
         return Ok(false);
     }

--- a/crates/wifi-manager/src/web.rs
+++ b/crates/wifi-manager/src/web.rs
@@ -143,7 +143,12 @@ async fn status_json(State(state): State<UiState>) -> Response {
 
 async fn monitor_connection(state: UiState, ssid: String) {
     for _ in 0..12 {
-        match nm::device_connected(&state.config.interface).await {
+        match nm::connected_to_infrastructure(
+            &state.config.interface,
+            &state.config.hotspot.connection_id,
+        )
+        .await
+        {
             Ok(true) => match nm::gateway_reachable(&state.config.interface).await {
                 Ok(true) => {
                     let message = "Frame is back online.".to_string();


### PR DESCRIPTION
## Summary
- add nmcli helper to read the active connection bound to an interface
- treat the hotspot profile as offline when checking watcher or provisioning status
- share the infrastructure-link predicate between the watcher and provisioning monitor

## Testing
- cargo fmt
- cargo test -p wifi-manager

------
https://chatgpt.com/codex/tasks/task_e_68f6ea4cb6608323a6f0c430c0c2a2e3