### PR TITLE
Handle explicit display names in buttond power commands

### DIFF
--- a/crates/buttond/src/main.rs
+++ b/crates/buttond/src/main.rs
@@ -178,13 +178,20 @@ impl ButtondSettings {
         let greeting_screen_delay = greeting_screen.effective_duration();
         let sleep_grace = Duration::from_millis(buttond.sleep_grace_ms);
 
+        let mut screen_on_command = on_command.into_spec("screen-on");
+        let mut screen_off_command = off_command.into_spec("screen-off");
+        if let Some(name) = display_name.as_ref() {
+            screen_on_command.args.push(name.clone());
+            screen_off_command.args.push(name.clone());
+        }
+
         Ok(Self {
             device,
             durations,
             control_socket_path,
             shutdown_command,
-            screen_on_command: on_command.into_spec("screen-on"),
-            screen_off_command: off_command.into_spec("screen-off"),
+            screen_on_command,
+            screen_off_command,
             screen_off_delay,
             screen_display_name: display_name,
             greeting_screen_delay,

--- a/docs/power-and-sleep.md
+++ b/docs/power-and-sleep.md
@@ -24,6 +24,7 @@ buttond now owns wake/sleep scheduling for the frame. It evaluates the shared `a
      sleep-grace-ms: 300000
      screen:
        off-delay-ms: 3500
+       display-name: HDMI-A-2
        on-command:
          program: /opt/photo-frame/bin/powerctl
          args: [wake]
@@ -43,6 +44,8 @@ buttond now owns wake/sleep scheduling for the frame. It evaluates the shared `a
    ```
    buttond applies the configured schedule after the greeting delay, then continues driving wake/sleep transitions automatically.
 
+   Update `display-name` in the snippet to match the connector reported by `wlr-randr | grep connected` (for example `HDMI-A-1`).
+
 ## Configuration essentials
 
 `awake-schedule` describes when the frame should be awake. The block supports wrap-past-midnight windows, weekday/weekend overrides, and per-day exceptions. Times accept `HH:MM` or `HH:MM:SS` strings and may optionally include a trailing IANA timezone name (for example `"07:30 America/Los_Angeles"`). When a field omits a zone the top-level `timezone` is used.
@@ -52,12 +55,12 @@ buttond honours a few additional knobs inside its namespaced section:
 - `sleep-grace-ms` — how long to defer scheduled sleep after button activity or a manual wake. This prevents accidental naps immediately after someone interacts with the frame.
 - `screen.off-delay-ms` — delay between sending the sleep command and running the configured power-off command so the on-device sleep screen has time to render.
 - `screen.on-command` / `screen.off-command` — shell commands executed when buttond transitions the panel. The defaults call `powerctl`, which issues `wlr-randr` DPMS requests with a `vcgencmd` fallback.
-- `screen.display-name` — optional explicit connector name (for example `HDMI-A-2`). When omitted buttond targets the first connected non-internal display.
+- `screen.display-name` — set this to the connector name reported by `wlr-randr` (for example `HDMI-A-2`). buttond appends the value to both power commands so wake/sleep do not rely on runtime auto-detection.
 
-The helper `/opt/photo-frame/bin/powerctl` bootstraps the Wayland environment, auto-detects the first connected output, falls back to `HDMI-A-1`, and chains `vcgencmd`. Use it directly or replicate its logic if you prefer bespoke scripts:
+The helper `/opt/photo-frame/bin/powerctl` bootstraps the Wayland environment, auto-detects the first connected output when no argument is supplied, and chains `vcgencmd` as a fallback. Set `buttond.screen.display-name` so buttond always calls it with an explicit connector:
 ```bash
-powerctl sleep        # auto-detect output
-powerctl wake HDMI-A-1 # override the connector
+powerctl sleep          # auto-detect output (used for manual testing only)
+powerctl wake HDMI-A-2  # explicit connector provided by configuration
 ```
 
 ## Manual overrides

--- a/setup/assets/app/bin/powerctl
+++ b/setup/assets/app/bin/powerctl
@@ -33,26 +33,27 @@ ensure_wayland_env() {
       export XDG_RUNTIME_DIR="$derived"
     else
       echo "powerctl: XDG_RUNTIME_DIR is unset and derived path '$derived' does not exist" >&2
-      exit 1
+      return 1
     fi
   fi
 
   if [[ ! -d "$XDG_RUNTIME_DIR" ]]; then
     echo "powerctl: XDG_RUNTIME_DIR '$XDG_RUNTIME_DIR' does not exist" >&2
-    exit 1
+    return 1
   fi
 
   if [[ -z "${WAYLAND_DISPLAY:-}" ]]; then
     local socket
     if ! socket="$(pick_wayland_socket "$XDG_RUNTIME_DIR")"; then
       echo "powerctl: no Wayland display sockets found in $XDG_RUNTIME_DIR" >&2
-      exit 1
+      return 1
     fi
     export WAYLAND_DISPLAY="$socket"
   fi
+
+  return 0
 }
 
-ensure_wayland_env
 detect_out() {
   wlr-randr | awk '
     function commit() {
@@ -125,11 +126,17 @@ detect_out() {
   '
 }
 if [[ "$OUT" == "@AUTO@" ]]; then
+  ensure_wayland_env
   if ! OUT="$(detect_out)"; then
     echo "powerctl: failed to detect connected output" >&2
     exit 1
   fi
+else
+  if [[ -z "${WAYLAND_DISPLAY:-}" || -z "${XDG_RUNTIME_DIR:-}" ]]; then
+    ensure_wayland_env || true
+  fi
 fi
+
 if [[ "$MODE" == "sleep" ]]; then
   wlr-randr --output "$OUT" --off || vcgencmd display_power 0
 else

--- a/tests/powerctl_explicit_output.sh
+++ b/tests/powerctl_explicit_output.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/setup/assets/app/bin/powerctl"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+log_file="$tmpdir/log.txt"
+export POWERCTL_TEST_LOG="$log_file"
+
+cat <<'STUB' > "$tmpdir/wlr-randr"
+#!/usr/bin/env bash
+set -Eeuo pipefail
+: "${POWERCTL_TEST_LOG:?missing log path}"
+if [[ "${1:-}" == "--output" ]]; then
+  printf 'command:%s\n' "$*" >>"$POWERCTL_TEST_LOG"
+  exit 1
+fi
+printf 'detect:%s\n' "$*" >>"$POWERCTL_TEST_LOG"
+exit 42
+STUB
+chmod +x "$tmpdir/wlr-randr"
+
+cat <<'STUB' > "$tmpdir/vcgencmd"
+#!/usr/bin/env bash
+set -Eeuo pipefail
+: "${POWERCTL_TEST_LOG:?missing log path}"
+printf 'vcgencmd %s\n' "$*" >>"$POWERCTL_TEST_LOG"
+STUB
+chmod +x "$tmpdir/vcgencmd"
+
+PATH="$tmpdir:$PATH" "$SCRIPT" wake HDMI-A-2
+
+grep -q 'command:--output HDMI-A-2 --on' "$log_file"
+grep -q 'vcgencmd display_power 1' "$log_file"
+if grep -q '^detect:' "$log_file"; then
+  echo "detect_out should not run for explicit output" >&2
+  exit 1
+fi
+
+echo "powerctl explicit output fallback test passed"


### PR DESCRIPTION
## Summary
- append the configured display name to buttond power commands so explicit connectors are passed to powerctl
- harden powerctl to skip auto-detection when a connector argument is supplied while still attempting wlr-randr and falling back to vcgencmd
- document the new expectation for buttond.screen.display-name and add a regression shell test that exercises `powerctl wake HDMI-A-2`

## Testing
- tests/powerctl_explicit_output.sh

------
https://chatgpt.com/codex/tasks/task_e_68f9a70f96088323b0282b8eb83e0cea