### PR TITLE
Update loginctl poweroff default shutdown command

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,7 +19,7 @@ buttond:
   double-window-ms: 400
   shutdown-command:
     program: /usr/bin/loginctl
-    args: [power-off]
+    args: [poweroff]
   screen:
     off-delay-ms: 3500
     on-command:

--- a/crates/buttond/src/main.rs
+++ b/crates/buttond/src/main.rs
@@ -214,7 +214,7 @@ impl ButtondFileConfig {
         CommandConfig {
             label: "shutdown".into(),
             program: PathBuf::from("/usr/bin/loginctl"),
-            args: vec!["power-off".into()],
+            args: vec!["poweroff".into()],
         }
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -231,7 +231,7 @@ buttond:
   double-window-ms: 400             # wait this long for a second tap
   shutdown-command:
     program: /usr/bin/loginctl
-    args: [power-off]
+    args: [poweroff]
   screen:
     off-delay-ms: 3500
     on-command:
@@ -245,7 +245,7 @@ buttond:
 The installer deploys `buttond.service`, which launches `/opt/photo-frame/bin/buttond --config /etc/photo-frame/config.yaml` as the `kiosk` user. At runtime the daemon behaves as follows:
 
 - **Single press:** writes `{ "command": "ToggleState" }` to the control socket, then toggles the screen. If the display was off it immediately executes the configured wake command; if the display was on it delays for `off-delay-ms` (so the sleep screen is visible) before running the sleep command. The daemon inspects `wlr-randr` output on each press instead of relying on cached state, so restarts and manual overrides stay in sync with reality.
-- **Double press:** executes the `shutdown-command`. The default uses `loginctl power-off`, and system provisioning installs a polkit rule so the `kiosk` user can issue the request without prompting.
+- **Double press:** executes the `shutdown-command`. The default uses `loginctl poweroff`, and system provisioning installs a polkit rule so the `kiosk` user can issue the request without prompting.
 - **Long press:** bypassed so the Pi firmware can force power-off.
 
 Auto-detection scans `/dev/input/by-path/*power*` before falling back to `/dev/input/event*`. Set `buttond.device` if the wrong input is chosen. Provisioning also pins `HandlePowerKey=ignore` inside `/etc/systemd/logind.conf` so logind never interprets presses as global shutdown requests; only `buttond` reacts to the events.


### PR DESCRIPTION
## Summary
- switch the button daemon's default shutdown command to `loginctl poweroff`
- update the sample configuration and documentation to reflect the new verb
- confirm provisioning references align with the revised shutdown command

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f6f48d189483239011a9de132bd2a1