### PR TITLE
feat(iris): add WGSL iris stroke renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ See [assets/backgrounds/Credits.md](assets/backgrounds/Credits.md) for image att
 
 - **Procedural studio mat weave texture.** Our weave shading is adapted from Mike Cauchi’s breakdown of tillable cloth shading, which layers sine-profiled warp/weft threads with randomized grain to keep the pattern from banding. See ["Research – Tillable Images and Cloth Shading"](https://www.mikecauchiart.com/single-post/2017/01/23/research-tillable-images-and-cloth-shading).
 - **Print simulation shading.** The gallery-lighting and relief model follows guidance from Rohit A. Patil, Mark D. Fairchild, and Garrett M. Johnson’s paper ["3D Simulation of Prints for Improved Soft Proofing"](https://doi.org/10.1117/12.813471).
-- **Iris transition geometry.** Our polygonal iris closure uses the trigonometric projection technique described in ["How to calculate polygons for camera aperture animation?"](https://stackoverflow.com/a/57571325), which maps fragment angles into blade sectors for precise aperture radii.
+- **Iris transition rendering.** The iris occluder is computed analytically in WGSL for smooth, artifact‑free opening/closing, while crisp blade outlines are rendered by a dedicated Bézier stroke pass. This splits composition from stroke styling for cleaner code and better performance on the Pi.
 
 ## AI Statement
 

--- a/config.yaml
+++ b/config.yaml
@@ -64,7 +64,6 @@ transition:
       fill-rgba: [0.85, 0.85, 0.85, 1.0]
       stroke-rgba: [0.10, 0.10, 0.10, 1.0]
       stroke-width: 1.5
-      tolerance: 0.25
 
 # Dwell time (ms) the current image remains fully displayed before the next transition
 dwell-ms: 2000

--- a/crates/photo-frame/src/config.rs
+++ b/crates/photo-frame/src/config.rs
@@ -1911,7 +1911,6 @@ impl TransitionOptions {
                     fill_rgba: builder.iris_fill_rgba.unwrap_or(defaults.fill_rgba),
                     stroke_rgba: builder.iris_stroke_rgba.unwrap_or(defaults.stroke_rgba),
                     stroke_width: builder.iris_stroke_width.unwrap_or(defaults.stroke_width),
-                    tolerance: builder.iris_tolerance.unwrap_or(defaults.tolerance),
                     stroke_enabled: builder
                         .iris_stroke_enabled
                         .unwrap_or(defaults.stroke_enabled),
@@ -2105,7 +2104,6 @@ pub struct IrisTransition {
     pub fill_rgba: [f32; 4],
     pub stroke_rgba: [f32; 4],
     pub stroke_width: f32,
-    pub tolerance: f32,
     pub stroke_enabled: bool,
     pub radius: f32,
     pub stroke_segments_per_90deg: u32,
@@ -2122,7 +2120,6 @@ impl Default for IrisTransition {
             fill_rgba: [0.85, 0.85, 0.85, 1.0],
             stroke_rgba: [0.10, 0.10, 0.10, 1.0],
             stroke_width: 2.0,
-            tolerance: 0.25,
             stroke_enabled: true,
             radius: 80.0,
             stroke_segments_per_90deg: 6,
@@ -2179,11 +2176,6 @@ impl IrisTransition {
         if self.stroke_width < 0.0 {
             self.stroke_width = 0.0;
         }
-        ensure!(
-            self.tolerance.is_finite(),
-            format!("transition option {} has non-finite iris.tolerance", kind)
-        );
-        self.tolerance = self.tolerance.clamp(0.01, 2.0);
         ensure!(
             self.radius.is_finite(),
             format!("transition option {} has non-finite iris.radius", kind)
@@ -2310,7 +2302,6 @@ struct TransitionOptionBuilder {
     iris_fill_rgba: Option<[f32; 4]>,
     iris_stroke_rgba: Option<[f32; 4]>,
     iris_stroke_width: Option<f32>,
-    iris_tolerance: Option<f32>,
     iris_stroke_enabled: Option<bool>,
     iris_radius: Option<f32>,
     iris_segments_per_90deg: Option<u32>,
@@ -2459,9 +2450,6 @@ fn apply_transition_inline_field<E: de::Error>(
         "stroke-px" | "stroke_px" if matches!(kind, TransitionKind::Iris) => {
             builder.iris_stroke_width = Some(inline_value_to::<f32, E>(value)?);
         }
-        "tolerance" if matches!(kind, TransitionKind::Iris) => {
-            builder.iris_tolerance = Some(inline_value_to::<f32, E>(value)?);
-        }
         "enabled" if matches!(kind, TransitionKind::Iris) => {
             builder.iris_stroke_enabled = Some(inline_value_to::<bool, E>(value)?);
         }
@@ -2500,7 +2488,6 @@ fn apply_transition_inline_field<E: de::Error>(
                     "fill-rgba",
                     "stroke-rgba",
                     "stroke-width",
-                    "tolerance",
                     "enabled",
                     "petal-count",
                     "radius",

--- a/crates/photo-frame/src/tasks/shaders/iris_stroke.wgsl
+++ b/crates/photo-frame/src/tasks/shaders/iris_stroke.wgsl
@@ -1,0 +1,110 @@
+struct Cubic {
+  p0: vec2<f32>;
+  p1: vec2<f32>;
+  p2: vec2<f32>;
+  p3: vec2<f32>;
+};
+
+struct Params {
+  mvp: mat4x4<f32>;
+  viewport_px: vec2<f32>;
+  half_width_px: f32;
+  _pad0: f32;
+  segments_per_cubic: u32;
+  petal_count: u32;
+  cubics_count: u32;
+  _pad1: u32;
+  color_rgba: vec4<f32>;
+};
+
+@group(0) @binding(0) var<storage, read> cubics: array<Cubic>;
+@group(0) @binding(1) var<uniform> params: Params;
+
+fn eval_cubic(p0: vec2<f32>, p1: vec2<f32>, p2: vec2<f32>, p3: vec2<f32>, t: f32) -> vec2<f32> {
+  let omt = 1.0 - t;
+  let omt2 = omt * omt;
+  let t2  = t * t;
+  return p0 * (omt2 * omt) +
+         p1 * (3.0 * omt2 * t) +
+         p2 * (3.0 * omt * t2) +
+         p3 * (t2 * t);
+}
+
+fn to_clip(p: vec2<f32>) -> vec4<f32> {
+  return params.mvp * vec4<f32>(p, 0.0, 1.0);
+}
+
+fn clip_to_ndc_xy(c: vec4<f32>) -> vec2<f32> {
+  return c.xy / c.w;
+}
+
+fn px_to_ndc(px: vec2<f32>) -> vec2<f32> {
+  return 2.0 * px / params.viewport_px;
+}
+
+fn safe_normalize(v: vec2<f32>) -> vec2<f32> {
+  let len = length(v);
+  if len > 1e-5 {
+    return v / len;
+  }
+  return vec2<f32>(0.0, 1.0);
+}
+
+struct VSOut {
+  @builtin(position) pos: vec4<f32>,
+  @location(0) v_color: vec4<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vid: u32,
+           @builtin(instance_index) iid: u32) -> VSOut {
+  let segs = max(params.segments_per_cubic, 1u);
+  let total_steps = segs * params.cubics_count;
+
+  let k = min(vid >> 1u, total_steps);
+  let side = (vid & 1u);
+
+  let cubic_idx = select(k / segs, 0u, params.cubics_count == 0u);
+  let step_in_cubic = select(k % segs, 0u, params.cubics_count == 0u);
+
+  let inv_segs = 1.0 / f32(segs);
+  let t0 = f32(step_in_cubic) * inv_segs;
+  let t1 = min(1.0, t0 + inv_segs);
+
+  let c = cubics[cubic_idx];
+  var p0 = eval_cubic(c.p0, c.p1, c.p2, c.p3, t0);
+  let p1 = eval_cubic(c.p0, c.p1, c.p2, c.p3, t1);
+
+  let count = max(params.petal_count, 1u);
+  let angle = (f32(iid) * 6.28318530718) / f32(count);
+  let cs = cos(angle);
+  let sn = sin(angle);
+  let rot = mat2x2<f32>(cs, -sn, sn, cs);
+  p0 = rot * p0;
+  let p1r = rot * p1;
+
+  let p0_clip = to_clip(p0);
+  let p1_clip = to_clip(p1r);
+  let p0_ndc = clip_to_ndc_xy(p0_clip);
+  let p1_ndc = clip_to_ndc_xy(p1_clip);
+
+  let dir = safe_normalize(p1_ndc - p0_ndc);
+  let n_ndc = vec2<f32>(-dir.y, dir.x);
+
+  let half_px = vec2<f32>(params.half_width_px, params.half_width_px);
+  let half_ndc = px_to_ndc(half_px);
+
+  let offset_ndc = safe_normalize(n_ndc) * half_ndc;
+  let signed = select(-1.0, 1.0, side == 1u);
+  let out_ndc = p0_ndc + signed * offset_ndc;
+
+  var outv: VSOut;
+  outv.pos = vec4<f32>(out_ndc, 0.0, 1.0);
+  outv.v_color = params.color_rgba;
+  return outv;
+}
+
+@fragment
+fn fs_main(@location(0) v_color: vec4<f32>) -> @location(0) vec4<f32> {
+  return v_color;
+}

--- a/crates/photo-frame/src/tasks/shaders/iris_stroke.wgsl
+++ b/crates/photo-frame/src/tasks/shaders/iris_stroke.wgsl
@@ -95,8 +95,8 @@ fn vs_main(@builtin(vertex_index) vid: u32,
   let half_ndc = px_to_ndc(half_px);
 
   let offset_ndc = safe_normalize(n_ndc) * half_ndc;
-  let signed = select(-1.0, 1.0, side == 1u);
-  let out_ndc = p0_ndc + signed * offset_ndc;
+  let side_sign = select(-1.0, 1.0, side == 1u);
+  let out_ndc = p0_ndc + side_sign * offset_ndc;
 
   var outv: VSOut;
   outv.pos = vec4<f32>(out_ndc, 0.0, 1.0);

--- a/crates/photo-frame/src/tasks/shaders/iris_stroke.wgsl
+++ b/crates/photo-frame/src/tasks/shaders/iris_stroke.wgsl
@@ -2,8 +2,8 @@
 // Matches the SVG construction (arcs from equal-radius disks).
 // Stroke width is in pixels and kept visually constant with proper AA.
 
-let PI  : f32 = 3.1415926535897932384626433832795;
-let TAU : f32 = 6.283185307179586476925286766559;
+const PI  : f32 = 3.1415926535897932384626433832795;
+const TAU : f32 = 6.283185307179586476925286766559;
 
 fn rot2(p: vec2<f32>, a: f32) -> vec2<f32> {
   let c = cos(a);

--- a/crates/photo-frame/src/tasks/shaders/iris_stroke.wgsl
+++ b/crates/photo-frame/src/tasks/shaders/iris_stroke.wgsl
@@ -1,20 +1,20 @@
 struct Cubic {
-  p0: vec2<f32>;
-  p1: vec2<f32>;
-  p2: vec2<f32>;
-  p3: vec2<f32>;
+  p0: vec2<f32>,
+  p1: vec2<f32>,
+  p2: vec2<f32>,
+  p3: vec2<f32>,
 };
 
 struct Params {
-  mvp: mat4x4<f32>;
-  viewport_px: vec2<f32>;
-  half_width_px: f32;
-  _pad0: f32;
-  segments_per_cubic: u32;
-  petal_count: u32;
-  cubics_count: u32;
-  _pad1: u32;
-  color_rgba: vec4<f32>;
+  mvp: mat4x4<f32>,
+  viewport_px: vec2<f32>,
+  half_width_px: f32,
+  _pad0: f32,
+  segments_per_cubic: u32,
+  petal_count: u32,
+  cubics_count: u32,
+  _pad1: u32,
+  color_rgba: vec4<f32>,
 };
 
 @group(0) @binding(0) var<storage, read> cubics: array<Cubic>;

--- a/crates/photo-frame/src/tasks/shaders/iris_stroke.wgsl
+++ b/crates/photo-frame/src/tasks/shaders/iris_stroke.wgsl
@@ -1,6 +1,5 @@
-// Curved-blade iris stroke using the same SDF as the fill shader.
-// Matches the SVG construction (arcs from equal-radius disks).
-// Stroke width is in pixels and kept visually constant with proper AA.
+// Geometry-driven iris stroke shader matching the pipeline layout in
+// crates/photo-frame/src/tasks/viewer/iris/mod.rs and geometry.rs
 
 const PI  : f32 = 3.1415926535897932384626433832795;
 const TAU : f32 = 6.283185307179586476925286766559;
@@ -11,81 +10,95 @@ fn rot2(p: vec2<f32>, a: f32) -> vec2<f32> {
   return vec2<f32>(c * p.x - s * p.y, s * p.x + c * p.y);
 }
 
-// --- uniforms ---------------------------------------------------------------
-// Adjust these names/types to match your existing bind group if needed.
-struct Globals {
-  resolution    : vec2<f32>; // framebuffer size in pixels (width, height)
-  aspect        : f32;       // width/height
-  open_scale    : f32;       // 0 (closed) .. 1 (fully open)
-  rotate_rad    : f32;       // iris rotation in radians
-  blades        : u32;       // number of blades
-  stroke_px     : f32;       // desired stroke width in *pixels*
-  _pad0         : vec3<f32>; // alignment padding
+// Storage buffer with cubic Bezier segments (built on CPU)
+struct Cubic {
+  p0: vec2<f32>,
+  p1: vec2<f32>,
+  p2: vec2<f32>,
+  p3: vec2<f32>,
 };
-@group(0) @binding(0) var<uniform> G : Globals;
+struct CubicBuf { data: array<Cubic>, };
+@group(0) @binding(0) var<storage, read> CUBICS: CubicBuf;
 
-struct VsOut {
-  @location(0) uv : vec2<f32>;
-  @builtin(position) pos: vec4<f32>;
+// Uniform parameters (kept in sync with geometry.rs::Params)
+struct Params {
+  mvp: mat4x4<f32>,
+  viewport_px: vec2<f32>,
+  half_width_px: f32,
+  _pad0: f32,
+  segments_per_cubic: u32,
+  petal_count: u32,
+  cubics_count: u32,
+  _pad1: u32,
+  color_rgba: vec4<f32>,
 };
+@group(0) @binding(1) var<uniform> P: Params;
 
-// --- curved-blade boundary ---------------------------------------------------
-// Returns factor s so that boundary radius = s * (G.aspect * G.open_scale).
-fn iris_boundary_factor(uv: vec2<f32>) -> f32 {
-  // Work in isotropic space so circles stay round: scale X by aspect
-  let p_iso = (uv * 2.0 - vec2<f32>(1.0, 1.0)) * vec2<f32>(G.aspect, 1.0);
-  let theta = atan2(p_iso.y, p_iso.x);
-  let u = vec2<f32>(cos(theta), sin(theta));
-
-  // Circle radius R sets the fully-open horizontal span.
-  let R = G.aspect; // half-width in isotropic units
-  // Centers move outward as the iris closes.
-  let d = (1.0 - clamp(G.open_scale, 0.0, 1.0)) * R;
-
-  let step = TAU / f32(G.blades);
-  let rc = mat2x2<f32>(cos(G.rotate_rad), -sin(G.rotate_rad),
-                       sin(G.rotate_rad),  cos(G.rotate_rad));
-
-  var r_min = 1e9;
-  for (var i: u32 = 0u; i < G.blades; i = i + 1u) {
-    let ang = f32(i) * step;
-    let c_local = vec2<f32>(d * cos(ang), d * sin(ang));
-    let c = rc * c_local;
-    let cu = dot(c, u);
-    let disc = max(R * R - dot(c, c) + cu * cu, 0.0);
-    let lam = cu + sqrt(disc);   // ray–circle first hit
-    r_min = min(r_min, lam);
-  }
-  // Factor so boundary radius = factor * (aspect * open_scale)
-  return r_min / max(G.aspect * max(G.open_scale, 1e-4), 1e-4);
+fn cubic_point(c: Cubic, t: f32) -> vec2<f32> {
+  let u = 1.0 - t;
+  return (u * u * u) * c.p0 +
+         (3.0 * u * u * t) * c.p1 +
+         (3.0 * u * t * t) * c.p2 +
+         (t * t * t) * c.p3;
 }
 
-// Signed distance to the iris edge in isotropic space (positive inside).
-fn iris_sdf(uv: vec2<f32>) -> f32 {
-  let p_iso = (uv * 2.0 - vec2<f32>(1.0, 1.0)) * vec2<f32>(G.aspect, 1.0);
-  let pr = rot2(p_iso, G.rotate_rad);
-  let r = length(pr);
-  let factor = iris_boundary_factor(uv);
-  let boundary = clamp(G.open_scale, 0.0, 1.0) * G.aspect * factor;
-  return boundary - r;
+fn cubic_tangent(c: Cubic, t: f32) -> vec2<f32> {
+  let u = 1.0 - t;
+  return 3.0 * u * u * (c.p1 - c.p0) +
+         6.0 * u * t * (c.p2 - c.p1) +
+         3.0 * t * t * (c.p3 - c.p2);
+}
+
+fn to_clip(p: vec2<f32>) -> vec2<f32> {
+  return (P.mvp * vec4<f32>(p, 0.0, 1.0)).xy;
+}
+
+fn dir_to_clip(d: vec2<f32>) -> vec2<f32> {
+  return (P.mvp * vec4<f32>(d, 0.0, 0.0)).xy;
+}
+
+struct VsOut {
+  @builtin(position) pos: vec4<f32>,
+};
+
+@vertex
+fn vs_main(@builtin(vertex_index) vid: u32, @builtin(instance_index) iid: u32) -> VsOut {
+  // Map vertex index to (cubic, segment, side)
+  let segs = max(P.segments_per_cubic, 1u);
+  let seg_idx_global = vid >> 1u;            // 1 pair per segment
+  let side = (vid & 1u);                     // 0 -> one side, 1 -> other
+  let cubic_idx = seg_idx_global / segs;
+  let seg_idx_local = seg_idx_global - cubic_idx * segs;
+
+  let cubic = CUBICS.data[min(cubic_idx, P.cubics_count - 1u)];
+  let t = f32(seg_idx_local) / f32(segs);
+
+  // Instance rotation around origin to duplicate petals
+  let petals = max(P.petal_count, 1u);
+  let phi = TAU * (f32(iid) / f32(petals));
+
+  let p_local = rot2(cubic_point(cubic, t), phi);
+  let d_local = rot2(cubic_tangent(cubic, t), phi);
+
+  // Convert to clip, then compute pixel-constant normal offset
+  let p_clip = to_clip(p_local);
+  let t_clip = dir_to_clip(d_local);
+
+  // Convert clip-space direction to pixel space for constant width
+  let px_per_clip = 0.5 * P.viewport_px; // since clip spans [-1,1]
+  let t_px = vec2<f32>(t_clip.x * px_per_clip.x, t_clip.y * px_per_clip.y);
+  let len_t = max(length(t_px), 1e-6);
+  let n_px = vec2<f32>(-t_px.y, t_px.x) / len_t;
+  let sign = select(-1.0, 1.0, side == 1u);
+  let off_px = n_px * (P.half_width_px * sign);
+  let off_clip = vec2<f32>(off_px.x / px_per_clip.x, off_px.y / px_per_clip.y);
+
+  var out: VsOut;
+  out.pos = vec4<f32>(p_clip + off_clip, 0.0, 1.0);
+  return out;
 }
 
 @fragment
-fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
-  let sdf = iris_sdf(in.uv);
-
-  // Convert stroke width from pixels to isotropic NDC units (Y maps to 2.0)
-  let stroke_ndc = (G.stroke_px / max(G.resolution.y, 1.0)) * 2.0;
-
-  // Draw where |sdf| <= w/2, with smooth AA around the edges.
-  let edge = abs(sdf) - 0.5 * stroke_ndc;
-  let aa  = max(fwidth(edge), 1e-4);
-  let alpha = 1.0 - smoothstep(0.0, aa, edge);
-
-  // Colors — wire these in from your pipeline as needed.
-  let stroke_color = vec3<f32>(0.0, 0.0, 0.0); // black outline
-  let bg_color     = vec3<f32>(0.0, 0.0, 0.0); // premultiplied over your fill
-
-  let rgb = mix(bg_color, stroke_color, alpha);
-  return vec4<f32>(rgb, alpha);
+fn fs_main(_in: VsOut) -> @location(0) vec4<f32> {
+  return P.color_rgba;
 }

--- a/crates/photo-frame/src/tasks/shaders/viewer_quad.wgsl
+++ b/crates/photo-frame/src/tasks/shaders/viewer_quad.wgsl
@@ -14,6 +14,8 @@ struct TransitionUniforms {
   _pad0: f32,
   iris_blades: u32,
   _pad1: u32,
+  // Final pad so the struct size rounds up to 128 bytes (std140 multiple of 16)
+  _pad2: vec2<u32>,
 };
 
 @group(0) @binding(0)

--- a/crates/photo-frame/src/tasks/shaders/viewer_quad.wgsl
+++ b/crates/photo-frame/src/tasks/shaders/viewer_quad.wgsl
@@ -7,14 +7,13 @@ struct TransitionUniforms {
   params0: vec4<f32>,
   params1: vec4<f32>,
   params2: vec4<f32>,
-  params3: vec4<f32>,
   t: f32,
   aspect: f32,
   iris_rotate_rad: f32,
-  iris_pad0: f32,
+  // Pad f32 to align next u32 pair to 16 bytes boundary
+  _pad0: f32,
   iris_blades: u32,
-  iris_direction: u32,
-  iris_pad1: vec2<u32>,
+  _pad1: u32,
 };
 
 @group(0) @binding(0)

--- a/crates/photo-frame/src/tasks/shaders/viewer_quad.wgsl
+++ b/crates/photo-frame/src/tasks/shaders/viewer_quad.wgsl
@@ -95,6 +95,7 @@ fn iris_boundary(
   aspect: f32,
   blades: u32,
   rotate_rad: f32,
+  open_scale: f32,
   // Returns the unscaled boundary radius (in aspect-corrected units) and a
   // boolean indicating if a valid boundary was computed.
 ) -> f32 {
@@ -148,7 +149,7 @@ fn iris_mask(
   let p = (uv * 2.0 - vec2<f32>(1.0, 1.0)) * vec2<f32>(aspect, 1.0);
   let pr = rot2(p, rotate_rad);
   let r = length(pr);
-  let factor = iris_boundary(uv, aspect, blades, rotate_rad);
+  let factor = iris_boundary(uv, aspect, blades, rotate_rad, open_scale);
   let boundary = clamp(open_scale, 0.0, 1.0) * aspect * factor;
   let sdf = boundary - r;
   let aa = max(fwidth(sdf), 1e-4);

--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -55,7 +55,6 @@ pub(super) enum ActiveTransition {
         fill_rgba: [f32; 4],
         stroke_rgba: [f32; 4],
         stroke_width: f32,
-        tolerance: f32,
         stroke_enabled: bool,
         radius: f32,
         segments_per_90deg: u32,
@@ -141,7 +140,6 @@ impl TransitionState {
                 fill_rgba: cfg.fill_rgba,
                 stroke_rgba: cfg.stroke_rgba,
                 stroke_width: cfg.stroke_width,
-                tolerance: cfg.tolerance,
                 stroke_enabled: cfg.stroke_enabled,
                 radius: cfg.radius,
                 segments_per_90deg: cfg.stroke_segments_per_90deg,
@@ -2486,23 +2484,9 @@ pub fn run_windowed(
                             }
 
                             let mut should_draw_quad = false;
-                            let debug_bezier = std::env::var("PHOTOFRAME_DEBUG_BEZIER")
-                                .map(|s| matches!(s.as_str(), "1" | "true" | "yes" | "on"))
-                                .unwrap_or(false);
                             let mut iris_request: Option<IrisConfig> = None;
 
-                            if debug_bezier {
-                                // Draw current image and overlay a debug quadratic Bezier stroke.
-                                uniforms.kind = 6; // bezier overlay
-                                // Control points in UV for a gentle arc across center
-                                uniforms.params0 = [0.15, 0.60, 0.50, 0.25]; // P0.xy, P1.xy
-                                uniforms.params1[0] = 0.85; // P2.x
-                                uniforms.params1[1] = 0.60; // P2.y
-                                uniforms.params1[2] = 4.0; // stroke width px
-                                // Red stroke by default
-                                uniforms.params3 = [1.0, 0.1, 0.1, 1.0];
-                                should_draw_quad = have_current;
-                            } else if let Some(state) = wake.transition_state() {
+                            if let Some(state) = wake.transition_state() {
                                 match state.variant() {
                                     ActiveTransition::Iris {
                                         blades,
@@ -2511,7 +2495,6 @@ pub fn run_windowed(
                                         fill_rgba,
                                         stroke_rgba,
                                         stroke_width,
-                                        tolerance,
                                         stroke_enabled,
                                         radius,
                                         segments_per_90deg,
@@ -2524,7 +2507,6 @@ pub fn run_windowed(
                                         let fill_rgba = *fill_rgba;
                                         let stroke_rgba = *stroke_rgba;
                                         let stroke_width = *stroke_width;
-                                        let _tolerance = *tolerance;
                                         let stroke_enabled = *stroke_enabled;
                                         let radius = *radius;
                                         let segments_per_90deg = *segments_per_90deg;

--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -799,6 +799,7 @@ pub fn run_windowed(
         _pad0: f32,
         iris_blades: u32,
         _pad1: u32,
+        _pad2: [u32; 2],
     }
 
     struct GpuCtx {
@@ -2450,6 +2451,7 @@ pub fn run_windowed(
                                 _pad0: 0.0,
                                 iris_blades: 0,
                                 _pad1: 0,
+                                _pad2: [0, 0],
                             };
                             let mut current_bind = &gpu.blank_plane.bind;
                             let mut next_bind = &gpu.blank_plane.bind;

--- a/crates/photo-frame/src/tasks/viewer.rs
+++ b/crates/photo-frame/src/tasks/viewer.rs
@@ -793,14 +793,12 @@ pub fn run_windowed(
         params0: [f32; 4],
         params1: [f32; 4],
         params2: [f32; 4],
-        params3: [f32; 4],
         t: f32,
         aspect: f32,
         iris_rotate_rad: f32,
-        iris_pad0: f32,
+        _pad0: f32,
         iris_blades: u32,
-        iris_direction: u32,
-        iris_pad1: [u32; 2],
+        _pad1: u32,
     }
 
     struct GpuCtx {
@@ -2446,14 +2444,12 @@ pub fn run_windowed(
                                 params0: [0.0; 4],
                                 params1: [0.0; 4],
                                 params2: [0.0; 4],
-                                params3: [0.0; 4],
                                 t: 0.0,
                                 aspect,
                                 iris_rotate_rad: 0.0,
-                                iris_pad0: 0.0,
+                                _pad0: 0.0,
                                 iris_blades: 0,
-                                iris_direction: 0,
-                                iris_pad1: [0, 0],
+                                _pad1: 0,
                             };
                             let mut current_bind = &gpu.blank_plane.bind;
                             let mut next_bind = &gpu.blank_plane.bind;
@@ -2532,16 +2528,8 @@ pub fn run_windowed(
                                             uniforms.aspect = aspect;
                                             uniforms.iris_blades = blades;
                                             uniforms.iris_rotate_rad = rotate_radians;
-                                            uniforms.iris_direction =
-                                                if matches!(direction, IrisDirection::Close) {
-                                                    1
-                                                } else {
-                                                    0
-                                                };
-                                            // Provide occluder fill/stroke and stroke width to WGSL path
-                                            uniforms.params2 = fill_rgba; // fill RGBA
-                                            uniforms.params3 = stroke_rgba; // stroke RGBA
-                                            uniforms.iris_pad0 = stroke_width; // stroke width in px
+                                            // Provide occluder fill to WGSL path
+        										uniforms.params2 = fill_rgba; // fill RGBA
                                             should_draw_quad = true;
                                             iris_request = Some(if stroke_enabled {
                                                 IrisConfig {

--- a/crates/photo-frame/src/tasks/viewer/iris/geometry.rs
+++ b/crates/photo-frame/src/tasks/viewer/iris/geometry.rs
@@ -1,0 +1,234 @@
+use std::f32::consts::{FRAC_PI_2, TAU};
+
+use wgpu::util::DeviceExt;
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Cubic {
+    pub p0: [f32; 2],
+    pub p1: [f32; 2],
+    pub p2: [f32; 2],
+    pub p3: [f32; 2],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Params {
+    pub mvp: [[f32; 4]; 4],
+    pub viewport_px: [f32; 2],
+    pub half_width_px: f32,
+    pub _pad0: f32,
+    pub segments_per_cubic: u32,
+    pub petal_count: u32,
+    pub cubics_count: u32,
+    pub _pad1: u32,
+    pub color_rgba: [f32; 4],
+}
+
+#[derive(Clone)]
+pub struct IrisStrokeBuffers {
+    pub cubics: wgpu::Buffer,
+    pub params: wgpu::Buffer,
+}
+
+pub fn build_iris_petal_cubics(
+    radius: f32,
+    count: u32,
+    value: f32,
+    segments_per_90deg: u32,
+) -> Vec<Cubic> {
+    if !radius.is_finite() || radius <= 0.0 || count == 0 {
+        return Vec::new();
+    }
+
+    let count_f = count as f32;
+    let step = std::f32::consts::PI * (0.5 + 2.0 / count_f);
+    let p1x = step.cos() * radius;
+    let p1y = step.sin() * radius;
+
+    let cos_v = (-value).cos();
+    let sin_v = (-value).sin();
+
+    let c1x = p1x - cos_v * p1x - sin_v * p1y;
+    let c1y = p1y - cos_v * p1y + sin_v * p1x;
+
+    let dx = -sin_v * radius - c1x;
+    let dy = radius - cos_v * radius - c1y;
+    let dc = (dx * dx + dy * dy).sqrt();
+    let denom = (2.0 * radius).max(f32::EPSILON);
+    let cos_term = (dc / denom).clamp(-1.0, 1.0);
+    let a = dy.atan2(dx) - cos_term.acos();
+    let x = c1x + a.cos() * radius;
+    let y = c1y + a.sin() * radius;
+
+    let mut cubics = Vec::new();
+
+    let theta_p1 = p1y.atan2(p1x);
+    let theta_q = FRAC_PI_2;
+    cubics.extend(arc_to_cubics(
+        [0.0, 0.0],
+        radius,
+        theta_p1,
+        theta_q,
+        false,
+        segments_per_90deg,
+    ));
+
+    let theta_q_c1 = (radius - c1y).atan2(0.0 - c1x);
+    let theta_r_c1 = (y - c1y).atan2(x - c1x);
+    cubics.extend(arc_to_cubics(
+        [c1x, c1y],
+        radius,
+        theta_q_c1,
+        theta_r_c1,
+        true,
+        segments_per_90deg,
+    ));
+
+    cubics
+}
+
+fn arc_to_cubics(
+    center: [f32; 2],
+    radius: f32,
+    a0: f32,
+    a1: f32,
+    ccw: bool,
+    segments_per_90deg: u32,
+) -> Vec<Cubic> {
+    if !radius.is_finite() || radius <= 0.0 {
+        return Vec::new();
+    }
+
+    let mut total_angle = a1 - a0;
+    if ccw {
+        while total_angle <= 0.0 {
+            total_angle += TAU;
+        }
+    } else {
+        while total_angle >= 0.0 {
+            total_angle -= TAU;
+        }
+    }
+
+    let abs_angle = total_angle.abs();
+    if abs_angle < f32::EPSILON {
+        return Vec::new();
+    }
+
+    let quarter_count = ((abs_angle / FRAC_PI_2).ceil() as u32).max(1);
+    let seg_per_quarter = segments_per_90deg.max(1);
+    let total_segments = quarter_count.saturating_mul(seg_per_quarter).max(1);
+    let delta = total_angle / total_segments as f32;
+
+    let mut cubics = Vec::with_capacity(total_segments as usize);
+    for idx in 0..total_segments {
+        let theta0 = a0 + delta * idx as f32;
+        let theta1 = theta0 + delta;
+
+        let p0 = point_on_circle(center, radius, theta0);
+        let p3 = point_on_circle(center, radius, theta1);
+
+        let k = 4.0 / 3.0 * (delta.abs() / 4.0).tan();
+        let t0 = tangent(theta0, ccw);
+        let t1 = tangent(theta1, ccw);
+
+        let p1 = [p0[0] + k * radius * t0[0], p0[1] + k * radius * t0[1]];
+        let p2 = [p3[0] - k * radius * t1[0], p3[1] - k * radius * t1[1]];
+
+        cubics.push(Cubic { p0, p1, p2, p3 });
+    }
+
+    cubics
+}
+
+fn point_on_circle(center: [f32; 2], radius: f32, theta: f32) -> [f32; 2] {
+    [
+        center[0] + radius * theta.cos(),
+        center[1] + radius * theta.sin(),
+    ]
+}
+
+fn tangent(theta: f32, ccw: bool) -> [f32; 2] {
+    if ccw {
+        [-theta.sin(), theta.cos()]
+    } else {
+        [theta.sin(), -theta.cos()]
+    }
+}
+
+fn make_mvp(radius: f32, rotation: f32) -> [[f32; 4]; 4] {
+    let scale = if radius.abs() < f32::EPSILON {
+        1.0
+    } else {
+        1.0 / radius
+    };
+    let (sin_r, cos_r) = rotation.sin_cos();
+
+    [
+        [cos_r * scale, -sin_r * scale, 0.0, 0.0],
+        [sin_r * scale, cos_r * scale, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+}
+
+pub fn rebuild_buffers(
+    device: &wgpu::Device,
+    cfg: &super::IrisConfig,
+    viewport: [f32; 2],
+) -> (IrisStrokeBuffers, usize, u32, Params) {
+    let mut cubics = build_iris_petal_cubics(
+        cfg.radius.max(f32::EPSILON),
+        cfg.petal_count.max(1),
+        cfg.value,
+        cfg.segments_per_90deg.max(1),
+    );
+
+    let actual_cubic_count = cubics.len() as u32;
+    if cubics.is_empty() {
+        cubics.push(Cubic {
+            p0: [0.0; 2],
+            p1: [0.0; 2],
+            p2: [0.0; 2],
+            p3: [0.0; 2],
+        });
+    }
+
+    let segments_per_cubic = cfg.segments_per_cubic.max(1);
+    let vertex_count = 2 * segments_per_cubic as usize * actual_cubic_count as usize;
+    let instance_count = cfg.petal_count.max(1);
+
+    let params = Params {
+        mvp: make_mvp(cfg.radius.max(f32::EPSILON), cfg.rotation),
+        viewport_px: viewport,
+        half_width_px: 0.5 * cfg.stroke_px,
+        _pad0: 0.0,
+        segments_per_cubic,
+        petal_count: cfg.petal_count.max(1),
+        cubics_count: actual_cubic_count,
+        _pad1: 0,
+        color_rgba: cfg.color_rgba,
+    };
+
+    let cubics_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("iris-cubics"),
+        contents: bytemuck::cast_slice(&cubics),
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+    });
+    let params_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("iris-params"),
+        contents: bytemuck::bytes_of(&params),
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+    });
+
+    (
+        IrisStrokeBuffers {
+            cubics: cubics_buf,
+            params: params_buf,
+        },
+        vertex_count,
+        instance_count,
+        params,
+    )
+}

--- a/crates/photo-frame/src/tasks/viewer/iris/mod.rs
+++ b/crates/photo-frame/src/tasks/viewer/iris/mod.rs
@@ -1,0 +1,214 @@
+mod geometry;
+
+use geometry::{IrisStrokeBuffers, Params, rebuild_buffers};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct IrisConfig {
+    pub enabled: bool,
+    pub petal_count: u32,
+    pub radius: f32,
+    pub stroke_px: f32,
+    pub segments_per_90deg: u32,
+    pub segments_per_cubic: u32,
+    pub color_rgba: [f32; 4],
+    pub value: f32,
+    pub rotation: f32,
+}
+
+impl IrisConfig {
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            petal_count: 0,
+            radius: 1.0,
+            stroke_px: 0.0,
+            segments_per_90deg: 1,
+            segments_per_cubic: 1,
+            color_rgba: [0.0, 0.0, 0.0, 1.0],
+            value: 0.0,
+            rotation: 0.0,
+        }
+    }
+}
+
+pub struct IrisRenderer {
+    pipeline: wgpu::RenderPipeline,
+    layout: wgpu::BindGroupLayout,
+    bind_group: Option<wgpu::BindGroup>,
+    buffers: Option<IrisStrokeBuffers>,
+    vertex_count: u32,
+    instance_count: u32,
+    last_params: Option<Params>,
+    last_cfg: Option<IrisConfig>,
+    last_viewport: Option<[f32; 2]>,
+}
+
+impl IrisRenderer {
+    pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Self {
+        let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("iris-stroke-bind-layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("iris-stroke-shader"),
+            source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(include_str!(
+                "../../shaders/iris_stroke.wgsl"
+            ))),
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("iris-stroke-pipeline-layout"),
+            bind_group_layouts: &[&layout],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("iris-stroke-pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleStrip,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: None,
+                unclipped_depth: false,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            multiview: None,
+            cache: None,
+        });
+
+        Self {
+            pipeline,
+            layout,
+            bind_group: None,
+            buffers: None,
+            vertex_count: 0,
+            instance_count: 0,
+            last_params: None,
+            last_cfg: None,
+            last_viewport: None,
+        }
+    }
+
+    pub fn resize(
+        &mut self,
+        _device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        viewport: [f32; 2],
+        cfg: &IrisConfig,
+    ) {
+        self.last_viewport = Some(viewport);
+        self.last_cfg = if cfg.enabled { Some(cfg.clone()) } else { None };
+        if let (Some(buffers), Some(params)) = (self.buffers.as_ref(), self.last_params.as_mut()) {
+            params.viewport_px = viewport;
+            queue.write_buffer(&buffers.params, 0, bytemuck::bytes_of(params));
+        }
+    }
+
+    pub fn update(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        viewport: [f32; 2],
+        cfg: &IrisConfig,
+    ) {
+        if !cfg.enabled || cfg.petal_count == 0 || cfg.stroke_px <= 0.0 {
+            self.disable();
+            return;
+        }
+
+        let (buffers, vertex_count, instance_count, params) =
+            rebuild_buffers(device, cfg, viewport);
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("iris-stroke-bind-group"),
+            layout: &self.layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: buffers.cubics.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: buffers.params.as_entire_binding(),
+                },
+            ],
+        });
+
+        queue.write_buffer(&buffers.params, 0, bytemuck::bytes_of(&params));
+
+        self.bind_group = Some(bind_group);
+        self.buffers = Some(buffers);
+        self.vertex_count = vertex_count.min(u32::MAX as usize) as u32;
+        self.instance_count = instance_count;
+        self.last_params = Some(params);
+        self.last_cfg = Some(cfg.clone());
+        self.last_viewport = Some(viewport);
+    }
+
+    pub fn disable(&mut self) {
+        self.bind_group = None;
+        self.buffers = None;
+        self.vertex_count = 0;
+        self.instance_count = 0;
+        self.last_params = None;
+        self.last_cfg = None;
+        self.last_viewport = None;
+    }
+
+    pub fn draw<'a>(&'a self, rpass: &mut wgpu::RenderPass<'a>) {
+        if self.vertex_count == 0 || self.instance_count == 0 {
+            return;
+        }
+        if let Some(bind) = &self.bind_group {
+            rpass.set_pipeline(&self.pipeline);
+            rpass.set_bind_group(0, bind, &[]);
+            rpass.draw(0..self.vertex_count, 0..self.instance_count);
+        }
+    }
+
+    pub fn last_config(&self) -> Option<&IrisConfig> {
+        self.last_cfg.as_ref()
+    }
+}

--- a/crates/photo-frame/tests/config_tests.rs
+++ b/crates/photo-frame/tests/config_tests.rs
@@ -701,12 +701,17 @@ transition:
   active:
     - kind: iris
       duration-ms: 880
-      blades: 9
+      enabled: true
+      petal-count: 9
       rotate-radians: 1.25
       direction: close
+      radius: 72.0
       fill-rgba: [0.75, 0.8, 0.85, 1.0]
-      stroke-rgba: [0.2, 0.25, 0.3, 1.0]
-      stroke-width: 2.0
+      color-rgba: [0.2, 0.25, 0.3, 1.0]
+      stroke-px: 2.0
+      segments-per-90deg: 4
+      segments-per-cubic: 12
+      value: 0.75
       tolerance: 0.2
 "#;
 
@@ -726,6 +731,7 @@ transition:
     match selected.option.mode() {
         rust_photo_frame::config::TransitionMode::Iris(cfg) => {
             assert_eq!(cfg.blades, 9);
+            assert!(cfg.stroke_enabled);
             assert!((cfg.rotate_radians - 1.25).abs() < f32::EPSILON);
             assert_eq!(
                 cfg.direction,
@@ -735,6 +741,10 @@ transition:
             assert_eq!(cfg.stroke_rgba, [0.2, 0.25, 0.3, 1.0]);
             assert!((cfg.stroke_width - 2.0).abs() < f32::EPSILON);
             assert!((cfg.tolerance - 0.2).abs() < f32::EPSILON);
+            assert!((cfg.radius - 72.0).abs() < f32::EPSILON);
+            assert_eq!(cfg.stroke_segments_per_90deg, 4);
+            assert_eq!(cfg.stroke_segments_per_cubic, 12);
+            assert!((cfg.stroke_value - 0.75).abs() < f32::EPSILON);
         }
         _ => panic!("expected iris transition"),
     }

--- a/crates/photo-frame/tests/config_tests.rs
+++ b/crates/photo-frame/tests/config_tests.rs
@@ -712,7 +712,6 @@ transition:
       segments-per-90deg: 4
       segments-per-cubic: 12
       value: 0.75
-      tolerance: 0.2
 "#;
 
     let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
@@ -740,7 +739,6 @@ transition:
             assert_eq!(cfg.fill_rgba, [0.75, 0.8, 0.85, 1.0]);
             assert_eq!(cfg.stroke_rgba, [0.2, 0.25, 0.3, 1.0]);
             assert!((cfg.stroke_width - 2.0).abs() < f32::EPSILON);
-            assert!((cfg.tolerance - 0.2).abs() < f32::EPSILON);
             assert!((cfg.radius - 72.0).abs() < f32::EPSILON);
             assert_eq!(cfg.stroke_segments_per_90deg, 4);
             assert_eq!(cfg.stroke_segments_per_cubic, 12);

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -364,10 +364,20 @@ The remaining knobs depend on the transition family.
   - **`stripe-count`** (integer ≥ 1, default `24`): How many horizontal bands sweep in; higher counts mimic a finer e-ink refresh.
   - **`flash-color`** (`[r, g, b]` array, default `[255, 255, 255]`): RGB color used for the bright flash phases before the black inversion. Channels outside `0–255` are clamped.
 - **`iris`**
-  - **`blades`** (integer, default `7`, clamped to `5–18`): Number of shutter spokes sketched around the aperture.
-  - **`blade-rgba`** (`[r, g, b, a]` float array, default `[0.12, 0.12, 0.12, 1.0]`): Base color for the iris blades. Channels outside `0–1` are clamped; the alpha component scales how dark the rendered blades appear.
+  - **`blades` / `petal-count`** (integer, default `7`, clamped to `3–12`): Number of shutter spokes around the aperture.
+  - **`rotate-radians`** (float, default `0.9`, clamped to `0–2π`): Total blade rotation applied over the course of the transition.
+  - **`direction`** (enum, default `open`): `open` re-opens from a small aperture; `close` closes first, then re-opens to reveal the next photo.
+  - **`fill-rgba`** (`[r, g, b, a]` float array, default `[0.85, 0.85, 0.85, 1.0]`): Occluder color used for the iris blades while they cover the image.
+  - Optional stroke overlay (drawn with the Bézier stroke pass):
+    - **`enabled`** (bool, default `true`): Enable/disable drawing blade outlines.
+    - **`stroke-rgba` / `color-rgba`** (`[r, g, b, a]` float array, default `[0.10, 0.10, 0.10, 1.0]`): Stroke color for the blade outlines.
+    - **`stroke-width` / `stroke-px`** (float pixels, default `2.0`, clamped to `≥ 0.0`): Stroke width in screen pixels.
+    - **`segments-per-90deg`** (integer ≥ 1, default `6`): Arc tessellation granularity per 90° when generating the blade curve.
+    - **`segments-per-cubic`** (integer ≥ 1, default `16`): Polyline steps per cubic Bezier when expanding the stroke on-GPU.
+    - **`radius`** (float > 0, default `80.0`): Geometric iris radius used in the analytic petal construction.
+    - **`value`** (float, default `1.04`, clamped to `0.0–1.2`): Petal curvature parameter controlling the shape of each blade edge.
 
-  The iris transition renders shaded SLR-style blades that first close over the current photo, then reopen to reveal the next one. Each half of the timeline is dedicated to one of those motions, producing a mechanical shutter feel.
+  The iris transition closes over the current photo, then reopens to reveal the next one. The occluder is composed in the main quad shader, while optional blade strokes are rendered by a dedicated Bézier stroke pass for crisp outlines.
 
 ### Example: single inline fade
 


### PR DESCRIPTION
## Summary
- add a GPU-driven iris stroke renderer that generates cubic Bézier strips and renders them with a new WGSL pipeline
- extend iris transition configuration with stroke geometry controls, logging, and parsing aliases for the new fields
- integrate the renderer into the viewer transition path and update tests to cover the expanded configuration surface

## Testing
- `cargo test --package rust-photo-frame config_tests::parse_inline_iris_transition`


------
https://chatgpt.com/codex/tasks/task_e_68f98d851d74832395d5800b3587e64f