### PR TITLE
Remove iris transition mode and extend matting wait harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
 # Changelog
 
 ## Added
-- CPU-tessellated iris transition with lyon-driven blades, mask/composite pipeline, and configurable fill/stroke styling.

--- a/README.md
+++ b/README.md
@@ -117,8 +117,6 @@ See [assets/backgrounds/Credits.md](assets/backgrounds/Credits.md) for image att
 
 - **Procedural studio mat weave texture.** Our weave shading is adapted from Mike Cauchi’s breakdown of tillable cloth shading, which layers sine-profiled warp/weft threads with randomized grain to keep the pattern from banding. See ["Research – Tillable Images and Cloth Shading"](https://www.mikecauchiart.com/single-post/2017/01/23/research-tillable-images-and-cloth-shading).
 - **Print simulation shading.** The gallery-lighting and relief model follows guidance from Rohit A. Patil, Mark D. Fairchild, and Garrett M. Johnson’s paper ["3D Simulation of Prints for Improved Soft Proofing"](https://doi.org/10.1117/12.813471).
-- **Iris transition geometry.** Our polygonal iris closure uses the trigonometric projection technique described in ["How to calculate polygons for camera aperture animation?"](https://stackoverflow.com/a/57571325), which maps fragment angles into blade sectors for precise aperture radii.
-
 ## AI Statement
 
 This project was developed with significant assistance from OpenAI’s AI tools:

--- a/config.yaml
+++ b/config.yaml
@@ -58,16 +58,6 @@ transition:
       reveal-portion: 0.55
       stripe-count: 24
       flash-color: [0, 0, 0]
-    - kind: iris
-      duration-ms: 900
-      blades: 7
-      rotate-radians: 1.05
-      direction: open
-      fill-rgba: [0.85, 0.85, 0.85, 1.0]
-      stroke-rgba: [0.10, 0.10, 0.10, 1.0]
-      stroke-width: 1.5
-      tolerance: 0.25
-
 # Dwell time (ms) the current image remains fully displayed before the next transition
 dwell-ms: 2000
 

--- a/crates/photo-frame/src/renderer/mod.rs
+++ b/crates/photo-frame/src/renderer/mod.rs
@@ -1,1 +1,1 @@
-// Tessellated iris removed; WGSL-only pipeline in viewer shaders.
+// Viewer transitions are implemented entirely in WGSL shaders.

--- a/crates/photo-frame/tests/config_tests.rs
+++ b/crates/photo-frame/tests/config_tests.rs
@@ -693,54 +693,6 @@ transition:
 }
 
 #[test]
-fn parse_inline_iris_transition() {
-    let yaml = r#"
-photo-library-path: "/photos"
-transition:
-  selection: fixed
-  active:
-    - kind: iris
-      duration-ms: 880
-      blades: 9
-      rotate-radians: 1.25
-      direction: close
-      fill-rgba: [0.75, 0.8, 0.85, 1.0]
-      stroke-rgba: [0.2, 0.25, 0.3, 1.0]
-      stroke-width: 2.0
-      tolerance: 0.2
-"#;
-
-    let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
-    assert!(matches!(
-        cfg.transition.selection(),
-        TransitionSelection::Fixed(entry)
-            if entry.kind == TransitionKind::Iris && entry.index == 0
-    ));
-    let selected = cfg
-        .transition
-        .primary_selected()
-        .expect("expected iris transition option");
-    assert_eq!(selected.entry.kind, TransitionKind::Iris);
-    assert_eq!(selected.entry.index, 0);
-    assert_eq!(selected.option.duration().as_millis(), 880);
-    match selected.option.mode() {
-        rust_photo_frame::config::TransitionMode::Iris(cfg) => {
-            assert_eq!(cfg.blades, 9);
-            assert!((cfg.rotate_radians - 1.25).abs() < f32::EPSILON);
-            assert_eq!(
-                cfg.direction,
-                rust_photo_frame::config::IrisDirection::Close
-            );
-            assert_eq!(cfg.fill_rgba, [0.75, 0.8, 0.85, 1.0]);
-            assert_eq!(cfg.stroke_rgba, [0.2, 0.25, 0.3, 1.0]);
-            assert!((cfg.stroke_width - 2.0).abs() < f32::EPSILON);
-            assert!((cfg.tolerance - 0.2).abs() < f32::EPSILON);
-        }
-        _ => panic!("expected iris transition"),
-    }
-}
-
-#[test]
 fn parse_random_transition_configuration() {
     let yaml = r#"
 photo-library-path: "/photos"
@@ -1059,31 +1011,6 @@ transition:
         err.to_string()
             .contains("requires angle-jitter-degrees >= 0")
     );
-}
-
-#[test]
-fn iris_transition_clamps_blade_count() {
-    let yaml = r#"
-photo-library-path: "/photos"
-transition:
-  selection: fixed
-  active:
-    - kind: iris
-      blades: 0
-"#;
-
-    let cfg: Configuration = serde_yaml::from_str(yaml).unwrap();
-    let selected = cfg
-        .transition
-        .primary_selected()
-        .expect("expected iris transition option");
-    assert_eq!(selected.entry.kind, TransitionKind::Iris);
-    match selected.option.mode() {
-        rust_photo_frame::config::TransitionMode::Iris(cfg) => {
-            assert_eq!(cfg.blades, 3);
-        }
-        _ => panic!("expected iris transition"),
-    }
 }
 
 #[test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -312,7 +312,7 @@ photo-effect:
 
 ## Transition configuration
 
-The `transition` block controls how the viewer blends between photos. Supply one or more entries under `transition.active`; each entry begins with a required `kind` tag (`fade`, `wipe`, `push`, `e-ink`, or `iris`) followed by the fields that customise that transition. Use `transition.selection` to describe how the viewer steps through that list.
+The `transition` block controls how the viewer blends between photos. Supply one or more entries under `transition.active`; each entry begins with a required `kind` tag (`fade`, `wipe`, `push`, or `e-ink`) followed by the fields that customise that transition. Use `transition.selection` to describe how the viewer steps through that list.
 
 | Key         | Required? | Default                                                       | Accepted values                           | Effect |
 | ----------- | --------- | ------------------------------------------------------------- | ----------------------------------------- | ------ |
@@ -343,12 +343,6 @@ The remaining knobs depend on the transition family.
   - **`reveal-portion`** (float, default `0.55`, clamped to `0.05–0.95`): Fraction of the timeline spent flashing before the stripes start uncovering the next slide.
   - **`stripe-count`** (integer ≥ 1, default `24`): How many horizontal bands sweep in; higher counts mimic a finer e-ink refresh.
   - **`flash-color`** (`[r, g, b]` array, default `[255, 255, 255]`): RGB color used for the bright flash phases before the black inversion. Channels outside `0–255` are clamped.
-- **`iris`**
-  - **`blades`** (integer, default `7`, clamped to `5–18`): Number of shutter spokes sketched around the aperture.
-  - **`blade-rgba`** (`[r, g, b, a]` float array, default `[0.12, 0.12, 0.12, 1.0]`): Base color for the iris blades. Channels outside `0–1` are clamped; the alpha component scales how dark the rendered blades appear.
-
-  The iris transition renders shaded SLR-style blades that first close over the current photo, then reopen to reveal the next one. Each half of the timeline is dedicated to one of those motions, producing a mechanical shutter feel.
-
 ### Example: single inline fade
 
 ```yaml

--- a/docs/sop.md
+++ b/docs/sop.md
@@ -74,7 +74,7 @@ sudo -u kiosk \
   XDG_RUNTIME_DIR="/run/user/$(id -u kiosk)" \
   dbus-run-session \
   env PHOTOFRAME_LOG=stdout \
-  env RUST_LOG='rust_photo_frame::renderer::iris_tess=debug,info' \
+  env RUST_LOG='rust_photo_frame::tasks::viewer=debug,info' \
   sway -c /usr/local/share/photoframe/sway/config
 ```
 
@@ -85,7 +85,7 @@ sudo -u kiosk \
   XDG_RUNTIME_DIR="/run/user/$(id -u kiosk)" \
   dbus-run-session \
   env PHOTOFRAME_LOG='file:/var/tmp/photo-frame.log' \
-  env RUST_LOG='rust_photo_frame::renderer::iris_tess=debug,info' \
+  env RUST_LOG='rust_photo_frame::tasks::viewer=debug,info' \
   sway -c /usr/local/share/photoframe/sway/config
 
 sudo tail -f /var/tmp/photo-frame.log


### PR DESCRIPTION
## Summary
- remove the iris transition mode from configuration parsing, runtime wiring, shaders, docs, and tests
- simplify transition uniforms and align remaining mode indices with the shader implementation
- extend the matting harness wait so it retries once when work is still in flight

## Testing
- cargo fmt
- cargo test --workspace --all-targets

------
https://chatgpt.com/codex/tasks/task_e_68fae681f1ac832381c26341e427054c