### PR TITLE
Refactor buttond wake/sleep control and add scheduler

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,7 @@ buttond:
   debounce-ms: 20
   single-window-ms: 250
   double-window-ms: 400
+  sleep-grace-ms: 300000 # Delay before scheduled sleep after a manual wake (ms)
   shutdown-command:
     program: /usr/bin/systemctl
     args: [poweroff]

--- a/crates/buttond/Cargo.toml
+++ b/crates/buttond/Cargo.toml
@@ -9,12 +9,15 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.100"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+chrono-tz = "0.10"
 clap = { version = "4.5.48", features = ["derive"] }
 evdev = "0.13"
 humantime = "2.1.0"
 nix = { version = "0.30.0", default-features = false, features = ["fs"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_yaml = "0.9.34"
+serde_json = "1.0"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["fmt", "env-filter"] }
 config-model = { path = "../config-model" }


### PR DESCRIPTION
## Summary
- refactor buttond runtime to send set-state commands, coordinate wake/sleep helpers, and share state across manual and scheduled events
- add a scheduler worker that reuses the shared awake schedule with greeting-delay and sleep-grace configuration
- harden control-socket retries, expose the new timing knob in config, and add targeted unit tests covering wake, sleep, and scheduler behavior

## Testing
- cargo test -p buttond

------
https://chatgpt.com/codex/tasks/task_e_68f98d1c6f588323815cb90184d93d5c