### PR TITLE
Switch buttond to swaymsg-based screen control

### DIFF
--- a/setup/assets/app/bin/powerctl
+++ b/setup/assets/app/bin/powerctl
@@ -1,24 +1,39 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
 MODE="${1:-}"
-OUT="${2:-@AUTO@}"
-if [[ -z "$MODE" ]]; then
+TARGET="${2:-*}"
+if [[ "$MODE" != "sleep" && "$MODE" != "wake" ]]; then
   echo "usage: powerctl {sleep|wake} [OUTPUT]" >&2
   exit 2
 fi
 
-pick_wayland_socket() {
-  local runtime_dir="${1%/}"
-  local matches
+runtime_dir="${XDG_RUNTIME_DIR:-}"
+if [[ -z "$runtime_dir" ]]; then
+  runtime_dir="/run/user/$(id -u)"
+fi
 
-  if ! matches=$(compgen -G "${runtime_dir}/wayland-*"); then
+if [[ ! -d "$runtime_dir" ]]; then
+  echo "powerctl: XDG_RUNTIME_DIR '$runtime_dir' does not exist" >&2
+  exit 1
+fi
+
+find_sway_socket() {
+  local socket="${SWAYSOCK:-}"
+  if [[ -n "$socket" && -S "$socket" ]]; then
+    printf '%s' "$socket"
+    return 0
+  fi
+
+  local matches
+  if ! matches=$(compgen -G "${runtime_dir%/}/sway-ipc.*.sock" 2>/dev/null); then
     return 1
   fi
 
   local candidate
   while IFS= read -r candidate; do
     if [[ -S "$candidate" ]]; then
-      basename "$candidate"
+      printf '%s' "$candidate"
       return 0
     fi
   done <<<"$matches"
@@ -26,119 +41,16 @@ pick_wayland_socket() {
   return 1
 }
 
-ensure_wayland_env() {
-  if [[ -z "${XDG_RUNTIME_DIR:-}" ]]; then
-    local derived="/run/user/$(id -u)"
-    if [[ -d "$derived" ]]; then
-      export XDG_RUNTIME_DIR="$derived"
-    else
-      echo "powerctl: XDG_RUNTIME_DIR is unset and derived path '$derived' does not exist" >&2
-      return 1
-    fi
-  fi
-
-  if [[ ! -d "$XDG_RUNTIME_DIR" ]]; then
-    echo "powerctl: XDG_RUNTIME_DIR '$XDG_RUNTIME_DIR' does not exist" >&2
-    return 1
-  fi
-
-  if [[ -z "${WAYLAND_DISPLAY:-}" ]]; then
-    local socket
-    if ! socket="$(pick_wayland_socket "$XDG_RUNTIME_DIR")"; then
-      echo "powerctl: no Wayland display sockets found in $XDG_RUNTIME_DIR" >&2
-      return 1
-    fi
-    export WAYLAND_DISPLAY="$socket"
-  fi
-
-  return 0
+socket="$(find_sway_socket)" || {
+  echo "powerctl: failed to locate sway IPC socket in $runtime_dir" >&2
+  exit 1
 }
 
-detect_out() {
-  wlr-randr | awk '
-    function commit() {
-      if (current == "") {
-        return
-      }
-
-      if (status_seen) {
-        connected = status_connected
-      } else if (enabled_seen) {
-        connected = enabled
-      } else {
-        connected = 0
-      }
-
-      if (!connected || internal) {
-        return
-      }
-
-      if (best == "") {
-        best = current
-      }
-    }
-
-    /^[[:space:]]*$/ {
-      next
-    }
-
-    /^[^[:space:]]/ {
-      commit()
-      current = $1
-      internal = ($1 ~ /^(eDP|LVDS)/)
-      enabled = 0
-      enabled_seen = 0
-      status_connected = 0
-      status_seen = 0
-      next
-    }
-
-    /^[[:space:]]+Enabled:[[:space:]]*/ {
-      value = tolower($2)
-      if (value == "yes" || value == "on" || value == "true" || value == "1") {
-        enabled = 1
-        enabled_seen = 1
-      } else if (value == "no" || value == "off" || value == "false" || value == "0") {
-        enabled = 0
-        enabled_seen = 1
-      }
-      next
-    }
-
-    /^[[:space:]]+Status:[[:space:]]*/ {
-      status_seen = 1
-      if (tolower($2) ~ /^connected/) {
-        status_connected = 1
-      } else if (tolower($2) ~ /^disconnected/) {
-        status_connected = 0
-      }
-      next
-    }
-
-    END {
-      commit()
-      if (best != "") {
-        print best
-        exit 0
-      }
-      exit 1
-    }
-  '
-}
-if [[ "$OUT" == "@AUTO@" ]]; then
-  ensure_wayland_env
-  if ! OUT="$(detect_out)"; then
-    echo "powerctl: failed to detect connected output" >&2
-    exit 1
-  fi
-else
-  if [[ -z "${WAYLAND_DISPLAY:-}" || -z "${XDG_RUNTIME_DIR:-}" ]]; then
-    ensure_wayland_env || true
-  fi
-fi
+export XDG_RUNTIME_DIR="$runtime_dir"
+export SWAYSOCK="$socket"
 
 if [[ "$MODE" == "sleep" ]]; then
-  wlr-randr --output "$OUT" --off || vcgencmd display_power 0
+  swaymsg output "$TARGET" power off
 else
-  wlr-randr --output "$OUT" --on  || vcgencmd display_power 1
+  swaymsg output "$TARGET" power on
 fi


### PR DESCRIPTION
## Summary
- require successful sway IPC discovery when bootstrapping buttond and drop the wlr-randr/Wayland fallbacks
- run screen detection and state changes through swaymsg with explicit SWAYSOCK/XDG_RUNTIME_DIR setup, including updated unit tests
- replace the powerctl script with a swaymsg-only implementation that targets `output *`

## Testing
- cargo test -p buttond

------
https://chatgpt.com/codex/tasks/task_e_68fab927813083239640f40cf0a5f013