### PR TITLE
Force buttond shutdown command to use systemctl -i

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,9 +18,10 @@ buttond:
   single-window-ms: 250
   double-window-ms: 400
   sleep-grace-ms: 300000 # Delay before scheduled sleep after a manual wake (ms)
+  force-shutdown: true # Append -i to bypass logind interactive user veto
   shutdown-command:
     program: /usr/bin/systemctl
-    args: [poweroff]
+    args: [poweroff, -i]
   screen:
     off-delay-ms: 3500
     display-name: null # Optional wlr-randr output name

--- a/developer/test-plan.md
+++ b/developer/test-plan.md
@@ -122,7 +122,7 @@ Exercise each axis at least once per release cycle.
   sudo evtest    # inspect for gpio-keys or power-button device
   ```
 - [ ] Short press → expect app sleep toggle (log should show control socket command).
-- [ ] Double-click → expect clean shutdown (`shutdown -h now` path confirmed in journal).
+- [ ] Double-click → expect clean shutdown (`systemctl poweroff -i` path confirmed in journal).
 - [ ] Long press → document expected behavior (hard-off). **Do not perform if risk of corruption.**
 - [ ] Evidence:
   ```sh


### PR DESCRIPTION
## Summary
- add a `force-shutdown` knob that defaults to appending `-i` to the buttond shutdown command
- update packaged configs and docs to describe the forced shutdown behavior
- extend buttond tests to cover the forced shutdown command path and the opt-out toggle

## Testing
- cargo test -p buttond

------
https://chatgpt.com/codex/tasks/task_e_68f9a710bcd88323800b3d12116b60b0