### PR TITLE
Update config path for log collection

### DIFF
--- a/tests/collect_logs.sh
+++ b/tests/collect_logs.sh
@@ -105,8 +105,17 @@ main() {
   fi
 
   info "Copying config"
-  if [ -f "${install_root}/var/config.yaml" ]; then
-    cp "${install_root}/var/config.yaml" "$tmpdir/runtime/config.yaml"
+  local etc_config
+  if [ "${install_root}" = "/" ]; then
+    etc_config="/etc/photo-frame/config.yaml"
+  else
+    etc_config="${install_root%/}/etc/photo-frame/config.yaml"
+  fi
+
+  if [ -f "$etc_config" ]; then
+    cp "$etc_config" "$tmpdir/runtime/config.yaml"
+  elif [ "${install_root}" != "/" ] && [ -f "/etc/photo-frame/config.yaml" ]; then
+    cp "/etc/photo-frame/config.yaml" "$tmpdir/runtime/config.yaml"
   elif [ -f "$REPO_ROOT/config.yaml" ]; then
     cp "$REPO_ROOT/config.yaml" "$tmpdir/runtime/config.yaml"
   fi


### PR DESCRIPTION
## Summary
- adjust the log collection script to pull the runtime config from /etc/photo-frame/config.yaml
- retain the repository config template as the fallback when a system copy is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6ec5a3be483238fff1892aafed883