### PR TITLE
Handle gateway reachability errors while monitoring connection

### DIFF
--- a/crates/wifi-manager/src/web.rs
+++ b/crates/wifi-manager/src/web.rs
@@ -158,7 +158,8 @@ async fn monitor_connection(state: UiState, ssid: String) {
                     }
                     return;
                 }
-                return;
+                Ok(false) => {}
+                Err(err) => warn!(error = ?err, "gateway reachability check failed while monitoring"),
             }
             Ok(false) => {}
             Err(err) => warn!(error = ?err, "device connectivity check failed while monitoring"),


### PR DESCRIPTION
## Summary
- add explicit handling for gateway reachability checks when monitoring Wi-Fi recovery
- keep returning early only when both the infrastructure and gateway checks succeed

## Testing
- cargo build -p wifi-manager

------
https://chatgpt.com/codex/tasks/task_e_68f6f8d12ac88323a631c0989ef87d3f