### PR TITLE
Handle missing Wayland environment variables in powerctl

### DIFF
--- a/docs/power-and-sleep.md
+++ b/docs/power-and-sleep.md
@@ -37,11 +37,12 @@ wlr-randr --output @OUTPUT@ --on  || vcgencmd display_power 1
 ```
 `@OUTPUT@` is replaced with the first connected output reported by `wlr-randr`. If detection fails the code falls back to `HDMI-A-1` and logs a warning.
 
-`/opt/photo-frame/bin/powerctl` wraps the same logic. It auto-detects the first connected output, falls back to `HDMI-A-1`, and chains `vcgencmd` so you do not need to duplicate shell logic in your configuration. The helper is safe to call from other scripts:
+`/opt/photo-frame/bin/powerctl` wraps the same logic. It bootstraps the Wayland session when the caller omitted environment variables by exporting `XDG_RUNTIME_DIR=/run/user/$(id -u)` and picking the first `wayland-*` socket in that directory, then auto-detects the first connected output, falls back to `HDMI-A-1`, and chains `vcgencmd` so you do not need to duplicate shell logic in your configuration. The helper is safe to call from other scripts:
 ```bash
 powerctl sleep        # auto-detect output
 powerctl wake HDMI-A-1 # override the connector
 ```
+If no Wayland socket can be located, the helper now exits with a clear diagnostic so `buttond` and other callers surface the real failure instead of the generic “failed to connect” message. wlroots compositors publish sockets named `wayland-*`; custom setups should align with that convention or export `WAYLAND_DISPLAY` explicitly before invoking `powerctl`.
 
 ### CLI support
 

--- a/setup/assets/app/bin/powerctl
+++ b/setup/assets/app/bin/powerctl
@@ -6,6 +6,53 @@ if [[ -z "$MODE" ]]; then
   echo "usage: powerctl {sleep|wake} [OUTPUT]" >&2
   exit 2
 fi
+
+pick_wayland_socket() {
+  local runtime_dir="${1%/}"
+  local matches
+
+  if ! matches=$(compgen -G "${runtime_dir}/wayland-*"); then
+    return 1
+  fi
+
+  local candidate
+  while IFS= read -r candidate; do
+    if [[ -S "$candidate" ]]; then
+      basename "$candidate"
+      return 0
+    fi
+  done <<<"$matches"
+
+  return 1
+}
+
+ensure_wayland_env() {
+  if [[ -z "${XDG_RUNTIME_DIR:-}" ]]; then
+    local derived="/run/user/$(id -u)"
+    if [[ -d "$derived" ]]; then
+      export XDG_RUNTIME_DIR="$derived"
+    else
+      echo "powerctl: XDG_RUNTIME_DIR is unset and derived path '$derived' does not exist" >&2
+      exit 1
+    fi
+  fi
+
+  if [[ ! -d "$XDG_RUNTIME_DIR" ]]; then
+    echo "powerctl: XDG_RUNTIME_DIR '$XDG_RUNTIME_DIR' does not exist" >&2
+    exit 1
+  fi
+
+  if [[ -z "${WAYLAND_DISPLAY:-}" ]]; then
+    local socket
+    if ! socket="$(pick_wayland_socket "$XDG_RUNTIME_DIR")"; then
+      echo "powerctl: no Wayland display sockets found in $XDG_RUNTIME_DIR" >&2
+      exit 1
+    fi
+    export WAYLAND_DISPLAY="$socket"
+  fi
+}
+
+ensure_wayland_env
 detect_out() {
   wlr-randr | awk '
     function commit() {


### PR DESCRIPTION
## Summary
- derive default Wayland environment variables in `powerctl` before invoking `wlr-randr`
- exit with a descriptive error when no compositor socket can be located
- document the helper's environment bootstrapping and socket naming assumptions

## Testing
- not run (not feasible in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f6f48bcb8c8323bffe77e57e41544c